### PR TITLE
Modify validate and formatting workspace URL in login logic

### DIFF
--- a/cmd/login.go
+++ b/cmd/login.go
@@ -4,6 +4,7 @@ import (
 	"crypto/tls"
 	"fmt"
 	"net/http"
+	"net/url"
 	"strings"
 
 	"github.com/alpacax/alpacon-cli/api/auth"
@@ -180,16 +181,13 @@ func validateAndFormatWorkspaceURL(workspaceURL string, httpClient *http.Client)
 	workspaceURL = strings.TrimSuffix(workspaceURL, "/")
 
 	// Transform URL patterns: domain.com/workspace -> workspace.domain.com
-	if strings.Contains(workspaceURL, "://") && strings.Contains(workspaceURL, "/") {
-		parts := strings.Split(workspaceURL, "/")
-		if len(parts) >= 4 {
-			protocol := parts[0]
-			domain := parts[2]
-			workspace := parts[3]
-
-			if domain != "" && workspace != "" {
-				workspaceURL = fmt.Sprintf("%s//%s.%s", protocol, workspace, domain)
-			}
+	parsedURL, err := url.Parse(workspaceURL)
+	if err == nil && parsedURL.Path != "" && parsedURL.Path != "/" {
+		workspace := strings.TrimPrefix(parsedURL.Path, "/")
+		domain := parsedURL.Host
+		protocol := parsedURL.Scheme
+		if domain != "" && workspace != "" {
+			workspaceURL = fmt.Sprintf("%s://%s.%s", protocol, workspace, domain)
 		}
 	}
 

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -27,7 +27,7 @@ var loginCmd = &cobra.Command{
 	alpacon login
 
 	alpacon login [WORKSPACE_URL] -u [USERNAME] -p [PASSWORD]
-	alpacon login example.alpacon.io
+	alpacon login [WORKSPACE_URL]
 	
 	# Include http if using localhost.
 	alpacon login http://localhost:8000

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -179,18 +179,16 @@ func validateAndFormatWorkspaceURL(workspaceURL string, httpClient *http.Client)
 
 	workspaceURL = strings.TrimSuffix(workspaceURL, "/")
 
-	// Transform URL patterns: region.alpacon.io/workspace -> workspace.region.alpacon.io
-	if strings.Contains(workspaceURL, ".alpacon.io/") {
+	// Transform URL patterns: domain.com/workspace -> workspace.domain.com
+	if strings.Contains(workspaceURL, "://") && strings.Contains(workspaceURL, "/") {
 		parts := strings.Split(workspaceURL, "/")
-		for i, part := range parts {
-			if strings.HasSuffix(part, ".alpacon.io") && i+1 < len(parts) {
-				workspace := parts[i+1]
-				domainParts := strings.Split(part, ".")
-				if len(domainParts) >= 3 {
-					domain := domainParts[0]
-					workspaceURL = strings.Replace(workspaceURL, part+"/"+workspace, workspace+"."+domain+".alpacon.io", 1)
-				}
-				break
+		if len(parts) >= 4 {
+			protocol := parts[0]
+			domain := parts[2]
+			workspace := parts[3]
+
+			if domain != "" && workspace != "" {
+				workspaceURL = fmt.Sprintf("%s//%s.%s", protocol, workspace, domain)
 			}
 		}
 	}

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -177,6 +177,24 @@ func validateAndFormatWorkspaceURL(workspaceURL string, httpClient *http.Client)
 		workspaceURL = "https://" + workspaceURL
 	}
 
+	workspaceURL = strings.TrimSuffix(workspaceURL, "/")
+
+	// Transform URL patterns: region.alpacon.io/workspace -> workspace.region.alpacon.io
+	if strings.Contains(workspaceURL, ".alpacon.io/") {
+		parts := strings.Split(workspaceURL, "/")
+		for i, part := range parts {
+			if strings.HasSuffix(part, ".alpacon.io") && i+1 < len(parts) {
+				workspace := parts[i+1]
+				domainParts := strings.Split(part, ".")
+				if len(domainParts) >= 3 {
+					domain := domainParts[0]
+					workspaceURL = strings.Replace(workspaceURL, part+"/"+workspace, workspace+"."+domain+".alpacon.io", 1)
+				}
+				break
+			}
+		}
+	}
+
 	resp, err := httpClient.Get(workspaceURL)
 	if err != nil || resp.StatusCode >= 400 {
 		return "", fmt.Errorf("workspace URL is unreachable: %v", workspaceURL)

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -186,6 +186,11 @@ func validateAndFormatWorkspaceURL(workspaceURL string, httpClient *http.Client)
 		workspace := strings.TrimPrefix(parsedURL.Path, "/")
 		domain := parsedURL.Host
 		protocol := parsedURL.Scheme
+
+		// ToDo: modify below code after region decision in portal (multiple region)
+		if domain == "alpacon.io" {
+			domain = "ap1." + domain
+		}
 		if domain != "" && workspace != "" {
 			workspaceURL = fmt.Sprintf("%s://%s.%s", protocol, workspace, domain)
 		}


### PR DESCRIPTION
Now alpacon-cli supports two workspace url patterns(example):
1. `alpacon login https://alpacax.dev.alpacon.io`
2. `alpacon login https://dev.alpacon.io/alpacax`