### PR TITLE
48 command warning for websh

### DIFF
--- a/cmd/websh/websh.go
+++ b/cmd/websh/websh.go
@@ -149,7 +149,7 @@ var WebshCmd = &cobra.Command{
 		} else if len(commandArgs) > 0 {
 			if len(commandArgs) > 1 && !skipQuestion {
 				utils.CliWarning("Command without quotes may cause unexpected behavior. Consider wrapping the command in quotes.")
-				confirm := utils.ConfirmModal("Do you want to continue executing the command?")
+				confirm := utils.CommandConfirmModal()
 				if !confirm {
 					return
 				}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"archive/zip"
+	"bufio"
 	"bytes"
 	"encoding/json"
 	"errors"
@@ -394,4 +395,22 @@ func CreateAndEditTempFile(data []byte) (string, error) {
 func SplitPath(path string) (string, string) {
 	parts := strings.SplitN(path, ":", 2)
 	return parts[0], parts[1]
+}
+
+func ConfirmModal(message string) bool {
+	fmt.Print(message + " (y/n): ")
+	reader := bufio.NewReader(os.Stdin)
+	input, err := reader.ReadString('\n')
+	if err != nil {
+		CliError("Failed to read user input: %s", err)
+		return false
+	}
+
+	input = strings.TrimSpace(strings.ToLower(input))
+	if input != "y" && input != "yes" {
+		fmt.Println("Command execution cancelled.")
+		return false
+	}
+
+	return true
 }

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -397,8 +397,16 @@ func SplitPath(path string) (string, string) {
 	return parts[0], parts[1]
 }
 
-func ConfirmModal(message string) bool {
-	fmt.Print(message + " (y/n): ")
+/*
+CommandConfirmModal prompts the user for confirmation to continue with a command.
+It reads a single line from standard input and returns true if the user
+enters "y" or "yes" (case-insensitive), and false otherwise.
+
+Returns:
+  - bool: true if the user confirms, false if they cancel or an error occurs.
+*/
+func CommandConfirmModal() bool {
+	fmt.Print("Do you want to continue executing the command? (y/n): ")
 	reader := bufio.NewReader(os.Stdin)
 	input, err := reader.ReadString('\n')
 	if err != nil {


### PR DESCRIPTION
We will prevent unintended consequences that can occur when the `websh` command is executed without using quotes.

For example, when running `alpacon websh test ls -al && mkdir test_dir`, the command after `&&` is executed on the local machine, not the remote server.

Following the SSH command convention, we will not block unquoted command execution. Instead, we will add a warning message and a confirmation prompt (y/n) to ask the user if they want to proceed with the command.

When using `alpacon-cli` in a CI/CD environment, it's not possible to provide a `y/n` response. Therefore, we'll add a **`-y` option** to skip the warning and proceed with execution.