### PR TITLE
Resolve "Add a new tag to resolve checksum mismatch"

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -26,10 +26,10 @@ builds:
         goarch: 386
 
 checksum:
-  name_template: "{{ .ProjectName }}-{{ .Version }}-checksums.sha256"
+  name_template: '{{ .ProjectName }}-{{ trimprefix .Version "v" }}-checksums.sha256'
 
 archives:
-  - name_template: "{{ .ProjectName }}-{{ .Version }}-{{ .Os }}-{{ .Arch }}"
+  - name_template: '{{ .ProjectName }}-{{ trimprefix .Version "v" }}-{{ .Os }}-{{ .Arch }}'
     format_overrides:
       - goos: windows
         format: zip
@@ -53,11 +53,12 @@ dockers:
       - alpacon
     image_templates:
       - "alpacax/alpacon-cli:latest"
-      - "alpacax/alpacon-cli:{{ .Tag }}"
+      - 'alpacax/alpacon-cli:{{ trimprefix .Tag "v" }}'
     dockerfile: Dockerfile
 
 nfpms:
-  - maintainer: AlpacaX <support@alpacax.com>
+  - file_name_template: '{{ .PackageName }}_{{ trimprefix .Version "v" }}_{{ .Os }}_{{ .Arch }}{{ with .Arm }}v{{ . }}{{ end }}{{ with .Mips }}_{{ . }}{{ end }}{{ if not (eq .Amd64 "v1") }}{{ .Amd64 }}{{ end }}''
+    maintainer: AlpacaX <support@alpacax.com>
     description: "Alpacon CLI"
     homepage: https://github.com/alpacax/alpacon-cli
     license: MIT

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -57,7 +57,7 @@ dockers:
     dockerfile: Dockerfile
 
 nfpms:
-  - file_name_template: '{{ .PackageName }}_{{ trimprefix .Version "v" }}_{{ .Os }}_{{ .Arch }}{{ with .Arm }}v{{ . }}{{ end }}{{ with .Mips }}_{{ . }}{{ end }}{{ if not (eq .Amd64 "v1") }}{{ .Amd64 }}{{ end }}''
+  - file_name_template: '{{ .PackageName }}_{{ trimprefix .Version "v" }}_{{ .Os }}_{{ .Arch }}{{ with .Arm }}v{{ . }}{{ end }}{{ with .Mips }}_{{ . }}{{ end }}{{ if not (eq .Amd64 "v1") }}{{ .Amd64 }}{{ end }}'
     maintainer: AlpacaX <support@alpacax.com>
     description: "Alpacon CLI"
     homepage: https://github.com/alpacax/alpacon-cli


### PR DESCRIPTION
As discussed in https://github.com/alpacax/alpacon-cli/issues/27,  update the `.goreleaser.yaml`. 
This ensures that while our new tags will follow Semantic Versioning 2.0.0 as mentioned 
in the Go docs (including the v prefix), 
the versions for Linux packages and other archives generated by Goreleaser will not include that v prefix.