### PR TITLE
fix(exec, websh): correct the --env guidance and document the credential gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ $ alpacon exec --env="PGPASSWORD" <server> -- psql -h localhost -U app -c 'SELEC
 
 Flags go before the server name; everything after is the remote command.
 
-The server rejects a command whose command line carries a credential—a `-p`/`--password` flag, a `KEY=VALUE` secret such as `PGPASSWORD=...`, or a `user:pass@host` connection string—before it runs. Pass the secret with `--env="KEY"` as shown above. The same applies to `alpacon websh` when it runs a command.
+Never put a secret on the command line: the server refuses such a command before it runs. Pass it with `--env="KEY"` as shown above. The same applies to `alpacon websh` when it runs a command. See [When a command is denied](#when-a-command-is-denied) for the exact forms the server rejects and the machine-readable refusal.
 
 ### File transfer
 ```bash
@@ -288,14 +288,18 @@ What each refusal code means and what to do next:
 | `work_session_assignee_mismatch` | session assigned to another principal | `work-session use <ID>` with your own session |
 | `work_session_not_usable` | session is no longer usable | `work-session create --use` |
 
-`work-session` subcommand failures (`create`, `use`, `extend`, ...) and `event wait` / `event watch` failures also emit a JSON error envelope under `--output json`, with exit code `1` and `error_code` carrying the server code when available (`usage_error` for local flag/argument errors). These envelopes may share an `error_code` with the gate-denial envelopes above—distinguish a subcommand failure (`exit_code: 1`) from a gate denial (`exit_code: 3`) via `exit_code`, not `error_code` alone. Run `alpacon whoami` to check upfront whether a work session is required for your auth.
+`work-session` subcommand failures (`create`, `use`, `extend`, ...), `event wait` / `event watch` failures, and the inline-credential refusal below also emit a JSON error envelope under `--output json`, with exit code `1` and `error_code` carrying the server code when available (`usage_error` for local flag/argument errors). These envelopes may share an `error_code` with the gate-denial envelopes above—distinguish a subcommand failure (`exit_code: 1`) from a gate denial (`exit_code: 3`) via `exit_code`, not `error_code` alone. Run `alpacon whoami` to check upfront whether a work session is required for your auth.
+
+Separately from the work session gate, `exec` (and `websh` when running a command) is refused before the command runs if the command line itself carries a credential—a `-p`/`--password` flag, a `KEY=VALUE` secret such as `PGPASSWORD=...`, or a `user:pass@host` connection string. Pass the secret with `--env="KEY"` instead: its value is read from your shell, so it never lands on the command line the server stores. The refusal is permanent—a retry submits the same command line—so rewrite rather than retry.
+
+Exit code is `1`, and under `--output json` the refusal is an error envelope on stderr with `error_code` `command_inline_credential`. That envelope carries no `next_actions`, because the fix is always the same `--env="KEY"` rewrite.
 
 ## Exit codes
 
 | Code | Meaning |
 |------|---------|
 | `0`  | Success |
-| `1`  | General error (network failure, server error, etc.). Also returned when the server rejects a command whose command line carries a credential (`command_inline_credential`)—a permanent refusal that fails the same way on retry, so move the secret to `--env="KEY"` rather than retrying |
+| `1`  | General error (network failure, server error, etc.), and permanent refusals such as a credential on the command line (`command_inline_credential`)—see "When a command is denied" |
 | `2`  | Usage error (invalid flags or arguments) |
 | `3`  | WorkSession gate denied—the active session does not authorize this action |
 | `4`  | Pending human approval—the action is awaiting an out-of-band approve/reject in the Alpacon console (web/Slack), not refused. For `exec`, re-run the command after approval (or pass `--wait` on the original command to block; `--wait-approval <duration>` raises the wait timeout, default 5m); `websh` command mode has no `--wait`, so re-run via `alpacon exec --wait` to block; for `work-session create` the session already exists—after approval attach it with `alpacon work-session use <id>` (or pass `--wait` on the original create to block; `--wait-approval <duration>` raises the wait timeout, default 5m). Under `--output json`, a `{"status":"pending_approval", ...}` object is emitted. Returned by `exec` (and `websh` when running a command) on a `SUDO_APPROVAL_REQUIRED` sudo denial and by `work-session create` when the session lands pending or when its `--wait` times out with the outcome still open. Also returned by `alpacon event wait` when the wait times out or is interrupted—the outcome is still open |

--- a/README.md
+++ b/README.md
@@ -142,13 +142,13 @@ $ alpacon exec -u admin -g developers <server> "..."
 # Pass a secret with --env="KEY": the value is read from your shell, so it stays off
 # the alpacon command line. Read it in rather than typing it inline, so it stays out
 # of shell history too.
-$ read -rs PGPASSWORD && export PGPASSWORD
+$ printf 'PGPASSWORD: ' && read -rs PGPASSWORD && export PGPASSWORD
 $ alpacon exec --env="PGPASSWORD" <server> -- psql -h localhost -U app -c 'SELECT 1'
 ```
 
 Flags go before the server name; everything after is the remote command.
 
-Never put a secret on the command line: the server refuses such a command before it runs. Pass it with `--env="KEY"` as shown above. The same applies to `alpacon websh` when it runs a command. See [When a command is denied](#when-a-command-is-denied) for the exact forms the server rejects and the machine-readable refusal.
+Never put a secret on the command line: the server refuses the recognizable forms before the command runs. Pass it with `--env="KEY"` as shown above. The same applies to `alpacon websh` when it runs a command. See [When a command is denied](#when-a-command-is-denied) for the exact forms the server rejects and the machine-readable refusal.
 
 ### File transfer
 ```bash
@@ -292,7 +292,7 @@ What each refusal code means and what to do next:
 
 Separately from the work session gate, `exec` (and `websh` when running a command) is refused before the command runs if the command line itself carries a credential—a `-p`/`--password` flag, a `KEY=VALUE` secret such as `PGPASSWORD=...`, or a `user:pass@host` connection string. Pass the secret with `--env="KEY"` instead: its value is read from your shell, so it never lands on the command line the server stores. The refusal is permanent—a retry submits the same command line—so rewrite rather than retry.
 
-Exit code is `1`, and under `--output json` the refusal is an error envelope on stderr with `error_code` `command_inline_credential`. That envelope carries no `next_actions`, because the fix is always the same `--env="KEY"` rewrite.
+Exit code is `1`, and under `--output json` the refusal is an error envelope on stderr with `error_code` `command_inline_credential`. That envelope currently carries no `next_actions`—rewrite the command with `--env="KEY"` as described above (`exec` takes the remote command after `--`, `websh` takes it as one quoted argument).
 
 ## Exit codes
 

--- a/README.md
+++ b/README.md
@@ -139,9 +139,10 @@ $ alpacon exec <server> "<cmd>"
 $ alpacon exec root@<server> "docker ps"
 $ alpacon exec -u admin -g developers <server> "..."
 
-# Pass a secret with --env="KEY": the value is read from your shell, so it never
-# reaches the alpacon command line, your shell history, ps output, or CI job logs.
-$ export PGPASSWORD=...
+# Pass a secret with --env="KEY": the value is read from your shell, so it stays off
+# the alpacon command line. Read it in rather than typing it inline, so it stays out
+# of shell history too.
+$ read -rs PGPASSWORD && export PGPASSWORD
 $ alpacon exec --env="PGPASSWORD" <server> -- psql -h localhost -U app -c 'SELECT 1'
 ```
 

--- a/README.md
+++ b/README.md
@@ -138,7 +138,11 @@ $ alpacon websh join --url <SHARED_URL> --password <PASSWORD>
 $ alpacon exec <server> "<cmd>"
 $ alpacon exec root@<server> "docker ps"
 $ alpacon exec -u admin -g developers <server> "..."
-$ alpacon exec --env="KEY=VALUE" <server> "echo $KEY"
+
+# Pass a secret with --env="KEY": the value is read from your shell, so it never
+# reaches the alpacon command line, your shell history, ps output, or CI job logs.
+$ export PGPASSWORD=...
+$ alpacon exec --env="PGPASSWORD" <server> -- psql -h localhost -U app -c 'SELECT 1'
 ```
 
 Flags go before the server name; everything after is the remote command.

--- a/README.md
+++ b/README.md
@@ -147,6 +147,8 @@ $ alpacon exec --env="PGPASSWORD" <server> -- psql -h localhost -U app -c 'SELEC
 
 Flags go before the server name; everything after is the remote command.
 
+The server rejects a command whose command line carries a credential—a `-p`/`--password` flag, a `KEY=VALUE` secret such as `PGPASSWORD=...`, or a `user:pass@host` connection string—before it runs. Pass the secret with `--env="KEY"` as shown above. The same applies to `alpacon websh` when it runs a command.
+
 ### File transfer
 ```bash
 $ alpacon cp ./local.txt <server>:/home/user/
@@ -292,7 +294,7 @@ What each refusal code means and what to do next:
 | Code | Meaning |
 |------|---------|
 | `0`  | Success |
-| `1`  | General error (network failure, server error, etc.) |
+| `1`  | General error (network failure, server error, etc.). Also returned when the server rejects a command whose command line carries a credential (`command_inline_credential`)—a permanent refusal that fails the same way on retry, so move the secret to `--env="KEY"` rather than retrying |
 | `2`  | Usage error (invalid flags or arguments) |
 | `3`  | WorkSession gate denied—the active session does not authorize this action |
 | `4`  | Pending human approval—the action is awaiting an out-of-band approve/reject in the Alpacon console (web/Slack), not refused. For `exec`, re-run the command after approval (or pass `--wait` on the original command to block; `--wait-approval <duration>` raises the wait timeout, default 5m); `websh` command mode has no `--wait`, so re-run via `alpacon exec --wait` to block; for `work-session create` the session already exists—after approval attach it with `alpacon work-session use <id>` (or pass `--wait` on the original create to block; `--wait-approval <duration>` raises the wait timeout, default 5m). Under `--output json`, a `{"status":"pending_approval", ...}` object is emitted. Returned by `exec` (and `websh` when running a command) on a `SUDO_APPROVAL_REQUIRED` sudo denial and by `work-session create` when the session lands pending or when its `--wait` times out with the outcome still open. Also returned by `alpacon event wait` when the wait times out or is interrupted—the outcome is still open |

--- a/cmd/exec/credential_hint_test.go
+++ b/cmd/exec/credential_hint_test.go
@@ -45,12 +45,12 @@ func TestIsCommandInlineCredentialError(t *testing.T) {
 func TestCredentialInlineHint(t *testing.T) {
 	tests := []struct {
 		name      string
-		invokedAs string
+		invokedAs Invocation
 		want      string
 	}{
-		{"exec", ExecInvocation, "alpacon exec --env=SECRET_NAME db-server -- <command>"},
-		{"websh takes the command as one quoted argument", WebshInvocation, "alpacon websh --env=SECRET_NAME db-server '<command>'"},
-		{"unset falls back to exec", "", "alpacon exec --env=SECRET_NAME db-server -- <command>"},
+		{"exec", ExecInvocation, `alpacon exec --env="SECRET_NAME" db-server -- <command>`},
+		{"websh takes the command as one quoted argument", WebshInvocation, `alpacon websh --env="SECRET_NAME" db-server '<command>'`},
+		{"unset falls back to exec", "", `alpacon exec --env="SECRET_NAME" db-server -- <command>`},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/cmd/exec/credential_hint_test.go
+++ b/cmd/exec/credential_hint_test.go
@@ -38,14 +38,29 @@ func TestIsCommandInlineCredentialError(t *testing.T) {
 	})
 }
 
-// TestCredentialInlineHint asserts the hint points at --env and never echoes a
-// credential value (there is nothing to echo—it's a fixed string—but this
-// guards against a future edit that starts interpolating the rejected line).
+// TestCredentialInlineHint asserts the hint points at --env, quotes the command
+// the caller actually ran, and never echoes a credential value (there is nothing
+// to echo—the example is fixed—but this guards against a future edit that starts
+// interpolating the rejected line).
 func TestCredentialInlineHint(t *testing.T) {
-	hint := credentialInlineHint()
-	assert.Contains(t, hint, "--env")
-	assert.Contains(t, hint, "Hint:")
-	assert.NotContains(t, hint, "hunter2", "hint must never echo a credential value")
+	tests := []struct {
+		name      string
+		invokedAs string
+		want      string
+	}{
+		{"exec", ExecInvocation, "alpacon exec --env=SECRET_NAME db-server -- <command>"},
+		{"websh takes the command as one quoted argument", WebshInvocation, "alpacon websh --env=SECRET_NAME db-server '<command>'"},
+		{"unset falls back to exec", "", "alpacon exec --env=SECRET_NAME db-server -- <command>"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			hint := credentialInlineHint(tt.invokedAs)
+			assert.Contains(t, hint, "--env")
+			assert.Contains(t, hint, "Hint:")
+			assert.Contains(t, hint, tt.want)
+			assert.NotContains(t, hint, "hunter2", "hint must never echo a credential value")
+		})
+	}
 }
 
 // newInlineCredentialDenialServer returns a test server that resolves one

--- a/cmd/exec/exec.go
+++ b/cmd/exec/exec.go
@@ -44,11 +44,12 @@ Flags:
   -g, --groupname [GROUP_NAME]  Specify the group name for command execution.
   --env="KEY"                   Pass an environment variable to the remote command,
                                 reading its value from the current shell. This keeps
-                                the value off the alpacon command line and out of the
-                                audit log—use it for secrets such as passwords or tokens.
+                                the value off your local alpacon command line—use it
+                                for secrets such as passwords or tokens.
   --env="KEY=VALUE"             Set 'KEY' to a literal value. Discouraged: the value
-                                is written on the command line and recorded verbatim
-                                in the audit log. Never pass credentials this way.
+                                stays on your local alpacon command line, so it lands
+                                in shell history, ps output, and CI job logs. Never
+                                pass credentials this way.
   --work-session [UUID]         Attach this command to a work-session.
                                 Overrides the workspace's active session set via
                                 'alpacon work-session use'.
@@ -80,9 +81,10 @@ Requires an active WorkSession when using Browser login (Auth0); Token auth (API
   alpacon exec -u root prod-docker systemctl status nginx
   alpacon exec -g docker user@server docker images
 
-  # Pass a secret via the shell env; the value stays off the alpacon command line
-  # and out of the audit log. psql reads PGPASSWORD from the environment, so it
-  # never lands in the remote process's argv either.
+  # Pass a secret via the shell env; the value stays off the alpacon command line,
+  # so it never reaches shell history, ps output, or CI job logs. psql reads
+  # PGPASSWORD from the environment, so it never lands in the remote process's
+  # argv either.
   export PGPASSWORD=hunter2
   alpacon exec --env="PGPASSWORD" db-server -- psql -h localhost -U app -c 'SELECT 1'
 

--- a/cmd/exec/exec.go
+++ b/cmd/exec/exec.go
@@ -213,7 +213,7 @@ func RunRemoteExec(parsed RemoteExecArgs) {
 	if buf != nil {
 		_, _ = os.Stdout.Write(buf.Bytes())
 	}
-	HandleCommandResult(err)
+	HandleCommandResult(err, parsed.InvokedAs)
 }
 
 // reRunHint reconstructs the exec invocation (server, command, and any
@@ -224,8 +224,10 @@ func RunRemoteExec(parsed RemoteExecArgs) {
 // caveat rides in Description, since the rerun re-reads each value from the
 // shell and a machine consumer replaying Command verbatim would otherwise
 // submit without those keys.
+// It names exec even when InvokedAs is websh: websh has no --wait, so the rerun
+// genuinely has to go through exec (README "Exit codes", row 4).
 func reRunHint(parsed RemoteExecArgs) utils.NextAction {
-	parts := []string{"alpacon exec"}
+	parts := []string{ExecInvocation}
 	if parsed.Username != "" {
 		parts = append(parts, "-u "+parsed.Username)
 	}

--- a/cmd/exec/exec.go
+++ b/cmd/exec/exec.go
@@ -85,11 +85,10 @@ Requires an active WorkSession when using Browser login (Auth0); Token auth (API
   alpacon exec -u root prod-docker systemctl status nginx
   alpacon exec -g docker user@server docker images
 
-  # Pass a secret via the shell env; the value stays off the alpacon command line,
-  # so it never reaches shell history, ps output, or CI job logs. psql reads
-  # PGPASSWORD from the environment, so it never lands in the remote process's
-  # argv either.
-  export PGPASSWORD=hunter2
+  # Pass a secret via the shell env; the value stays off the alpacon command line.
+  # Read it in rather than typing it inline, so it stays out of shell history too.
+  # psql reads PGPASSWORD from the environment, so it never reaches the remote argv.
+  read -rs PGPASSWORD && export PGPASSWORD
   alpacon exec --env="PGPASSWORD" db-server -- psql -h localhost -U app -c 'SELECT 1'
 
   # Submit a command asynchronously and retrieve the result later

--- a/cmd/exec/exec.go
+++ b/cmd/exec/exec.go
@@ -71,7 +71,8 @@ DURATION to block with a longer timeout); --output json emits
 The server rejects a command whose command line carries a credential—a
 -p/--password flag, a KEY=VALUE secret such as PGPASSWORD=..., or a
 user:pass@host connection string—before it runs, with exit code 1. Pass the
-secret with --env="KEY" instead.
+secret with --env="KEY" instead; --output json emits an error envelope on
+stderr with error_code command_inline_credential.
 Requires an active WorkSession when using Browser login (Auth0); Token auth (API token or Service token) bypasses this requirement.`,
 	Example: `  # Simple command execution
   alpacon exec prod-docker docker ps

--- a/cmd/exec/exec.go
+++ b/cmd/exec/exec.go
@@ -227,7 +227,7 @@ func RunRemoteExec(parsed RemoteExecArgs) {
 // It names exec even when InvokedAs is websh: websh has no --wait, so the rerun
 // genuinely has to go through exec (README "Exit codes", row 4).
 func reRunHint(parsed RemoteExecArgs) utils.NextAction {
-	parts := []string{ExecInvocation}
+	parts := []string{string(ExecInvocation)}
 	if parsed.Username != "" {
 		parts = append(parts, "-u "+parsed.Username)
 	}

--- a/cmd/exec/exec.go
+++ b/cmd/exec/exec.go
@@ -68,6 +68,10 @@ Exit code 4 indicates the sudo command is pending human approval (approve it in
 the Alpacon console, then re-run, or pass --wait to block—--wait-approval
 DURATION to block with a longer timeout); --output json emits
 {"status":"pending_approval", ...} on stdout.
+The server rejects a command whose command line carries a credential—a
+-p/--password flag, a KEY=VALUE secret such as PGPASSWORD=..., or a
+user:pass@host connection string—before it runs, with exit code 1. Pass the
+secret with --env="KEY" instead.
 Requires an active WorkSession when using Browser login (Auth0); Token auth (API token or Service token) bypasses this requirement.`,
 	Example: `  # Simple command execution
   alpacon exec prod-docker docker ps

--- a/cmd/exec/exec.go
+++ b/cmd/exec/exec.go
@@ -89,7 +89,7 @@ Requires an active WorkSession when using Browser login (Auth0); Token auth (API
   # Pass a secret via the shell env; the value stays off the alpacon command line.
   # Read it in rather than typing it inline, so it stays out of shell history too.
   # psql reads PGPASSWORD from the environment, so it never reaches the remote argv.
-  read -rs PGPASSWORD && export PGPASSWORD
+  printf 'PGPASSWORD: ' && read -rs PGPASSWORD && export PGPASSWORD
   alpacon exec --env="PGPASSWORD" db-server -- psql -h localhost -U app -c 'SELECT 1'
 
   # Submit a command asynchronously and retrieve the result later

--- a/cmd/exec/parse.go
+++ b/cmd/exec/parse.go
@@ -16,12 +16,16 @@ type RemoteExecArgs struct {
 	OutputFormat  string
 	Server        string
 	Command       string
-	Env           map[string]string
-	WaitApproval  time.Duration
-	Detach        bool
-	Wait          bool
-	ShowHelp      bool
-	Err           string
+	// InvokedAs is the command the user typed, ExecInvocation or
+	// WebshInvocation, so hints can show an example in their own syntax. Empty
+	// means exec.
+	InvokedAs    string
+	Env          map[string]string
+	WaitApproval time.Duration
+	Detach       bool
+	Wait         bool
+	ShowHelp     bool
+	Err          string
 }
 
 // ParseRemoteExecArgs parses raw CLI arguments with manual flag handling.

--- a/cmd/exec/parse.go
+++ b/cmd/exec/parse.go
@@ -16,9 +16,9 @@ type RemoteExecArgs struct {
 	OutputFormat  string
 	Server        string
 	Command       string
-	// InvokedAs is the command the user typed, ExecInvocation or
-	// WebshInvocation, so hints can show an example in their own syntax. Empty
-	// means exec.
+	// InvokedAs selects which syntax a hint renders its example in. The caller
+	// sets it, not ParseRemoteExecArgs: websh command mode marks its args
+	// WebshInvocation, and exec leaves it empty, which the hint reads as exec.
 	InvokedAs    string
 	Env          map[string]string
 	WaitApproval time.Duration

--- a/cmd/exec/parse.go
+++ b/cmd/exec/parse.go
@@ -19,7 +19,7 @@ type RemoteExecArgs struct {
 	// InvokedAs selects which syntax a hint renders its example in. The caller
 	// sets it, not ParseRemoteExecArgs: websh command mode marks its args
 	// WebshInvocation, and exec leaves it empty, which the hint reads as exec.
-	InvokedAs    string
+	InvokedAs    Invocation
 	Env          map[string]string
 	WaitApproval time.Duration
 	Detach       bool

--- a/cmd/exec/run.go
+++ b/cmd/exec/run.go
@@ -105,7 +105,7 @@ func isCommandInlineCredentialError(err error) bool {
 // warning about.
 func credentialInlineHint() string {
 	return fmt.Sprintf(
-		"%s move the secret to --env instead (its value is read from your shell, not the command line, and is never recorded):\n"+
+		"%s move the secret to --env instead (its value is read from your shell, so it never lands on the command line the server stores):\n"+
 			"  alpacon exec --env=SECRET_NAME db-server -- <command>\n",
 		utils.Yellow("Hint:"))
 }

--- a/cmd/exec/run.go
+++ b/cmd/exec/run.go
@@ -27,13 +27,11 @@ const sudoDenialLinePrefix = "Alpacon denied this sudo command"
 // alpacon-server inline-credential gate (utils.CommandInlineCredential, ADR 0037).
 const commandInlineCredentialMessage = "server rejected this command—the command line carries a credential"
 
-// ExecInvocation and WebshInvocation name the command the user ran, so a hint
-// can show an example they can copy without translating it first. Both reach
-// this package through RemoteExecArgs.InvokedAs, since websh command mode runs
-// on the exec path.
+// ExecInvocation and WebshInvocation are the two Invocation values (see the
+// Invocation type below).
 const (
-	ExecInvocation  = "alpacon exec"
-	WebshInvocation = "alpacon websh"
+	ExecInvocation  Invocation = "alpacon exec"
+	WebshInvocation Invocation = "alpacon websh"
 )
 
 // approvalWaitPollInterval throttles the --wait re-attempt loop—slower than the MFA poll (api/mfa/mfa.go) since each tick re-runs the command; a var so tests can shorten it.
@@ -44,6 +42,13 @@ var (
 	runPresenceStepUp     = RunExecWithPresenceStepUp
 	streamApprovedCommand = event.StreamApprovedCommand
 )
+
+// Invocation names the command the user ran, so a hint can show an example
+// they can copy without translating it first. A defined type rather than a
+// bare string, so a stray value cannot be assigned by accident. Websh command
+// mode reaches this package through RemoteExecArgs.InvokedAs; the zero value
+// renders as exec.
+type Invocation string
 
 // sudoDenialHints maps a non-interactive sudo denial code to actionable
 // guidance. Codes are kept in sync with alpacon-server utils/error_codes.py.
@@ -111,18 +116,18 @@ func isCommandInlineCredentialError(err error) bool {
 // credentialInlineExample renders the --env line for invokedAs. The two commands
 // take the remote command differently: only exec has the -- separator
 // (cmd/exec/parse.go), while websh takes it as one quoted argument.
-func credentialInlineExample(invokedAs string) string {
+func credentialInlineExample(invokedAs Invocation) string {
 	if invokedAs == WebshInvocation {
-		return WebshInvocation + " --env=SECRET_NAME db-server '<command>'"
+		return string(WebshInvocation) + ` --env="SECRET_NAME" db-server '<command>'`
 	}
-	return ExecInvocation + " --env=SECRET_NAME db-server -- <command>"
+	return string(ExecInvocation) + ` --env="SECRET_NAME" db-server -- <command>`
 }
 
 // credentialInlineHint returns the actionable guidance printed alongside
 // commandInlineCredentialMessage. It never echoes the rejected command
 // line—only fixed guidance naming --env—so it cannot leak the credential it is
 // warning about. invokedAs picks the example; empty falls back to exec.
-func credentialInlineHint(invokedAs string) string {
+func credentialInlineHint(invokedAs Invocation) string {
 	return fmt.Sprintf(
 		"%s move the secret to --env instead (its value is read from your shell, so it never lands on the command line the server stores):\n"+
 			"  %s\n",
@@ -348,7 +353,7 @@ func RunCommandWithRetry(ac *client.AlpaconClient, serverName, command, username
 // during execution; on a remote failure the error carries that output, used here
 // only to surface the sudo-denial hint (not re-printed). invokedAs names the
 // command the user ran so a hint can quote it; empty falls back to exec.
-func HandleCommandResult(err error, invokedAs string) {
+func HandleCommandResult(err error, invokedAs Invocation) {
 	if err != nil {
 		var remoteErr *event.RemoteCommandError
 		if errors.As(err, &remoteErr) {

--- a/cmd/exec/run.go
+++ b/cmd/exec/run.go
@@ -27,6 +27,15 @@ const sudoDenialLinePrefix = "Alpacon denied this sudo command"
 // alpacon-server inline-credential gate (utils.CommandInlineCredential, ADR 0037).
 const commandInlineCredentialMessage = "server rejected this command—the command line carries a credential, which would land in the audit log in plaintext"
 
+// ExecInvocation and WebshInvocation name the command the user ran, so a hint
+// can show an example they can copy without translating it first. Both reach
+// this package through RemoteExecArgs.InvokedAs, since websh command mode runs
+// on the exec path.
+const (
+	ExecInvocation  = "alpacon exec"
+	WebshInvocation = "alpacon websh"
+)
+
 // approvalWaitPollInterval throttles the --wait re-attempt loop—slower than the MFA poll (api/mfa/mfa.go) since each tick re-runs the command; a var so tests can shorten it.
 var approvalWaitPollInterval = 5 * time.Second
 
@@ -99,15 +108,25 @@ func isCommandInlineCredentialError(err error) bool {
 	return code == utils.CommandInlineCredential
 }
 
+// credentialInlineExample renders the --env line for invokedAs. The two commands
+// take the remote command differently: only exec has the -- separator
+// (cmd/exec/parse.go), while websh takes it as one quoted argument.
+func credentialInlineExample(invokedAs string) string {
+	if invokedAs == WebshInvocation {
+		return WebshInvocation + " --env=SECRET_NAME db-server '<command>'"
+	}
+	return ExecInvocation + " --env=SECRET_NAME db-server -- <command>"
+}
+
 // credentialInlineHint returns the actionable guidance printed alongside
 // commandInlineCredentialMessage. It never echoes the rejected command
 // line—only fixed guidance naming --env—so it cannot leak the credential it is
-// warning about.
-func credentialInlineHint() string {
+// warning about. invokedAs picks the example; empty falls back to exec.
+func credentialInlineHint(invokedAs string) string {
 	return fmt.Sprintf(
 		"%s move the secret to --env instead (its value is read from your shell, so it never lands on the command line the server stores):\n"+
-			"  alpacon exec --env=SECRET_NAME db-server -- <command>\n",
-		utils.Yellow("Hint:"))
+			"  %s\n",
+		utils.Yellow("Hint:"), credentialInlineExample(invokedAs))
 }
 
 // hasSudoPresenceDenial reports whether output carries the non-interactive sudo
@@ -327,8 +346,9 @@ func RunCommandWithRetry(ac *client.AlpaconClient, serverName, command, username
 
 // HandleCommandResult exits appropriately on error. Output is streamed to stdout
 // during execution; on a remote failure the error carries that output, used here
-// only to surface the sudo-denial hint (not re-printed).
-func HandleCommandResult(err error) {
+// only to surface the sudo-denial hint (not re-printed). invokedAs names the
+// command the user ran so a hint can quote it; empty falls back to exec.
+func HandleCommandResult(err error, invokedAs string) {
 	if err != nil {
 		var remoteErr *event.RemoteCommandError
 		if errors.As(err, &remoteErr) {
@@ -352,7 +372,7 @@ func HandleCommandResult(err error) {
 				return
 			}
 			fmt.Fprintf(os.Stderr, "%s: %s.\n", utils.Red("Error"), commandInlineCredentialMessage)
-			fmt.Fprint(os.Stderr, credentialInlineHint())
+			fmt.Fprint(os.Stderr, credentialInlineHint(invokedAs))
 			os.Exit(1)
 		}
 		utils.CliErrorWithExit("%s", err)

--- a/cmd/exec/run.go
+++ b/cmd/exec/run.go
@@ -25,7 +25,7 @@ const sudoDenialLinePrefix = "Alpacon denied this sudo command"
 
 // commandInlineCredentialMessage is the exec-facing error line for the
 // alpacon-server inline-credential gate (utils.CommandInlineCredential, ADR 0037).
-const commandInlineCredentialMessage = "server rejected this command—the command line carries a credential, which would land in the audit log in plaintext"
+const commandInlineCredentialMessage = "server rejected this command—the command line carries a credential"
 
 // ExecInvocation and WebshInvocation name the command the user ran, so a hint
 // can show an example they can copy without translating it first. Both reach
@@ -102,7 +102,7 @@ func sudoDenialHint(output string) string {
 // submitted command line itself contained a credential (e.g. a -p/--password
 // flag, a KEY=VALUE secret such as PGPASSWORD=..., or a user:pass@host
 // connection string), so the server refused the command before it ever ran
-// rather than record it in the audit log in plaintext.
+// rather than persist that line.
 func isCommandInlineCredentialError(err error) bool {
 	code, _ := utils.ParseErrorResponse(err)
 	return code == utils.CommandInlineCredential

--- a/cmd/websh/websh.go
+++ b/cmd/websh/websh.go
@@ -128,10 +128,11 @@ Exit code 3 indicates a WorkSession gate denial; run with --output json to
 parse a machine-readable diagnostic on stderr.
 Exit code 4 indicates the sudo command is pending human approval; approve it in
 the Alpacon console (web), then re-run—or use 'alpacon exec --wait' to block.
-The server rejects a command whose command line carries a credential—a
--p/--password flag, a KEY=VALUE secret such as PGPASSWORD=..., or a
-user:pass@host connection string—before it runs, with exit code 1. Pass the
-secret with --env="KEY" instead.
+When websh runs a command, the server rejects it before it runs if its command
+line carries a credential—a -p/--password flag, a KEY=VALUE secret such as
+PGPASSWORD=..., or a user:pass@host connection string—with exit code 1. Pass
+the secret with --env="KEY" instead; --output json emits an error envelope on
+stderr with error_code command_inline_credential.
 Requires an active WorkSession when using Browser login (Auth0); Token auth (API token or Service token) bypasses this requirement.`,
 	Example: `  # Open a websh terminal
   alpacon websh my-server

--- a/cmd/websh/websh.go
+++ b/cmd/websh/websh.go
@@ -128,6 +128,10 @@ Exit code 3 indicates a WorkSession gate denial; run with --output json to
 parse a machine-readable diagnostic on stderr.
 Exit code 4 indicates the sudo command is pending human approval; approve it in
 the Alpacon console (web), then re-run—or use 'alpacon exec --wait' to block.
+The server rejects a command whose command line carries a credential—a
+-p/--password flag, a KEY=VALUE secret such as PGPASSWORD=..., or a
+user:pass@host connection string—before it runs, with exit code 1. Pass the
+secret with --env="KEY" instead.
 Requires an active WorkSession when using Browser login (Auth0); Token auth (API token or Service token) bypasses this requirement.`,
 	Example: `  # Open a websh terminal
   alpacon websh my-server

--- a/cmd/websh/websh.go
+++ b/cmd/websh/websh.go
@@ -168,7 +168,7 @@ Requires an active WorkSession when using Browser login (Auth0); Token auth (API
   # Pass a secret via the shell env; the value stays off the alpacon command line.
   # Read it in rather than typing it inline, so it stays out of shell history too.
   # psql reads PGPASSWORD directly from the env.
-  read -rs PGPASSWORD && export PGPASSWORD
+  printf 'PGPASSWORD: ' && read -rs PGPASSWORD && export PGPASSWORD
   alpacon websh --env="PGPASSWORD" my-server 'psql -h localhost -U app -c "SELECT 1"'
 
   # Share terminal session

--- a/cmd/websh/websh.go
+++ b/cmd/websh/websh.go
@@ -236,6 +236,7 @@ Note: All flags must be placed before the server name.
 				Groupname:     groupname,
 				WorkSessionID: parsed.WorkSessionID,
 				OutputFormat:  parsed.OutputFormat,
+				InvokedAs:     execCmd.WebshInvocation,
 				Server:        serverName,
 				Command:       execCmd.ShellJoin(commandArgs),
 				Env:           env,

--- a/cmd/websh/websh.go
+++ b/cmd/websh/websh.go
@@ -147,10 +147,10 @@ Requires an active WorkSession when using Browser login (Auth0); Token auth (API
   alpacon websh my-server "ls -la /var/log"
   alpacon websh root@my-server "systemctl status nginx"
 
-  # Pass a secret via the shell env; the value stays off the alpacon command line,
-  # so it never reaches shell history, ps output, or CI job logs. psql reads
-  # PGPASSWORD directly from the env.
-  export PGPASSWORD=hunter2
+  # Pass a secret via the shell env; the value stays off the alpacon command line.
+  # Read it in rather than typing it inline, so it stays out of shell history too.
+  # psql reads PGPASSWORD directly from the env.
+  read -rs PGPASSWORD && export PGPASSWORD
   alpacon websh --env="PGPASSWORD" my-server 'psql -h localhost -U app -c "SELECT 1"'
 
   # Share terminal session

--- a/cmd/websh/websh.go
+++ b/cmd/websh/websh.go
@@ -108,6 +108,23 @@ func ParseWebshArgs(args []string) (WebshArgs, error) {
 	return res, nil
 }
 
+// buildRemoteExecArgs assembles the shared-runner args for websh command mode.
+// username and serverName come in separately because Run resolves user@host
+// after parsing. InvokedAs is pinned to WebshInvocation so a refusal hint
+// renders websh syntax.
+func buildRemoteExecArgs(parsed WebshArgs, username, serverName string) execCmd.RemoteExecArgs {
+	return execCmd.RemoteExecArgs{
+		Username:      username,
+		Groupname:     parsed.Groupname,
+		WorkSessionID: parsed.WorkSessionID,
+		OutputFormat:  parsed.OutputFormat,
+		InvokedAs:     execCmd.WebshInvocation,
+		Server:        serverName,
+		Command:       execCmd.ShellJoin(parsed.CommandArgs),
+		Env:           parsed.Env,
+	}
+}
+
 var WebshCmd = &cobra.Command{
 	Use:   "websh [flags] [USER@]SERVER [COMMAND]",
 	Short: "Open a websh terminal or execute a command on a server",
@@ -232,16 +249,7 @@ Note: All flags must be placed before the server name.
 		// pending-approval exit code, sudo-denial hints, and JSON buffering match
 		// exec. Wait is left false—websh has no --wait, so the blocking wait never runs.
 		if len(commandArgs) > 0 {
-			execCmd.RunRemoteExec(execCmd.RemoteExecArgs{
-				Username:      username,
-				Groupname:     groupname,
-				WorkSessionID: parsed.WorkSessionID,
-				OutputFormat:  parsed.OutputFormat,
-				InvokedAs:     execCmd.WebshInvocation,
-				Server:        serverName,
-				Command:       execCmd.ShellJoin(commandArgs),
-				Env:           env,
-			})
+			execCmd.RunRemoteExec(buildRemoteExecArgs(parsed, username, serverName))
 			return
 		}
 

--- a/cmd/websh/websh.go
+++ b/cmd/websh/websh.go
@@ -143,8 +143,9 @@ Requires an active WorkSession when using Browser login (Auth0); Token auth (API
   alpacon websh my-server "ls -la /var/log"
   alpacon websh root@my-server "systemctl status nginx"
 
-  # Pass a secret via the shell env; the value stays off the alpacon command line
-  # and out of the session recording. psql reads PGPASSWORD directly from the env.
+  # Pass a secret via the shell env; the value stays off the alpacon command line,
+  # so it never reaches shell history, ps output, or CI job logs. psql reads
+  # PGPASSWORD directly from the env.
   export PGPASSWORD=hunter2
   alpacon websh --env="PGPASSWORD" my-server 'psql -h localhost -U app -c "SELECT 1"'
 
@@ -168,12 +169,12 @@ Flags:
   -g, --groupname [GROUP_NAME]       Specify the group name for command execution.
   --env="KEY"                        Pass an environment variable, reading its value
                                      from the current shell. This keeps the value off
-                                     the alpacon command line and out of the audit
-                                     log—use it for secrets such as passwords or tokens.
+                                     your local alpacon command line—use it for
+                                     secrets such as passwords or tokens.
   --env="KEY=VALUE"                  Set 'KEY' to a literal value. Discouraged: the
-                                     value is written on the command line and recorded
-                                     verbatim in the audit log. Never pass credentials
-                                     this way.
+                                     value stays on your local alpacon command line,
+                                     so it lands in shell history, ps output, and CI
+                                     job logs. Never pass credentials this way.
   -s, --share                        Share the terminal via a temporary link.
   --read-only=[true|false]           Set shared session to read-only (default: false).
   --work-session [UUID]              Attach this session to a work-session.

--- a/cmd/websh/websh_test.go
+++ b/cmd/websh/websh_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/alpacax/alpacon-cli/api/types"
 	"github.com/alpacax/alpacon-cli/api/websh"
+	execCmd "github.com/alpacax/alpacon-cli/cmd/exec"
 	"github.com/alpacax/alpacon-cli/utils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -408,4 +409,29 @@ func TestPrintWatchHeader_StripsControlSequences(t *testing.T) {
 	assert.Equal(t, 8, strings.Count(got, "\n"), "a newline must not forge an identity line")
 	assert.Contains(t, got, "Server:   web-01db-prod\n")
 	assert.Contains(t, got, "Username: alice\n")
+}
+
+// TestBuildRemoteExecArgsPinsWebshInvocation pins InvokedAs to WebshInvocation:
+// the one line that makes a refusal hint render websh syntax instead of exec's.
+// Without it every field still flows and the whole suite stays green, so this
+// is the only guard against a refactor dropping the field.
+func TestBuildRemoteExecArgsPinsWebshInvocation(t *testing.T) {
+	parsed := WebshArgs{
+		Groupname:     "devs",
+		WorkSessionID: "ws-1",
+		OutputFormat:  "json",
+		CommandArgs:   []string{"psql", "-h", "localhost"},
+		Env:           map[string]string{"PGPASSWORD": "x"},
+	}
+
+	args := buildRemoteExecArgs(parsed, "root", "prod")
+
+	assert.Equal(t, execCmd.WebshInvocation, args.InvokedAs)
+	assert.Equal(t, "root", args.Username)
+	assert.Equal(t, "devs", args.Groupname)
+	assert.Equal(t, "ws-1", args.WorkSessionID)
+	assert.Equal(t, "json", args.OutputFormat)
+	assert.Equal(t, "prod", args.Server)
+	assert.Equal(t, "psql -h localhost", args.Command)
+	assert.Equal(t, parsed.Env, args.Env)
 }

--- a/utils/error.go
+++ b/utils/error.go
@@ -16,8 +16,8 @@ const (
 
 	// CommandInlineCredential: alpacon-server refused a command because its command
 	// line carries a credential (e.g. a -p/--password flag, a KEY=VALUE secret such
-	// as PGPASSWORD=..., or a user:pass@host connection string), which would
-	// otherwise be recorded in the audit log in plaintext. Move the secret to
+	// as PGPASSWORD=..., or a user:pass@host connection string), which the server
+	// would otherwise persist in the stored command line. Move the secret to
 	// --env instead. See alpacon-server ADR 0037 (Refs alpacax/alpacon-server#2745).
 	CommandInlineCredential = "command_inline_credential"
 

--- a/utils/error.go
+++ b/utils/error.go
@@ -19,6 +19,9 @@ const (
 	// as PGPASSWORD=..., or a user:pass@host connection string), which the server
 	// would otherwise persist in the stored command line. Move the secret to
 	// --env instead. See alpacon-server ADR 0037 (Refs alpacax/alpacon-server#2745).
+	// The rejected-forms list above is repeated in the exec and websh help text
+	// and the README's "When a command is denied" section—when the server-side
+	// gate changes, update all of them together.
 	CommandInlineCredential = "command_inline_credential"
 
 	// WorkSession gate codes (returned by alpacon-server work_sessions/services.py)


### PR DESCRIPTION
## Background

#304 added the `command_inline_credential` hint for the ADR 0037 inline-credential gate (alpacax/alpacon-server#2745). Working through #305 afterwards, the CLI's copy around that gate was checked against what the server actually does, and three things did not hold up.

The largest is that the `--env` guidance was wrong. The help discouraged `--env="KEY=VALUE"` because the value is "recorded verbatim in the audit log", and recommended `--env="KEY"` for keeping it "out of the audit log". Both forms travel in the request's `env` field. The gate (`check_inline_credential` in `execution_gate/stages.py`) reads only `command_line`, `env` is absent from the command serializer's read fields, and `expose_command_env_in_audit` defaults to false, which masks env values out of stored results. The audit log does not separate the two forms at all.

What does separate them is local. A literal value stays on the user's own alpacon command line, so it reaches shell history, `ps` output, and CI job logs.

## Changes

| Commit | What |
|---|---|
| `25064b4` | Drop the audit-log claim from the `--env` help and the inline-credential hint, replacing it with the real exposure, which is local (`cmd/exec/exec.go`, `cmd/websh/websh.go`, `cmd/exec/run.go`) |
| `53f2eef` | Replace the README's only `--env` example, which used the literal form the help discourages, with the shell-read form. Also fixes the quoting bug in that line, where `"echo $KEY"` was expanded by the local shell before alpacon saw it |
| `7d4cb0b` | Document the gate itself, in the `exec` and `websh` help, in the README body, and in the exit code table's row for `1` |
| `89da43f` | Make the hint name the command the caller ran. websh command mode delegates to the exec runner, so websh users were handed an `alpacon exec` example |
| `6db173d` | Narrow the examples' exposure claim to the alpacon command line, and read the secret with `read -rs` instead of an inline `export`, so the example itself stays out of shell history rather than merely claiming to |
| `f2093d5` | Drop the "audit log in plaintext" claim from the rejection message and comments. The command line is persisted, but `redact_inline_credentials` (ADR 0042) is keyed on the same predicate as the gate, so anything the gate rejects is stored as `[REDACTED]`, never plaintext |
| `11eaf2a` | Describe `RemoteExecArgs.InvokedAs` as caller-set rather than parsed, matching what `ParseRemoteExecArgs` actually does |
| `8c49952` | Consolidate the gate's rejected-forms list into one README section ("When a command is denied") with the exec section pointing at it, document the `command_inline_credential` JSON envelope in both helps and the README, and scope the websh wording to command mode, where the gate actually applies |
| `768f975` | Give `InvokedAs` a defined `Invocation` type, so a stray value cannot silently fall back to the exec example, and quote the hint's flag as `--env="SECRET_NAME"` to match the spelling every doc recommends |
| `001ca38` | Extract websh command mode's `RemoteExecArgs` construction into `buildRemoteExecArgs` and pin `InvokedAs: WebshInvocation` with a unit test—previously no test would fail if a refactor dropped the field |
| `ef5db01` | Scope README's "refuses such a command" to "the recognizable forms" (shapes like `--token=xyz` pass through), fix the `next_actions` rationale that `89da43f` had invalidated, add a `printf` prompt to the `read -rs` examples, and record next to `CommandInlineCredential` that the rejected-forms list lives in five places |

`89da43f` needed more than a name swap. The `--` separator exists only in `cmd/exec/parse.go:58`; websh takes the remote command as a single quoted argument, so the shape of the example differs too. `RemoteExecArgs.InvokedAs` carries the entry point and `HandleCommandResult` renders from it. `reRunHint` still names exec on purpose: websh has no `--wait`, so a rerun after approval genuinely has to go through exec, which row 4 of the README exit code table already documents.

`6db173d`–`11eaf2a` apply the five findings from the Copilot review round; each finding's resolution is answered in its review thread. `8c49952` is a follow-up documentation pass: the rejected-forms list previously lived in three places and would drift on the next change, and the README's list of JSON-envelope emitters predated this branch making `exec`/`websh` one of them. `768f975`–`ef5db01` apply the human review round (warnings 1–2, suggestions 3–7); warning 2's actionable half—populating `next_actions` in the JSON envelope—is split out as #310 since it changes envelope behavior.

No behavior of `--env` changed. Only the wording and the hint's example, and exit codes are untouched throughout.

## Testing

`gofmt -l .` clean, `go vet ./...` clean, `go test -race ./...` passing.

`TestCredentialInlineHint` is now table-driven and pins the example for exec, websh, and the unset fallback. `TestBuildRemoteExecArgsPinsWebshInvocation` pins websh command mode's `InvokedAs`. The existing assertions that the rejected command line never appears in output are unchanged.

Also verified against a real server (`web-editor`):

- `--env="PGPASSWORD=hunter2"` passes the gate, delivers the value, and the stored result renders as `[MASKED]`
- `--env="TESTKEY"` behaves identically
- a credential on the remote command line (`mysql -pSecret123`) is rejected with the hint and exit 1, and the command is not stored
- the websh path prints the quoted-argument example, the exec path the `--` one
- the websh form the hint suggests actually runs

## Follow-up

Populating `next_actions` in the `command_inline_credential` JSON envelope is split out as #310: the fix is invocation-dependent since `89da43f`, but adding it means extending `CliErrorEnvelopeWithExit`, which is envelope behavior rather than wording.

The error-code mapping is not in this PR; it is split out as #306. The server defines 262 error codes and `utils/error.go` knows 11, so when one of the rest arrives without a `detail`, the raw `code: X` becomes the user-facing message and the issue-tracker line is appended on top. That is a structural change rather than a wording fix, so it reviews better on its own.

Merge this one and cut the release first; #306 is for the next cycle.

Refs #305, #304, alpacax/alpacon-server#2745

