### PR TITLE
fix(websh): let every session goroutine leave teardown

### DIFF
--- a/api/websh/types.go
+++ b/api/websh/types.go
@@ -10,7 +10,7 @@ import (
 )
 
 type WebsocketClient struct {
-	Header     http.Header
+	header     http.Header
 	conn       *websocket.Conn
 	done       chan struct{} // closed once the first outcome is recorded
 	err        error

--- a/api/websh/types.go
+++ b/api/websh/types.go
@@ -2,6 +2,7 @@ package websh
 
 import (
 	"net/http"
+	"sync"
 	"time"
 
 	"github.com/alpacax/alpacon-cli/api/types"
@@ -9,9 +10,11 @@ import (
 )
 
 type WebsocketClient struct {
-	Header http.Header
-	conn   *websocket.Conn
-	Done   chan error
+	Header    http.Header
+	conn      *websocket.Conn
+	Done      chan error
+	quit      chan struct{} // closed once the first outcome is reported
+	closeOnce sync.Once
 }
 
 type SessionRequest struct {

--- a/api/websh/types.go
+++ b/api/websh/types.go
@@ -10,11 +10,11 @@ import (
 )
 
 type WebsocketClient struct {
-	Header    http.Header
-	conn      *websocket.Conn
-	Done      chan error
-	quit      chan struct{} // closed once the first outcome is reported
-	closeOnce sync.Once
+	Header     http.Header
+	conn       *websocket.Conn
+	done       chan struct{} // closed once the first outcome is recorded
+	err        error
+	finishOnce sync.Once
 }
 
 type SessionRequest struct {

--- a/api/websh/websh.go
+++ b/api/websh/websh.go
@@ -241,6 +241,9 @@ func OpenReadOnlyTerminal(ac *client.AlpaconClient, sessionResponse SessionRespo
 		return err
 	}
 	defer func() { _ = wsClient.conn.Close() }()
+	// Whatever this returns through, the goroutines below have to be released.
+	// The sync.Once makes it a no-op once an outcome is already recorded.
+	defer wsClient.finish(nil)
 
 	sigChan := make(chan os.Signal, 1)
 	signal.Notify(sigChan, os.Interrupt, syscall.SIGTERM)
@@ -248,7 +251,6 @@ func OpenReadOnlyTerminal(ac *client.AlpaconClient, sessionResponse SessionRespo
 	// arriving mid-teardown lands in the buffered channel instead of killing the
 	// process with the terminal still in raw mode.
 	defer signal.Stop(sigChan)
-	go wsClient.watchInterrupt(sigChan)
 
 	restore, err := enterRawMode()
 	if err != nil {
@@ -256,6 +258,7 @@ func OpenReadOnlyTerminal(ac *client.AlpaconClient, sessionResponse SessionRespo
 	}
 	defer restore()
 
+	go wsClient.watchInterrupt(sigChan)
 	go wsClient.readCtrlC()
 	go wsClient.readFromServer()
 

--- a/api/websh/websh.go
+++ b/api/websh/websh.go
@@ -275,7 +275,7 @@ func OpenNewTerminal(ac *client.AlpaconClient, sessionResponse SessionResponse) 
 func (wsClient *WebsocketClient) runWsClient() error {
 	oldState, err := checkTerminal()
 	if err != nil {
-		utils.CliErrorWithExit("websocket connection failed %v", err)
+		utils.CliErrorWithExit("failed to set up terminal: %v", err)
 	}
 	defer func() { _ = term.Restore(int(os.Stdin.Fd()), oldState) }()
 

--- a/api/websh/websh.go
+++ b/api/websh/websh.go
@@ -206,9 +206,14 @@ func newWebsocketClient(header http.Header) *WebsocketClient {
 }
 
 func (wsClient *WebsocketClient) dial(websocketURL string) {
-	conn, _, err := websocket.DefaultDialer.Dial(websocketURL, wsClient.Header)
+	conn, resp, err := websocket.DefaultDialer.Dial(websocketURL, wsClient.Header)
 	if err != nil {
-		utils.CliErrorWithExit("websocket connection failed: %v", err)
+		// The handshake response carries the reason a bad handshake alone never names.
+		status := ""
+		if resp != nil {
+			status = fmt.Sprintf(" (status %s)", resp.Status)
+		}
+		utils.CliErrorWithExit("websocket connection failed: %v%s", err, status)
 	}
 	wsClient.conn = conn
 }

--- a/api/websh/websh.go
+++ b/api/websh/websh.go
@@ -272,8 +272,8 @@ func OpenReadOnlyTerminal(ac *client.AlpaconClient, sessionResponse SessionRespo
 	return wsClient.err
 }
 
-// Handles graceful termination of the websh terminal.
-// Exits on error without further error handling.
+// OpenNewTerminal opens an interactive terminal on the session.
+// A failed dial exits the process instead of returning.
 func OpenNewTerminal(ac *client.AlpaconClient, sessionResponse SessionResponse) error {
 	wsClient := newWebsocketClient(ac.SetWebsocketHeader())
 	wsClient.dial(sessionResponse.WebsocketURL)

--- a/api/websh/websh.go
+++ b/api/websh/websh.go
@@ -30,8 +30,8 @@ const (
 	writeFlushInterval = 5 * time.Millisecond
 
 	// sessionEndCloseCode is how the proxy closes a user channel at the end of a
-	// session (sendCloseFrame in proxy-server internal/ws/channel.go); alpamon spends
-	// the same 4000 on the same meaning. A websh session never ends with 1000, so
+	// session (sendCloseFrame in proxy-server internal/ws/channel.go); alpamon sends
+	// the same 4000 for the same meaning. A websh session never ends with 1000, so
 	// without this every normal end would be reported as a failure.
 	sessionEndCloseCode = 4000
 )

--- a/api/websh/websh.go
+++ b/api/websh/websh.go
@@ -201,8 +201,7 @@ func CreateWebshSession(ac *client.AlpaconClient, serverName, username, groupnam
 func newWebsocketClient(header http.Header) *WebsocketClient {
 	return &WebsocketClient{
 		Header: header,
-		Done:   make(chan error, 1),
-		quit:   make(chan struct{}),
+		done:   make(chan struct{}),
 	}
 }
 
@@ -214,12 +213,12 @@ func (wsClient *WebsocketClient) dial(websocketURL string) {
 	wsClient.conn = conn
 }
 
-// finish takes effect only once: Done holds one value and is received once, so a
-// second send would park its goroutine for good.
+// finish keeps the first outcome. err is written before done closes, so anyone
+// who saw done can read it.
 func (wsClient *WebsocketClient) finish(err error) {
-	wsClient.closeOnce.Do(func() {
-		wsClient.Done <- err
-		close(wsClient.quit)
+	wsClient.finishOnce.Do(func() {
+		wsClient.err = err
+		close(wsClient.done)
 	})
 }
 
@@ -241,7 +240,7 @@ func OpenReadOnlyTerminal(ac *client.AlpaconClient, sessionResponse SessionRespo
 		select {
 		case <-sigChan:
 			wsClient.finish(nil)
-		case <-wsClient.quit:
+		case <-wsClient.done:
 		}
 	}()
 
@@ -264,7 +263,8 @@ func OpenReadOnlyTerminal(ac *client.AlpaconClient, sessionResponse SessionRespo
 	}()
 
 	go wsClient.readFromServer()
-	return <-wsClient.Done
+	<-wsClient.done
+	return wsClient.err
 }
 
 // Handles graceful termination of the websh terminal.
@@ -290,7 +290,8 @@ func (wsClient *WebsocketClient) runWsClient() error {
 	go wsClient.readUserInput(inputChan)
 	go wsClient.writeToServer(inputChan)
 
-	return <-wsClient.Done
+	<-wsClient.done
+	return wsClient.err
 }
 
 func checkTerminal() (*term.State, error) {
@@ -331,7 +332,7 @@ func (wsClient *WebsocketClient) readUserInput(inputChan chan<- string) {
 		// After teardown writeToServer is gone, so an unguarded send would park here.
 		select {
 		case inputChan <- string(char):
-		case <-wsClient.quit:
+		case <-wsClient.done:
 			return
 		}
 	}
@@ -341,7 +342,7 @@ func (wsClient *WebsocketClient) writeToServer(inputChan <-chan string) {
 	var inputBuffer []rune
 	for {
 		select {
-		case <-wsClient.quit:
+		case <-wsClient.done:
 			return
 		case input := <-inputChan:
 			inputBuffer = append(inputBuffer, []rune(input)...)

--- a/api/websh/websh.go
+++ b/api/websh/websh.go
@@ -333,11 +333,11 @@ func (wsClient *WebsocketClient) runWsClient() error {
 // enterRawMode returns the restore for the caller to defer.
 func enterRawMode() (func(), error) {
 	if !term.IsTerminal(int(os.Stdin.Fd())) {
-		return nil, errors.New("failed to set up terminal: stdin is not a terminal")
+		return nil, errors.New("stdin is not a terminal")
 	}
 	oldState, err := term.MakeRaw(int(os.Stdin.Fd()))
 	if err != nil {
-		return nil, fmt.Errorf("failed to set up terminal: %w", err)
+		return nil, fmt.Errorf("failed to enter raw mode: %w", err)
 	}
 
 	return func() { _ = term.Restore(int(os.Stdin.Fd()), oldState) }, nil

--- a/api/websh/websh.go
+++ b/api/websh/websh.go
@@ -248,12 +248,8 @@ func OpenReadOnlyTerminal(ac *client.AlpaconClient, sessionResponse SessionRespo
 	}
 	defer func() { _ = wsClient.conn.Close() }()
 
-	sigChan := make(chan os.Signal, 1)
-	signal.Notify(sigChan, os.Interrupt, syscall.SIGTERM)
-	// Registered before the raw-mode restore so LIFO runs it after: a signal
-	// arriving mid-teardown lands in the buffered channel instead of killing the
-	// process with the terminal still in raw mode.
-	defer signal.Stop(sigChan)
+	sigChan, stopSignals := notifySignals()
+	defer stopSignals()
 
 	restore, err := enterRawMode()
 	if err != nil {
@@ -299,7 +295,7 @@ func (wsClient *WebsocketClient) readCtrlC() {
 
 // OpenNewTerminal opens an interactive terminal on the session.
 // Input is forwarded to the server. Terminal echo is suppressed via raw mode.
-// Ends cleanly on the remote close or on Ctrl+D.
+// Ends cleanly on the remote close, on Ctrl+D, or on a signal.
 func OpenNewTerminal(ac *client.AlpaconClient, sessionResponse SessionResponse) error {
 	wsClient := newWebsocketClient(ac.SetWebsocketHeader())
 	if err := wsClient.dial(sessionResponse.WebsocketURL); err != nil {
@@ -311,6 +307,9 @@ func OpenNewTerminal(ac *client.AlpaconClient, sessionResponse SessionResponse) 
 }
 
 func (wsClient *WebsocketClient) runWsClient() error {
+	sigChan, stopSignals := notifySignals()
+	defer stopSignals()
+
 	restore, err := enterRawMode()
 	if err != nil {
 		return err
@@ -319,12 +318,24 @@ func (wsClient *WebsocketClient) runWsClient() error {
 
 	inputChan := make(chan string, 1)
 
+	go wsClient.watchInterrupt(sigChan)
 	go wsClient.readFromServer()
 	go wsClient.readUserInput(inputChan)
 	go wsClient.writeToServer(inputChan)
 
 	<-wsClient.done
 	return wsClient.err
+}
+
+// notifySignals returns the signal channel and the stop for the caller to defer.
+// Defer the stop before the raw-mode restore so LIFO runs it after: a signal
+// arriving mid-teardown lands in the buffered channel instead of killing the
+// process with the terminal still in raw mode.
+func notifySignals() (chan os.Signal, func()) {
+	sigChan := make(chan os.Signal, 1)
+	signal.Notify(sigChan, os.Interrupt, syscall.SIGTERM)
+
+	return sigChan, func() { signal.Stop(sigChan) }
 }
 
 // enterRawMode returns the restore for the caller to defer.

--- a/api/websh/websh.go
+++ b/api/websh/websh.go
@@ -358,8 +358,7 @@ func (wsClient *WebsocketClient) readUserInput(inputChan chan<- string) {
 		char, _, err := reader.ReadRune()
 		if err != nil {
 			if errors.Is(err, io.EOF) {
-				wsClient.finish(nil)
-				return
+				err = nil // the user closing stdin ends the session rather than failing it
 			}
 			wsClient.finish(err)
 			return

--- a/api/websh/websh.go
+++ b/api/websh/websh.go
@@ -29,10 +29,10 @@ const (
 	ctrlC              = 0x03
 	writeFlushInterval = 5 * time.Millisecond
 
-	// sessionEndCloseCode is what the proxy closes a user channel with when the
-	// session ends normally—see sendCloseFrame in proxy-server internal/ws/channel.go.
-	// alpamon spends the same 4000 on the same meaning. A websh session never ends
-	// with 1000, so leaving this out would leave every normal end reported as a failure.
+	// sessionEndCloseCode is how the proxy closes a user channel at the end of a
+	// session (sendCloseFrame in proxy-server internal/ws/channel.go); alpamon spends
+	// the same 4000 on the same meaning. A websh session never ends with 1000, so
+	// without this every normal end would be reported as a failure.
 	sessionEndCloseCode = 4000
 )
 
@@ -225,9 +225,9 @@ func (wsClient *WebsocketClient) dial(websocketURL string) error {
 	return nil
 }
 
-// finish keeps the first outcome. err is written before done closes, so anyone
-// who saw done can read it. A normal remote close is how a session ends rather
-// than a failure; every other close code stays an error.
+// finish keeps the first outcome. err is written before done closes, so anyone who
+// saw done can read it. A deliberate close ends the session rather than failing it;
+// every other close code stays an error.
 func (wsClient *WebsocketClient) finish(err error) {
 	if websocket.IsCloseError(err, sessionEndCloseCode, websocket.CloseNormalClosure, websocket.CloseGoingAway) {
 		err = nil
@@ -247,6 +247,7 @@ func OpenReadOnlyTerminal(ac *client.AlpaconClient, sessionResponse SessionRespo
 		return err
 	}
 	defer func() { _ = wsClient.conn.Close() }()
+
 	sigChan := make(chan os.Signal, 1)
 	signal.Notify(sigChan, os.Interrupt, syscall.SIGTERM)
 	// Registered before the raw-mode restore so LIFO runs it after: a signal
@@ -350,8 +351,8 @@ func (wsClient *WebsocketClient) readFromServer() {
 	}
 }
 
-// Teardown cannot release this one mid-read: a goroutine parked in ReadRune
-// stays there until the next keystroke, and only closing stdin would change that.
+// readUserInput cannot be released mid-read: a goroutine parked in ReadRune stays
+// there until the next keystroke, and only closing stdin would change that.
 func (wsClient *WebsocketClient) readUserInput(inputChan chan<- string) {
 	reader := bufio.NewReader(os.Stdin)
 	for {

--- a/api/websh/websh.go
+++ b/api/websh/websh.go
@@ -206,6 +206,14 @@ func newWebsocketClient(header http.Header) *WebsocketClient {
 	}
 }
 
+func (wsClient *WebsocketClient) dial(websocketURL string) {
+	conn, _, err := websocket.DefaultDialer.Dial(websocketURL, wsClient.Header)
+	if err != nil {
+		utils.CliErrorWithExit("websocket connection failed: %v", err)
+	}
+	wsClient.conn = conn
+}
+
 // finish takes effect only once: Done holds one value and is received once, so a
 // second send would park its goroutine for good.
 func (wsClient *WebsocketClient) finish(err error) {
@@ -220,12 +228,7 @@ func (wsClient *WebsocketClient) finish(err error) {
 // Exits cleanly on Ctrl+C or SIGTERM.
 func OpenReadOnlyTerminal(ac *client.AlpaconClient, sessionResponse SessionResponse) error {
 	wsClient := newWebsocketClient(ac.SetWebsocketHeader())
-
-	var err error
-	wsClient.conn, _, err = websocket.DefaultDialer.Dial(sessionResponse.WebsocketURL, wsClient.Header)
-	if err != nil {
-		utils.CliErrorWithExit("websocket connection failed: %v", err)
-	}
+	wsClient.dial(sessionResponse.WebsocketURL)
 	defer func() { _ = wsClient.conn.Close() }()
 
 	sigChan := make(chan os.Signal, 1)
@@ -268,20 +271,10 @@ func OpenReadOnlyTerminal(ac *client.AlpaconClient, sessionResponse SessionRespo
 // Exits on error without further error handling.
 func OpenNewTerminal(ac *client.AlpaconClient, sessionResponse SessionResponse) error {
 	wsClient := newWebsocketClient(ac.SetWebsocketHeader())
-
-	var err error
-	wsClient.conn, _, err = websocket.DefaultDialer.Dial(sessionResponse.WebsocketURL, wsClient.Header)
-	if err != nil {
-		utils.CliErrorWithExit("websocket connection failed: %v", err)
-	}
+	wsClient.dial(sessionResponse.WebsocketURL)
 	defer func() { _ = wsClient.conn.Close() }()
 
-	err = wsClient.runWsClient()
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return wsClient.runWsClient()
 }
 
 func (wsClient *WebsocketClient) runWsClient() error {

--- a/api/websh/websh.go
+++ b/api/websh/websh.go
@@ -25,6 +25,9 @@ import (
 const (
 	sessionsBaseURL     = "/api/websh/sessions/"
 	userChannelsBaseURL = "/api/websh/user-channels/"
+
+	ctrlC              = 0x03
+	writeFlushInterval = 5 * time.Millisecond
 )
 
 func GetSessionList(ac *client.AlpaconClient) ([]SessionListItem, error) {
@@ -203,9 +206,8 @@ func newWebsocketClient(header http.Header) *WebsocketClient {
 	}
 }
 
-// finish reports the first outcome of the session and signals teardown to every
-// goroutine. Later calls are dropped: Done holds one value and is received once,
-// so a second send would park its goroutine for good.
+// finish takes effect only once: Done holds one value and is received once, so a
+// second send would park its goroutine for good.
 func (wsClient *WebsocketClient) finish(err error) {
 	wsClient.closeOnce.Do(func() {
 		wsClient.Done <- err
@@ -246,12 +248,12 @@ func OpenReadOnlyTerminal(ac *client.AlpaconClient, sessionResponse SessionRespo
 	}
 	defer func() { _ = term.Restore(int(os.Stdin.Fd()), oldState) }()
 
-	// In raw mode Ctrl+C is 0x03 — detect it to exit
+	// Raw mode suppresses SIGINT, so Ctrl+C only ever arrives as a byte
 	go func() {
 		buf := make([]byte, 1)
 		for {
 			_, err := os.Stdin.Read(buf)
-			if err != nil || buf[0] == 0x03 {
+			if err != nil || buf[0] == ctrlC {
 				wsClient.finish(nil)
 				return
 			}
@@ -350,7 +352,7 @@ func (wsClient *WebsocketClient) writeToServer(inputChan <-chan string) {
 			return
 		case input := <-inputChan:
 			inputBuffer = append(inputBuffer, []rune(input)...)
-		case <-time.After(time.Millisecond * 5):
+		case <-time.After(writeFlushInterval):
 			if len(inputBuffer) > 0 {
 				err := wsClient.conn.WriteMessage(websocket.BinaryMessage, []byte(string(inputBuffer)))
 				if err != nil {

--- a/api/websh/websh.go
+++ b/api/websh/websh.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/http"
 	"net/url"
 	"os"
 	"os/signal"
@@ -194,14 +195,29 @@ func CreateWebshSession(ac *client.AlpaconClient, serverName, username, groupnam
 	return response, nil
 }
 
+func newWebsocketClient(header http.Header) *WebsocketClient {
+	return &WebsocketClient{
+		Header: header,
+		Done:   make(chan error, 1),
+		quit:   make(chan struct{}),
+	}
+}
+
+// finish reports the first outcome of the session and signals teardown to every
+// goroutine. Later calls are dropped: Done holds one value and is received once,
+// so a second send would park its goroutine for good.
+func (wsClient *WebsocketClient) finish(err error) {
+	wsClient.closeOnce.Do(func() {
+		wsClient.Done <- err
+		close(wsClient.quit)
+	})
+}
+
 // OpenReadOnlyTerminal opens a read-only terminal view for watching another user's session.
 // Input is not forwarded to the server. Terminal echo is suppressed via raw mode.
 // Exits cleanly on Ctrl+C or SIGTERM.
 func OpenReadOnlyTerminal(ac *client.AlpaconClient, sessionResponse SessionResponse) error {
-	wsClient := &WebsocketClient{
-		Header: ac.SetWebsocketHeader(),
-		Done:   make(chan error, 1),
-	}
+	wsClient := newWebsocketClient(ac.SetWebsocketHeader())
 
 	var err error
 	wsClient.conn, _, err = websocket.DefaultDialer.Dial(sessionResponse.WebsocketURL, wsClient.Header)
@@ -218,10 +234,7 @@ func OpenReadOnlyTerminal(ac *client.AlpaconClient, sessionResponse SessionRespo
 	defer signal.Stop(sigChan)
 	go func() {
 		<-sigChan
-		select {
-		case wsClient.Done <- nil:
-		default:
-		}
+		wsClient.finish(nil)
 	}()
 
 	oldState, err := checkTerminal()
@@ -236,10 +249,7 @@ func OpenReadOnlyTerminal(ac *client.AlpaconClient, sessionResponse SessionRespo
 		for {
 			_, err := os.Stdin.Read(buf)
 			if err != nil || buf[0] == 0x03 {
-				select {
-				case wsClient.Done <- nil:
-				default:
-				}
+				wsClient.finish(nil)
 				return
 			}
 		}
@@ -252,10 +262,7 @@ func OpenReadOnlyTerminal(ac *client.AlpaconClient, sessionResponse SessionRespo
 // Handles graceful termination of the websh terminal.
 // Exits on error without further error handling.
 func OpenNewTerminal(ac *client.AlpaconClient, sessionResponse SessionResponse) error {
-	wsClient := &WebsocketClient{
-		Header: ac.SetWebsocketHeader(),
-		Done:   make(chan error, 1),
-	}
+	wsClient := newWebsocketClient(ac.SetWebsocketHeader())
 
 	var err error
 	wsClient.conn, _, err = websocket.DefaultDialer.Dial(sessionResponse.WebsocketURL, wsClient.Header)
@@ -304,10 +311,7 @@ func (wsClient *WebsocketClient) readFromServer() {
 	for {
 		_, message, err := wsClient.conn.ReadMessage()
 		if err != nil {
-			select {
-			case wsClient.Done <- err:
-			default:
-			}
+			wsClient.finish(err)
 			return
 		}
 		fmt.Print(string(message))
@@ -320,13 +324,18 @@ func (wsClient *WebsocketClient) readUserInput(inputChan chan<- string) {
 		char, _, err := reader.ReadRune()
 		if err != nil {
 			if err == io.EOF {
-				wsClient.Done <- nil
+				wsClient.finish(nil)
 				return
 			}
-			wsClient.Done <- err
+			wsClient.finish(err)
 			return
 		}
-		inputChan <- string(char)
+		// After teardown writeToServer is gone, so an unguarded send would park here.
+		select {
+		case inputChan <- string(char):
+		case <-wsClient.quit:
+			return
+		}
 	}
 }
 
@@ -334,13 +343,15 @@ func (wsClient *WebsocketClient) writeToServer(inputChan <-chan string) {
 	var inputBuffer []rune
 	for {
 		select {
+		case <-wsClient.quit:
+			return
 		case input := <-inputChan:
 			inputBuffer = append(inputBuffer, []rune(input)...)
 		case <-time.After(time.Millisecond * 5):
 			if len(inputBuffer) > 0 {
 				err := wsClient.conn.WriteMessage(websocket.BinaryMessage, []byte(string(inputBuffer)))
 				if err != nil {
-					wsClient.Done <- err
+					wsClient.finish(err)
 					return
 				}
 				inputBuffer = []rune{}

--- a/api/websh/websh.go
+++ b/api/websh/websh.go
@@ -247,10 +247,6 @@ func OpenReadOnlyTerminal(ac *client.AlpaconClient, sessionResponse SessionRespo
 		return err
 	}
 	defer func() { _ = wsClient.conn.Close() }()
-	// Whatever this returns through, the goroutines below have to be released.
-	// The sync.Once makes it a no-op once an outcome is already recorded.
-	defer wsClient.finish(nil)
-
 	sigChan := make(chan os.Signal, 1)
 	signal.Notify(sigChan, os.Interrupt, syscall.SIGTERM)
 	// Registered before the raw-mode restore so LIFO runs it after: a signal

--- a/api/websh/websh.go
+++ b/api/websh/websh.go
@@ -200,27 +200,32 @@ func CreateWebshSession(ac *client.AlpaconClient, serverName, username, groupnam
 
 func newWebsocketClient(header http.Header) *WebsocketClient {
 	return &WebsocketClient{
-		Header: header,
+		header: header,
 		done:   make(chan struct{}),
 	}
 }
 
-func (wsClient *WebsocketClient) dial(websocketURL string) {
-	conn, resp, err := websocket.DefaultDialer.Dial(websocketURL, wsClient.Header)
+func (wsClient *WebsocketClient) dial(websocketURL string) error {
+	conn, resp, err := websocket.DefaultDialer.Dial(websocketURL, wsClient.header)
 	if err != nil {
 		// The handshake response carries the reason a bad handshake alone never names.
-		status := ""
-		if resp != nil {
-			status = fmt.Sprintf(" (status %s)", utils.SanitizeTerminalText(resp.Status))
+		if resp == nil {
+			return fmt.Errorf("websocket connection failed: %w", err)
 		}
-		utils.CliErrorWithExit("websocket connection failed: %v%s", err, status)
+		return fmt.Errorf("websocket connection failed: %w (status %s)", err, utils.SanitizeTerminalText(resp.Status))
 	}
 	wsClient.conn = conn
+
+	return nil
 }
 
 // finish keeps the first outcome. err is written before done closes, so anyone
-// who saw done can read it.
+// who saw done can read it. A normal remote close is how a session ends rather
+// than a failure; every other close code stays an error.
 func (wsClient *WebsocketClient) finish(err error) {
+	if websocket.IsCloseError(err, websocket.CloseNormalClosure, websocket.CloseGoingAway) {
+		err = nil
+	}
 	wsClient.finishOnce.Do(func() {
 		wsClient.err = err
 		close(wsClient.done)
@@ -229,39 +234,31 @@ func (wsClient *WebsocketClient) finish(err error) {
 
 // OpenReadOnlyTerminal opens a read-only terminal view for watching another user's session.
 // Input is not forwarded to the server. Terminal echo is suppressed via raw mode.
-// Exits cleanly on Ctrl+C or SIGTERM.
+// Ends cleanly on the remote close, on Ctrl+C, or on a signal.
 func OpenReadOnlyTerminal(ac *client.AlpaconClient, sessionResponse SessionResponse) error {
 	wsClient := newWebsocketClient(ac.SetWebsocketHeader())
-	wsClient.dial(sessionResponse.WebsocketURL)
+	if err := wsClient.dial(sessionResponse.WebsocketURL); err != nil {
+		return err
+	}
 	defer func() { _ = wsClient.conn.Close() }()
 
 	sigChan := make(chan os.Signal, 1)
 	signal.Notify(sigChan, os.Interrupt, syscall.SIGTERM)
-	// Registered before the term.Restore defer so LIFO runs it after: a signal
+	// Registered before the raw-mode restore so LIFO runs it after: a signal
 	// arriving mid-teardown lands in the buffered channel instead of killing the
 	// process with the terminal still in raw mode.
 	defer signal.Stop(sigChan)
 	go wsClient.watchInterrupt(sigChan)
 
-	oldState, err := checkTerminal()
+	restore, err := enterRawMode()
 	if err != nil {
-		utils.CliErrorWithExit("failed to set up terminal: %v", err)
+		return err
 	}
-	defer func() { _ = term.Restore(int(os.Stdin.Fd()), oldState) }()
+	defer restore()
 
-	// Raw mode suppresses SIGINT, so Ctrl+C only ever arrives as a byte
-	go func() {
-		buf := make([]byte, 1)
-		for {
-			_, err := os.Stdin.Read(buf)
-			if err != nil || buf[0] == ctrlC {
-				wsClient.finish(nil)
-				return
-			}
-		}
-	}()
-
+	go wsClient.readCtrlC()
 	go wsClient.readFromServer()
+
 	<-wsClient.done
 	return wsClient.err
 }
@@ -275,22 +272,44 @@ func (wsClient *WebsocketClient) watchInterrupt(sigChan <-chan os.Signal) {
 	}
 }
 
+// readCtrlC ends the session on Ctrl+C — raw mode suppresses SIGINT, so it only
+// ever arrives as a byte. Once anything else has ended the session it stops
+// consuming stdin, though not before the read it is already parked in returns.
+func (wsClient *WebsocketClient) readCtrlC() {
+	buf := make([]byte, 1)
+	for {
+		n, err := os.Stdin.Read(buf)
+		if err != nil || (n > 0 && buf[0] == ctrlC) {
+			wsClient.finish(nil)
+			return
+		}
+		select {
+		case <-wsClient.done:
+			return
+		default:
+		}
+	}
+}
+
 // OpenNewTerminal opens an interactive terminal on the session.
-// A failed dial or terminal setup exits the process instead of returning.
+// Input is forwarded to the server. Terminal echo is suppressed via raw mode.
+// Ends cleanly on the remote close or on Ctrl+D.
 func OpenNewTerminal(ac *client.AlpaconClient, sessionResponse SessionResponse) error {
 	wsClient := newWebsocketClient(ac.SetWebsocketHeader())
-	wsClient.dial(sessionResponse.WebsocketURL)
+	if err := wsClient.dial(sessionResponse.WebsocketURL); err != nil {
+		return err
+	}
 	defer func() { _ = wsClient.conn.Close() }()
 
 	return wsClient.runWsClient()
 }
 
 func (wsClient *WebsocketClient) runWsClient() error {
-	oldState, err := checkTerminal()
+	restore, err := enterRawMode()
 	if err != nil {
-		utils.CliErrorWithExit("failed to set up terminal: %v", err)
+		return err
 	}
-	defer func() { _ = term.Restore(int(os.Stdin.Fd()), oldState) }()
+	defer restore()
 
 	inputChan := make(chan string, 1)
 
@@ -302,16 +321,17 @@ func (wsClient *WebsocketClient) runWsClient() error {
 	return wsClient.err
 }
 
-func checkTerminal() (*term.State, error) {
+// enterRawMode returns the restore for the caller to defer.
+func enterRawMode() (func(), error) {
 	if !term.IsTerminal(int(os.Stdin.Fd())) {
-		return nil, errors.New("stdin is not a terminal")
+		return nil, errors.New("failed to set up terminal: stdin is not a terminal")
 	}
 	oldState, err := term.MakeRaw(int(os.Stdin.Fd()))
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to set up terminal: %w", err)
 	}
 
-	return oldState, nil
+	return func() { _ = term.Restore(int(os.Stdin.Fd()), oldState) }, nil
 }
 
 func (wsClient *WebsocketClient) readFromServer() {

--- a/api/websh/websh.go
+++ b/api/websh/websh.go
@@ -233,8 +233,11 @@ func OpenReadOnlyTerminal(ac *client.AlpaconClient, sessionResponse SessionRespo
 	// process with the terminal still in raw mode.
 	defer signal.Stop(sigChan)
 	go func() {
-		<-sigChan
-		wsClient.finish(nil)
+		select {
+		case <-sigChan:
+			wsClient.finish(nil)
+		case <-wsClient.quit:
+		}
 	}()
 
 	oldState, err := checkTerminal()

--- a/api/websh/websh.go
+++ b/api/websh/websh.go
@@ -211,7 +211,7 @@ func (wsClient *WebsocketClient) dial(websocketURL string) {
 		// The handshake response carries the reason a bad handshake alone never names.
 		status := ""
 		if resp != nil {
-			status = fmt.Sprintf(" (status %s)", resp.Status)
+			status = fmt.Sprintf(" (status %s)", utils.SanitizeTerminalText(resp.Status))
 		}
 		utils.CliErrorWithExit("websocket connection failed: %v%s", err, status)
 	}

--- a/api/websh/websh.go
+++ b/api/websh/websh.go
@@ -276,7 +276,7 @@ func (wsClient *WebsocketClient) watchInterrupt(sigChan <-chan os.Signal) {
 }
 
 // OpenNewTerminal opens an interactive terminal on the session.
-// A failed dial exits the process instead of returning.
+// A failed dial or terminal setup exits the process instead of returning.
 func OpenNewTerminal(ac *client.AlpaconClient, sessionResponse SessionResponse) error {
 	wsClient := newWebsocketClient(ac.SetWebsocketHeader())
 	wsClient.dial(sessionResponse.WebsocketURL)

--- a/api/websh/websh.go
+++ b/api/websh/websh.go
@@ -321,16 +321,18 @@ func (wsClient *WebsocketClient) readFromServer() {
 			wsClient.finish(err)
 			return
 		}
-		fmt.Print(string(message))
+		_, _ = os.Stdout.Write(message)
 	}
 }
 
+// Teardown cannot release this one mid-read: a goroutine parked in ReadRune
+// stays there until the next keystroke, and only closing stdin would change that.
 func (wsClient *WebsocketClient) readUserInput(inputChan chan<- string) {
 	reader := bufio.NewReader(os.Stdin)
 	for {
 		char, _, err := reader.ReadRune()
 		if err != nil {
-			if err == io.EOF {
+			if errors.Is(err, io.EOF) {
 				wsClient.finish(nil)
 				return
 			}
@@ -347,6 +349,11 @@ func (wsClient *WebsocketClient) readUserInput(inputChan chan<- string) {
 }
 
 func (wsClient *WebsocketClient) writeToServer(inputChan <-chan string) {
+	// A ticker rather than time.After, which restarts on every arriving rune and
+	// so defers the flush for as long as input keeps coming.
+	ticker := time.NewTicker(writeFlushInterval)
+	defer ticker.Stop()
+
 	var inputBuffer []rune
 	for {
 		select {
@@ -354,7 +361,7 @@ func (wsClient *WebsocketClient) writeToServer(inputChan <-chan string) {
 			return
 		case input := <-inputChan:
 			inputBuffer = append(inputBuffer, []rune(input)...)
-		case <-time.After(writeFlushInterval):
+		case <-ticker.C:
 			if len(inputBuffer) > 0 {
 				err := wsClient.conn.WriteMessage(websocket.BinaryMessage, []byte(string(inputBuffer)))
 				if err != nil {

--- a/api/websh/websh.go
+++ b/api/websh/websh.go
@@ -241,13 +241,7 @@ func OpenReadOnlyTerminal(ac *client.AlpaconClient, sessionResponse SessionRespo
 	// arriving mid-teardown lands in the buffered channel instead of killing the
 	// process with the terminal still in raw mode.
 	defer signal.Stop(sigChan)
-	go func() {
-		select {
-		case <-sigChan:
-			wsClient.finish(nil)
-		case <-wsClient.done:
-		}
-	}()
+	go wsClient.watchInterrupt(sigChan)
 
 	oldState, err := checkTerminal()
 	if err != nil {
@@ -270,6 +264,15 @@ func OpenReadOnlyTerminal(ac *client.AlpaconClient, sessionResponse SessionRespo
 	go wsClient.readFromServer()
 	<-wsClient.done
 	return wsClient.err
+}
+
+// watchInterrupt ends the session on a signal, and leaves once anything else has ended it.
+func (wsClient *WebsocketClient) watchInterrupt(sigChan <-chan os.Signal) {
+	select {
+	case <-sigChan:
+		wsClient.finish(nil)
+	case <-wsClient.done:
+	}
 }
 
 // OpenNewTerminal opens an interactive terminal on the session.

--- a/api/websh/websh.go
+++ b/api/websh/websh.go
@@ -222,7 +222,7 @@ func OpenReadOnlyTerminal(ac *client.AlpaconClient, sessionResponse SessionRespo
 	var err error
 	wsClient.conn, _, err = websocket.DefaultDialer.Dial(sessionResponse.WebsocketURL, wsClient.Header)
 	if err != nil {
-		utils.CliErrorWithExit("websocket connection failed %v", err)
+		utils.CliErrorWithExit("websocket connection failed: %v", err)
 	}
 	defer func() { _ = wsClient.conn.Close() }()
 
@@ -270,7 +270,7 @@ func OpenNewTerminal(ac *client.AlpaconClient, sessionResponse SessionResponse) 
 	var err error
 	wsClient.conn, _, err = websocket.DefaultDialer.Dial(sessionResponse.WebsocketURL, wsClient.Header)
 	if err != nil {
-		utils.CliErrorWithExit("websocket connection failed %v", err)
+		utils.CliErrorWithExit("websocket connection failed: %v", err)
 	}
 	defer func() { _ = wsClient.conn.Close() }()
 
@@ -300,7 +300,7 @@ func (wsClient *WebsocketClient) runWsClient() error {
 
 func checkTerminal() (*term.State, error) {
 	if !term.IsTerminal(int(os.Stdin.Fd())) {
-		return nil, errors.New("websh command should be a terminal")
+		return nil, errors.New("stdin is not a terminal")
 	}
 	oldState, err := term.MakeRaw(int(os.Stdin.Fd()))
 	if err != nil {

--- a/api/websh/websh.go
+++ b/api/websh/websh.go
@@ -28,6 +28,12 @@ const (
 
 	ctrlC              = 0x03
 	writeFlushInterval = 5 * time.Millisecond
+
+	// sessionEndCloseCode is what the proxy closes a user channel with when the
+	// session ends normally—see sendCloseFrame in proxy-server internal/ws/channel.go.
+	// alpamon spends the same 4000 on the same meaning. A websh session never ends
+	// with 1000, so leaving this out would leave every normal end reported as a failure.
+	sessionEndCloseCode = 4000
 )
 
 func GetSessionList(ac *client.AlpaconClient) ([]SessionListItem, error) {
@@ -223,7 +229,7 @@ func (wsClient *WebsocketClient) dial(websocketURL string) error {
 // who saw done can read it. A normal remote close is how a session ends rather
 // than a failure; every other close code stays an error.
 func (wsClient *WebsocketClient) finish(err error) {
-	if websocket.IsCloseError(err, websocket.CloseNormalClosure, websocket.CloseGoingAway) {
+	if websocket.IsCloseError(err, sessionEndCloseCode, websocket.CloseNormalClosure, websocket.CloseGoingAway) {
 		err = nil
 	}
 	wsClient.finishOnce.Do(func() {

--- a/api/websh/websh_test.go
+++ b/api/websh/websh_test.go
@@ -3,16 +3,19 @@ package websh
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"os/exec"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/alpacax/alpacon-cli/api"
 	"github.com/alpacax/alpacon-cli/api/types"
 	"github.com/alpacax/alpacon-cli/client"
+	"github.com/gorilla/websocket"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -274,6 +277,130 @@ func TestGetSessionRecords_QueryHitsSearchEndpoint(t *testing.T) {
 	assert.Len(t, records, 1)
 }
 
+// teardownWait bounds how long a goroutine may take to return once its exit
+// condition is met. A blocked send never returns, so any value proves the point.
+const teardownWait = 2 * time.Second
+
+// dialTestServer opens a real websocket connection to a server that reads until
+// the peer goes away, so a closed connection produces genuine write failures.
+func dialTestServer(t *testing.T) *websocket.Conn {
+	t.Helper()
+
+	upgrader := websocket.Upgrader{}
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer func() { _ = conn.Close() }()
+		for {
+			if _, _, err := conn.ReadMessage(); err != nil {
+				return
+			}
+		}
+	}))
+	t.Cleanup(ts.Close)
+
+	conn, _, err := websocket.DefaultDialer.Dial("ws"+strings.TrimPrefix(ts.URL, "http"), nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = conn.Close() })
+
+	return conn
+}
+
+// pipeStdin points os.Stdin at a pipe and returns its write end. Closing that end
+// yields EOF, which is how a real session ends its input.
+func pipeStdin(t *testing.T) *os.File {
+	t.Helper()
+
+	pipeRead, pipeWrite, err := os.Pipe()
+	require.NoError(t, err)
+
+	realStdin := os.Stdin
+	os.Stdin = pipeRead
+	t.Cleanup(func() {
+		os.Stdin = realStdin
+		_ = pipeRead.Close()
+		_ = pipeWrite.Close()
+	})
+
+	return pipeWrite
+}
+
+// awaitReturn runs fn and fails the test if it has not returned in time.
+func awaitReturn(t *testing.T, msg string, fn func()) {
+	t.Helper()
+
+	returned := make(chan struct{})
+	go func() {
+		fn()
+		close(returned)
+	}()
+
+	select {
+	case <-returned:
+	case <-time.After(teardownWait):
+		t.Fatal(msg)
+	}
+}
+
+func TestReadUserInputReturnsWhenOutcomeAlreadyReported(t *testing.T) {
+	pipeWrite := pipeStdin(t)
+	require.NoError(t, pipeWrite.Close()) // stdin yields EOF right away
+
+	wsClient := newWebsocketClient(nil)
+	wsClient.finish(errors.New("teardown already reported")) // the lone receiver has returned
+
+	awaitReturn(t, "readUserInput parked reporting EOF after the outcome was taken", func() {
+		wsClient.readUserInput(make(chan string, 1))
+	})
+}
+
+func TestReadUserInputReturnsWhenWriterIsGone(t *testing.T) {
+	pipeWrite := pipeStdin(t)
+	_, err := pipeWrite.WriteString("x")
+	require.NoError(t, err)
+
+	wsClient := newWebsocketClient(nil)
+	wsClient.finish(errors.New("teardown already reported"))
+
+	inputChan := make(chan string, 1)
+	inputChan <- "buffered" // writeToServer has returned, so nothing drains this
+
+	awaitReturn(t, "readUserInput parked sending to inputChan after teardown", func() {
+		wsClient.readUserInput(inputChan)
+	})
+}
+
+func TestWriteToServerReturnsWhenOutcomeAlreadyReported(t *testing.T) {
+	conn := dialTestServer(t)
+	require.NoError(t, conn.Close()) // every later WriteMessage fails
+
+	wsClient := newWebsocketClient(nil)
+	wsClient.conn = conn
+	wsClient.finish(errors.New("teardown already reported"))
+
+	inputChan := make(chan string, 1)
+	inputChan <- "x" // buffered input forces the failing write
+
+	awaitReturn(t, "writeToServer parked reporting a write failure after the outcome was taken", func() {
+		wsClient.writeToServer(inputChan)
+	})
+}
+
+func TestFinishKeepsTheFirstOutcome(t *testing.T) {
+	wsClient := newWebsocketClient(nil)
+
+	first := errors.New("remote closed the session")
+	wsClient.finish(first)
+	wsClient.finish(errors.New("write failed on the closed connection"))
+
+	assert.Equal(t, first, <-wsClient.Done)
+
+	_, open := <-wsClient.quit
+	assert.False(t, open, "quit must be closed so the remaining goroutines can leave")
+}
+
 func TestRunWsClientReportsTerminalSetupFailure(t *testing.T) {
 	helper := exec.Command(os.Args[0], "-test.run=TestRunWsClientTerminalHelperProcess")
 	helper.Env = append(os.Environ(), "GO_WANT_HELPER_PROCESS=1")
@@ -291,6 +418,5 @@ func TestRunWsClientTerminalHelperProcess(t *testing.T) {
 		return
 	}
 	// stdin is not a tty here, so checkTerminal fails before the connection is used.
-	wsClient := &WebsocketClient{Done: make(chan error, 1)}
-	_ = wsClient.runWsClient()
+	_ = newWebsocketClient(nil).runWsClient()
 }

--- a/api/websh/websh_test.go
+++ b/api/websh/websh_test.go
@@ -590,7 +590,7 @@ func TestRunWsClient_ReportsTerminalSetupFailure(t *testing.T) {
 	err := newWebsocketClient(nil).runWsClient()
 
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "failed to set up terminal: stdin is not a terminal")
+	assert.Contains(t, err.Error(), "stdin is not a terminal")
 	assert.NotContains(t, err.Error(), "websocket connection failed")
 }
 

--- a/api/websh/websh_test.go
+++ b/api/websh/websh_test.go
@@ -406,6 +406,35 @@ func TestRunWsClientTerminalHelperProcess(t *testing.T) {
 	_ = newWebsocketClient(nil).runWsClient()
 }
 
+func TestDialReportsTheHandshakeStatus(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "denied", http.StatusUnauthorized)
+	}))
+	t.Cleanup(ts.Close)
+
+	helper := exec.Command(os.Args[0], "-test.run=TestDialHelperProcess")
+	helper.Env = append(os.Environ(),
+		"GO_WANT_HELPER_PROCESS=1",
+		"WEBSH_TEST_URL=ws"+strings.TrimPrefix(ts.URL, "http"),
+	)
+
+	var stderr bytes.Buffer
+	helper.Stderr = &stderr
+	require.Error(t, helper.Run())
+
+	// gorilla reports every rejected upgrade as "bad handshake", so only the
+	// status tells the user which one this was.
+	assert.Contains(t, stderr.String(), "websocket connection failed:")
+	assert.Contains(t, stderr.String(), "(status 401 Unauthorized)")
+}
+
+func TestDialHelperProcess(t *testing.T) {
+	if os.Getenv("GO_WANT_HELPER_PROCESS") != "1" {
+		return
+	}
+	newWebsocketClient(nil).dial(os.Getenv("WEBSH_TEST_URL"))
+}
+
 // dialTestServer returns a live connection, so closing it produces genuine write failures.
 func dialTestServer(t *testing.T) *websocket.Conn {
 	t.Helper()

--- a/api/websh/websh_test.go
+++ b/api/websh/websh_test.go
@@ -409,7 +409,7 @@ func TestRunWsClientReportsTerminalSetupFailure(t *testing.T) {
 	helper.Stderr = &stderr
 	require.Error(t, helper.Run())
 
-	assert.Contains(t, stderr.String(), "failed to set up terminal: websh command should be a terminal")
+	assert.Contains(t, stderr.String(), "failed to set up terminal: stdin is not a terminal")
 	assert.NotContains(t, stderr.String(), "websocket connection failed")
 }
 

--- a/api/websh/websh_test.go
+++ b/api/websh/websh_test.go
@@ -6,7 +6,10 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"os/signal"
+	"runtime"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 
@@ -532,6 +535,47 @@ func TestFinish_NormalizesARemoteCloseToASuccess(t *testing.T) {
 			assert.NoError(t, wsClient.err)
 		})
 	}
+}
+
+// The dial succeeds and raw mode then fails, so this is the one path that returns
+// with goroutines already started and no outcome recorded by any of them.
+func TestOpenReadOnlyTerminal_LeavesNoGoroutineWhenSetupFails(t *testing.T) {
+	// SetWebsocketHeader sends an Origin, which the default CheckOrigin rejects
+	// as cross-origin against the httptest host.
+	upgrader := websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if !assert.NoError(t, err) {
+			return
+		}
+		_ = conn.Close() // the handler must not outlive the assertion below
+	}))
+	t.Cleanup(ts.Close)
+
+	pipeStdin(t) // a pipe is not a tty, so raw mode fails after the dial succeeds
+
+	// signal.Notify starts one process-wide goroutine on first use anywhere, and
+	// it never exits. Priming it keeps that out of the baseline below.
+	warmUp := make(chan os.Signal, 1)
+	signal.Notify(warmUp, syscall.SIGTERM)
+	signal.Stop(warmUp)
+
+	before := runtime.NumGoroutine()
+	err := OpenReadOnlyTerminal(&client.AlpaconClient{}, SessionResponse{
+		WebsocketURL: "ws" + strings.TrimPrefix(ts.URL, "http"),
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "stdin is not a terminal")
+
+	// Polled inline rather than with assert.Eventually, which runs its condition
+	// in a goroutine of its own and so can never see the count come back down.
+	deadline := time.Now().Add(teardownWait)
+	for runtime.NumGoroutine() > before && time.Now().Before(deadline) {
+		time.Sleep(10 * time.Millisecond)
+	}
+	assert.LessOrEqual(t, runtime.NumGoroutine(), before,
+		"a goroutine outlived OpenReadOnlyTerminal: signal.Stop disarms sigChan without closing it, so only done can release the watcher")
 }
 
 func TestRunWsClient_ReportsTerminalSetupFailure(t *testing.T) {

--- a/api/websh/websh_test.go
+++ b/api/websh/websh_test.go
@@ -547,8 +547,8 @@ func TestFinish_NormalizesARemoteCloseToASuccess(t *testing.T) {
 	}
 }
 
-// The dial succeeds and raw mode then fails, so this is the one path that returns
-// with goroutines already started and no outcome recorded by any of them.
+// The dial succeeds and raw mode then fails, which is the return no goroutine may
+// outlive: nothing here calls finish, so anything already started waits forever.
 func TestOpenReadOnlyTerminal_LeavesNoGoroutineWhenSetupFails(t *testing.T) {
 	// SetWebsocketHeader sends an Origin, which the default CheckOrigin rejects
 	// as cross-origin against the httptest host.
@@ -614,8 +614,8 @@ func TestDial_ReportsTheHandshakeStatus(t *testing.T) {
 }
 
 // dialTestServer returns a live connection, so closing it produces genuine write
-// failures, along with the messages the server received. The server sends each of
-// send and then goes away, which is how a real session ends.
+// failures, along with the messages the server received. The server writes send and
+// then goes away, which is how a real session ends.
 func dialTestServer(t *testing.T, send ...string) (*websocket.Conn, <-chan string) {
 	t.Helper()
 

--- a/api/websh/websh_test.go
+++ b/api/websh/websh_test.go
@@ -341,7 +341,7 @@ func TestWriteToServerReportsWriteFailure(t *testing.T) {
 	assert.Error(t, wsClient.err)
 }
 
-func TestReadFromServerReportsReadFailure(t *testing.T) {
+func TestReadFromServer_ReportsReadFailure(t *testing.T) {
 	conn, _ := dialTestServer(t)
 	require.NoError(t, conn.Close()) // every later ReadMessage fails
 
@@ -356,7 +356,7 @@ func TestReadFromServerReportsReadFailure(t *testing.T) {
 	assert.Error(t, wsClient.err)
 }
 
-func TestReadFromServerPrintsEveryMessage(t *testing.T) {
+func TestReadFromServer_PrintsEveryMessage(t *testing.T) {
 	conn, _ := dialTestServer(t, "hi ", "there")
 
 	wsClient := newWebsocketClient(nil)
@@ -373,7 +373,7 @@ func TestReadFromServerPrintsEveryMessage(t *testing.T) {
 	assert.Error(t, wsClient.err)
 }
 
-func TestReadUserInputForwardsToTheWriter(t *testing.T) {
+func TestReadUserInput_ForwardsToTheWriter(t *testing.T) {
 	pipeWrite := pipeStdin(t)
 	_, err := pipeWrite.WriteString("l")
 	require.NoError(t, err)
@@ -392,7 +392,7 @@ func TestReadUserInputForwardsToTheWriter(t *testing.T) {
 	}
 }
 
-func TestWriteToServerFlushesBufferedInput(t *testing.T) {
+func TestWriteToServer_FlushesBufferedInput(t *testing.T) {
 	conn, received := dialTestServer(t)
 
 	wsClient := newWebsocketClient(nil)
@@ -417,7 +417,7 @@ func TestWriteToServerFlushesBufferedInput(t *testing.T) {
 	}
 }
 
-func TestWatchInterruptEndsTheSessionOnSignal(t *testing.T) {
+func TestWatchInterrupt_EndsTheSessionOnSignal(t *testing.T) {
 	wsClient := newWebsocketClient(nil)
 
 	sigChan := make(chan os.Signal, 1)
@@ -431,7 +431,7 @@ func TestWatchInterruptEndsTheSessionOnSignal(t *testing.T) {
 	assert.NoError(t, wsClient.err) // Ctrl+C is how a session is meant to end
 }
 
-func TestWatchInterruptReturnsWhenOutcomeAlreadyReported(t *testing.T) {
+func TestWatchInterrupt_ReturnsWhenOutcomeAlreadyReported(t *testing.T) {
 	wsClient := newWebsocketClient(nil)
 	wsClient.finish(errors.New("teardown already reported"))
 

--- a/api/websh/websh_test.go
+++ b/api/websh/websh_test.go
@@ -336,6 +336,45 @@ func TestWriteToServerReportsWriteFailure(t *testing.T) {
 	assert.Error(t, wsClient.err)
 }
 
+func TestReadFromServerReportsReadFailure(t *testing.T) {
+	conn := dialTestServer(t)
+	require.NoError(t, conn.Close()) // every later ReadMessage fails
+
+	wsClient := newWebsocketClient(nil)
+	wsClient.conn = conn
+
+	awaitReturn(t, "readFromServer parked on the failing read", func() {
+		wsClient.readFromServer()
+	})
+
+	assertReported(t, wsClient)
+	assert.Error(t, wsClient.err)
+}
+
+func TestWatchInterruptEndsTheSessionOnSignal(t *testing.T) {
+	wsClient := newWebsocketClient(nil)
+
+	sigChan := make(chan os.Signal, 1)
+	sigChan <- os.Interrupt
+
+	awaitReturn(t, "watchInterrupt parked on the signal", func() {
+		wsClient.watchInterrupt(sigChan)
+	})
+
+	assertReported(t, wsClient)
+	assert.NoError(t, wsClient.err) // Ctrl+C is how a session is meant to end
+}
+
+func TestWatchInterruptReturnsWhenOutcomeAlreadyReported(t *testing.T) {
+	wsClient := newWebsocketClient(nil)
+	wsClient.finish(errors.New("teardown already reported"))
+
+	// No signal ever arrives, so only the done branch can release the watcher.
+	awaitReturn(t, "watchInterrupt parked waiting for a signal after teardown", func() {
+		wsClient.watchInterrupt(make(chan os.Signal))
+	})
+}
+
 func TestFinishKeepsTheFirstOutcome(t *testing.T) {
 	wsClient := newWebsocketClient(nil)
 

--- a/api/websh/websh_test.go
+++ b/api/websh/websh_test.go
@@ -502,6 +502,12 @@ func TestFinish_NormalizesARemoteCloseToASuccess(t *testing.T) {
 		keepAsErr bool
 	}{
 		{
+			// What the proxy actually sends: every other case here is a contract
+			// the CLI honors but never meets in production.
+			name:     "session end",
+			reported: &websocket.CloseError{Code: sessionEndCloseCode},
+		},
+		{
 			name:     "normal closure",
 			reported: &websocket.CloseError{Code: websocket.CloseNormalClosure, Text: "session ended"},
 		},

--- a/api/websh/websh_test.go
+++ b/api/websh/websh_test.go
@@ -547,8 +547,9 @@ func TestFinish_NormalizesARemoteCloseToASuccess(t *testing.T) {
 	}
 }
 
-// The dial succeeds and raw mode then fails, which is the return no goroutine may
-// outlive: nothing here calls finish, so anything already started waits forever.
+// The dial succeeds and raw mode then fails, and nothing on that return calls
+// finish. Today every go statement sits below enterRawMode, so none has started
+// and the count holds; this fails if one is ever moved back above it.
 func TestOpenReadOnlyTerminal_LeavesNoGoroutineWhenSetupFails(t *testing.T) {
 	// SetWebsocketHeader sends an Origin, which the default CheckOrigin rejects
 	// as cross-origin against the httptest host.
@@ -585,7 +586,7 @@ func TestOpenReadOnlyTerminal_LeavesNoGoroutineWhenSetupFails(t *testing.T) {
 		time.Sleep(10 * time.Millisecond)
 	}
 	assert.LessOrEqual(t, runtime.NumGoroutine(), before,
-		"a goroutine outlived OpenReadOnlyTerminal: signal.Stop disarms sigChan without closing it, so only done can release the watcher")
+		"a goroutine was started before enterRawMode and outlived OpenReadOnlyTerminal: on this return nothing closes done, and signal.Stop disarms sigChan without closing it, so the watcher would have no way out")
 }
 
 func TestRunWsClient_ReportsTerminalSetupFailure(t *testing.T) {

--- a/api/websh/websh_test.go
+++ b/api/websh/websh_test.go
@@ -488,16 +488,6 @@ func TestWatchInterrupt_EndsTheSessionOnSignal(t *testing.T) {
 	assert.NoError(t, wsClient.err) // Ctrl+C is how a session is meant to end
 }
 
-func TestWatchInterrupt_ReturnsWhenOutcomeAlreadyReported(t *testing.T) {
-	wsClient := newWebsocketClient(nil)
-	wsClient.finish(errors.New("teardown already reported"))
-
-	// No signal ever arrives, so only the done branch can release the watcher.
-	awaitReturn(t, "watchInterrupt parked waiting for a signal after teardown", func() {
-		wsClient.watchInterrupt(make(chan os.Signal))
-	})
-}
-
 func TestFinish_KeepsTheFirstOutcome(t *testing.T) {
 	wsClient := newWebsocketClient(nil)
 

--- a/api/websh/websh_test.go
+++ b/api/websh/websh_test.go
@@ -1,13 +1,11 @@
 package websh
 
 import (
-	"bytes"
 	"encoding/json"
 	"errors"
 	"net/http"
 	"net/http/httptest"
 	"os"
-	"os/exec"
 	"strings"
 	"testing"
 	"time"
@@ -285,45 +283,87 @@ func TestGetSessionRecords_QueryHitsSearchEndpoint(t *testing.T) {
 	assert.Len(t, records, 1)
 }
 
-func TestReadUserInputReturnsWhenOutcomeAlreadyReported(t *testing.T) {
-	pipeWrite := pipeStdin(t)
-	require.NoError(t, pipeWrite.Close()) // stdin yields EOF right away
+// Each of these can still be running once the outcome is taken, and each has to
+// notice and leave. readFromServer is absent: it ends on its own failing read,
+// covered separately.
+func TestSessionGoroutines_ReturnAfterTheOutcomeIsTaken(t *testing.T) {
+	tests := []struct {
+		name  string
+		start func(t *testing.T, wsClient *WebsocketClient) func()
+	}{
+		{
+			name: "readUserInput reporting EOF",
+			start: func(t *testing.T, wsClient *WebsocketClient) func() {
+				pipeWrite := pipeStdin(t)
+				require.NoError(t, pipeWrite.Close()) // stdin yields EOF right away
 
-	wsClient := newWebsocketClient(nil)
-	wsClient.finish(errors.New("teardown already reported")) // the outcome is already recorded
+				return func() { wsClient.readUserInput(make(chan string, 1)) }
+			},
+		},
+		{
+			name: "readUserInput sending to inputChan",
+			start: func(t *testing.T, wsClient *WebsocketClient) func() {
+				pipeWrite := pipeStdin(t)
+				_, err := pipeWrite.WriteString("x")
+				require.NoError(t, err)
 
-	awaitReturn(t, "readUserInput parked reporting EOF after the outcome was taken", func() {
-		wsClient.readUserInput(make(chan string, 1))
-	})
+				inputChan := make(chan string, 1)
+				inputChan <- "buffered" // writeToServer has returned, so nothing drains this
+
+				return func() { wsClient.readUserInput(inputChan) }
+			},
+		},
+		{
+			name: "writeToServer waiting to flush",
+			start: func(t *testing.T, wsClient *WebsocketClient) func() {
+				// Empty, so only the done branch can end the loop: nothing is ever flushed.
+				return func() { wsClient.writeToServer(make(chan string)) }
+			},
+		},
+		{
+			name: "watchInterrupt waiting for a signal",
+			start: func(t *testing.T, wsClient *WebsocketClient) func() {
+				// No signal ever arrives, so only the done branch can release the watcher.
+				return func() { wsClient.watchInterrupt(make(chan os.Signal)) }
+			},
+		},
+		{
+			name: "readCtrlC waiting for the next byte",
+			start: func(t *testing.T, wsClient *WebsocketClient) func() {
+				pipeWrite := pipeStdin(t)
+				_, err := pipeWrite.WriteString("x") // not Ctrl+C, so the loop goes around
+				require.NoError(t, err)
+
+				return func() { wsClient.readCtrlC() }
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			wsClient := newWebsocketClient(nil)
+			wsClient.finish(errors.New("teardown already reported"))
+
+			awaitReturn(t, tt.name+" parked after the outcome was taken", tt.start(t, wsClient))
+		})
+	}
 }
 
-func TestReadUserInputReturnsWhenWriterIsGone(t *testing.T) {
+func TestReadCtrlC_EndsTheSessionOnCtrlC(t *testing.T) {
 	pipeWrite := pipeStdin(t)
-	_, err := pipeWrite.WriteString("x")
+	// The leading byte proves the loop goes around rather than ending on any input.
+	_, err := pipeWrite.Write([]byte{'a', ctrlC})
 	require.NoError(t, err)
 
 	wsClient := newWebsocketClient(nil)
-	wsClient.finish(errors.New("teardown already reported"))
 
-	inputChan := make(chan string, 1)
-	inputChan <- "buffered" // writeToServer has returned, so nothing drains this
+	awaitReturn(t, "readCtrlC parked on the Ctrl+C byte", wsClient.readCtrlC)
 
-	awaitReturn(t, "readUserInput parked sending to inputChan after teardown", func() {
-		wsClient.readUserInput(inputChan)
-	})
+	assertReported(t, wsClient)
+	assert.NoError(t, wsClient.err) // Ctrl+C is how a session is meant to end
 }
 
-func TestWriteToServerReturnsWhenDoneIsClosed(t *testing.T) {
-	wsClient := newWebsocketClient(nil)
-	wsClient.finish(errors.New("teardown already reported"))
-
-	// Empty, so only the done branch can end the loop: nothing is ever flushed.
-	awaitReturn(t, "writeToServer parked after the outcome was taken", func() {
-		wsClient.writeToServer(make(chan string))
-	})
-}
-
-func TestWriteToServerReportsWriteFailure(t *testing.T) {
+func TestWriteToServer_ReportsWriteFailure(t *testing.T) {
 	conn, _ := dialTestServer(t)
 	require.NoError(t, conn.Close()) // every later WriteMessage fails
 
@@ -441,7 +481,7 @@ func TestWatchInterrupt_ReturnsWhenOutcomeAlreadyReported(t *testing.T) {
 	})
 }
 
-func TestFinishKeepsTheFirstOutcome(t *testing.T) {
+func TestFinish_KeepsTheFirstOutcome(t *testing.T) {
 	wsClient := newWebsocketClient(nil)
 
 	first := errors.New("remote closed the session")
@@ -452,53 +492,71 @@ func TestFinishKeepsTheFirstOutcome(t *testing.T) {
 	assert.Equal(t, first, wsClient.err)
 }
 
-func TestRunWsClientReportsTerminalSetupFailure(t *testing.T) {
-	helper := exec.Command(os.Args[0], "-test.run=TestRunWsClientTerminalHelperProcess")
-	helper.Env = append(os.Environ(), "GO_WANT_HELPER_PROCESS=1")
-
-	var stderr bytes.Buffer
-	helper.Stderr = &stderr
-	require.Error(t, helper.Run())
-
-	assert.Contains(t, stderr.String(), "failed to set up terminal: stdin is not a terminal")
-	assert.NotContains(t, stderr.String(), "websocket connection failed")
-}
-
-func TestRunWsClientTerminalHelperProcess(t *testing.T) {
-	if os.Getenv("GO_WANT_HELPER_PROCESS") != "1" {
-		return
+func TestFinish_NormalizesARemoteCloseToASuccess(t *testing.T) {
+	tests := []struct {
+		name      string
+		reported  error
+		keepAsErr bool
+	}{
+		{
+			name:     "normal closure",
+			reported: &websocket.CloseError{Code: websocket.CloseNormalClosure, Text: "session ended"},
+		},
+		{
+			name:     "going away",
+			reported: &websocket.CloseError{Code: websocket.CloseGoingAway},
+		},
+		{
+			name:      "abnormal closure",
+			reported:  &websocket.CloseError{Code: websocket.CloseAbnormalClosure},
+			keepAsErr: true,
+		},
+		{
+			name:      "transport failure",
+			reported:  errors.New("connection reset by peer"),
+			keepAsErr: true,
+		},
 	}
-	// stdin is not a tty here, so checkTerminal fails before the connection is used.
-	_ = newWebsocketClient(nil).runWsClient()
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			wsClient := newWebsocketClient(nil)
+			wsClient.finish(tt.reported)
+
+			assertReported(t, wsClient)
+			if tt.keepAsErr {
+				assert.Equal(t, tt.reported, wsClient.err)
+				return
+			}
+			// Typing exit is not a failure, and every caller exits non-zero on one.
+			assert.NoError(t, wsClient.err)
+		})
+	}
 }
 
-func TestDialReportsTheHandshakeStatus(t *testing.T) {
+func TestRunWsClient_ReportsTerminalSetupFailure(t *testing.T) {
+	pipeStdin(t) // a pipe is not a tty, so raw mode cannot be entered
+
+	err := newWebsocketClient(nil).runWsClient()
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to set up terminal: stdin is not a terminal")
+	assert.NotContains(t, err.Error(), "websocket connection failed")
+}
+
+func TestDial_ReportsTheHandshakeStatus(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "denied", http.StatusUnauthorized)
 	}))
 	t.Cleanup(ts.Close)
 
-	helper := exec.Command(os.Args[0], "-test.run=TestDialHelperProcess")
-	helper.Env = append(os.Environ(),
-		"GO_WANT_HELPER_PROCESS=1",
-		"WEBSH_TEST_URL=ws"+strings.TrimPrefix(ts.URL, "http"),
-	)
-
-	var stderr bytes.Buffer
-	helper.Stderr = &stderr
-	require.Error(t, helper.Run())
+	err := newWebsocketClient(nil).dial("ws" + strings.TrimPrefix(ts.URL, "http"))
 
 	// gorilla reports every rejected upgrade as "bad handshake", so only the
 	// status tells the user which one this was.
-	assert.Contains(t, stderr.String(), "websocket connection failed:")
-	assert.Contains(t, stderr.String(), "(status 401 Unauthorized)")
-}
-
-func TestDialHelperProcess(t *testing.T) {
-	if os.Getenv("GO_WANT_HELPER_PROCESS") != "1" {
-		return
-	}
-	newWebsocketClient(nil).dial(os.Getenv("WEBSH_TEST_URL"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "websocket connection failed:")
+	assert.Contains(t, err.Error(), "(status 401 Unauthorized)")
 }
 
 // dialTestServer returns a live connection, so closing it produces genuine write

--- a/api/websh/websh_test.go
+++ b/api/websh/websh_test.go
@@ -1,9 +1,12 @@
 package websh
 
 import (
+	"bytes"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"os/exec"
 	"strings"
 	"testing"
 
@@ -269,4 +272,25 @@ func TestGetSessionRecords_QueryHitsSearchEndpoint(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "docker", gotQuery)
 	assert.Len(t, records, 1)
+}
+
+func TestRunWsClientReportsTerminalSetupFailure(t *testing.T) {
+	helper := exec.Command(os.Args[0], "-test.run=TestRunWsClientTerminalHelperProcess")
+	helper.Env = append(os.Environ(), "GO_WANT_HELPER_PROCESS=1")
+
+	var stderr bytes.Buffer
+	helper.Stderr = &stderr
+	require.Error(t, helper.Run())
+
+	assert.Contains(t, stderr.String(), "failed to set up terminal: websh command should be a terminal")
+	assert.NotContains(t, stderr.String(), "websocket connection failed")
+}
+
+func TestRunWsClientTerminalHelperProcess(t *testing.T) {
+	if os.Getenv("GO_WANT_HELPER_PROCESS") != "1" {
+		return
+	}
+	// stdin is not a tty here, so checkTerminal fails before the connection is used.
+	wsClient := &WebsocketClient{Done: make(chan error, 1)}
+	_ = wsClient.runWsClient()
 }

--- a/api/websh/websh_test.go
+++ b/api/websh/websh_test.go
@@ -285,7 +285,7 @@ func TestReadUserInputReturnsWhenOutcomeAlreadyReported(t *testing.T) {
 	require.NoError(t, pipeWrite.Close()) // stdin yields EOF right away
 
 	wsClient := newWebsocketClient(nil)
-	wsClient.finish(errors.New("teardown already reported")) // the lone receiver has returned
+	wsClient.finish(errors.New("teardown already reported")) // the outcome is already recorded
 
 	awaitReturn(t, "readUserInput parked reporting EOF after the outcome was taken", func() {
 		wsClient.readUserInput(make(chan string, 1))
@@ -308,20 +308,32 @@ func TestReadUserInputReturnsWhenWriterIsGone(t *testing.T) {
 	})
 }
 
-func TestWriteToServerReturnsWhenOutcomeAlreadyReported(t *testing.T) {
+func TestWriteToServerReturnsWhenDoneIsClosed(t *testing.T) {
+	wsClient := newWebsocketClient(nil)
+	wsClient.finish(errors.New("teardown already reported"))
+
+	// Empty, so only the done branch can end the loop: nothing is ever flushed.
+	awaitReturn(t, "writeToServer parked after the outcome was taken", func() {
+		wsClient.writeToServer(make(chan string))
+	})
+}
+
+func TestWriteToServerReportsWriteFailure(t *testing.T) {
 	conn := dialTestServer(t)
 	require.NoError(t, conn.Close()) // every later WriteMessage fails
 
 	wsClient := newWebsocketClient(nil)
 	wsClient.conn = conn
-	wsClient.finish(errors.New("teardown already reported"))
 
 	inputChan := make(chan string, 1)
 	inputChan <- "x" // buffered input forces the failing write
 
-	awaitReturn(t, "writeToServer parked reporting a write failure after the outcome was taken", func() {
+	awaitReturn(t, "writeToServer parked on the failing write", func() {
 		wsClient.writeToServer(inputChan)
 	})
+
+	assertReported(t, wsClient)
+	assert.Error(t, wsClient.err)
 }
 
 func TestFinishKeepsTheFirstOutcome(t *testing.T) {
@@ -331,10 +343,8 @@ func TestFinishKeepsTheFirstOutcome(t *testing.T) {
 	wsClient.finish(first)
 	wsClient.finish(errors.New("write failed on the closed connection"))
 
-	assert.Equal(t, first, <-wsClient.Done)
-
-	_, open := <-wsClient.quit
-	assert.False(t, open, "quit must be closed so the remaining goroutines can leave")
+	assertReported(t, wsClient)
+	assert.Equal(t, first, wsClient.err)
 }
 
 func TestRunWsClientReportsTerminalSetupFailure(t *testing.T) {
@@ -400,6 +410,16 @@ func pipeStdin(t *testing.T) *os.File {
 	})
 
 	return pipeWrite
+}
+
+func assertReported(t *testing.T, wsClient *WebsocketClient) {
+	t.Helper()
+
+	select {
+	case <-wsClient.done:
+	default:
+		require.Fail(t, "done must be closed so the remaining goroutines can leave")
+	}
 }
 
 func awaitReturn(t *testing.T, msg string, fn func()) {

--- a/api/websh/websh_test.go
+++ b/api/websh/websh_test.go
@@ -280,67 +280,6 @@ func TestGetSessionRecords_QueryHitsSearchEndpoint(t *testing.T) {
 	assert.Len(t, records, 1)
 }
 
-// dialTestServer returns a live connection, so closing it produces genuine write failures.
-func dialTestServer(t *testing.T) *websocket.Conn {
-	t.Helper()
-
-	upgrader := websocket.Upgrader{}
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		conn, err := upgrader.Upgrade(w, r, nil)
-		if err != nil {
-			return
-		}
-		defer func() { _ = conn.Close() }()
-		for {
-			if _, _, err := conn.ReadMessage(); err != nil {
-				return
-			}
-		}
-	}))
-	t.Cleanup(ts.Close)
-
-	conn, _, err := websocket.DefaultDialer.Dial("ws"+strings.TrimPrefix(ts.URL, "http"), nil)
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = conn.Close() })
-
-	return conn
-}
-
-// pipeStdin points os.Stdin at a pipe and returns its write end. Closing that end
-// yields EOF, which is how a real session ends its input.
-func pipeStdin(t *testing.T) *os.File {
-	t.Helper()
-
-	pipeRead, pipeWrite, err := os.Pipe()
-	require.NoError(t, err)
-
-	realStdin := os.Stdin
-	os.Stdin = pipeRead
-	t.Cleanup(func() {
-		os.Stdin = realStdin
-		_ = pipeRead.Close()
-		_ = pipeWrite.Close()
-	})
-
-	return pipeWrite
-}
-
-func awaitReturn(t *testing.T, msg string, fn func()) {
-	t.Helper()
-
-	returned := make(chan struct{})
-	go func() {
-		fn()
-		close(returned)
-	}()
-
-	select {
-	case <-returned:
-	case <-time.After(teardownWait):
-		t.Fatal(msg)
-	}
-}
-
 func TestReadUserInputReturnsWhenOutcomeAlreadyReported(t *testing.T) {
 	pipeWrite := pipeStdin(t)
 	require.NoError(t, pipeWrite.Close()) // stdin yields EOF right away
@@ -416,4 +355,65 @@ func TestRunWsClientTerminalHelperProcess(t *testing.T) {
 	}
 	// stdin is not a tty here, so checkTerminal fails before the connection is used.
 	_ = newWebsocketClient(nil).runWsClient()
+}
+
+// dialTestServer returns a live connection, so closing it produces genuine write failures.
+func dialTestServer(t *testing.T) *websocket.Conn {
+	t.Helper()
+
+	upgrader := websocket.Upgrader{}
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if !assert.NoError(t, err) {
+			return
+		}
+		defer func() { _ = conn.Close() }()
+		for {
+			if _, _, err := conn.ReadMessage(); err != nil {
+				return
+			}
+		}
+	}))
+	t.Cleanup(ts.Close)
+
+	conn, _, err := websocket.DefaultDialer.Dial("ws"+strings.TrimPrefix(ts.URL, "http"), nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = conn.Close() })
+
+	return conn
+}
+
+// pipeStdin points os.Stdin at a pipe and returns its write end. Closing that end
+// yields EOF, which is how a real session ends its input.
+func pipeStdin(t *testing.T) *os.File {
+	t.Helper()
+
+	pipeRead, pipeWrite, err := os.Pipe()
+	require.NoError(t, err)
+
+	realStdin := os.Stdin
+	os.Stdin = pipeRead
+	t.Cleanup(func() {
+		os.Stdin = realStdin
+		_ = pipeRead.Close()
+		_ = pipeWrite.Close()
+	})
+
+	return pipeWrite
+}
+
+func awaitReturn(t *testing.T, msg string, fn func()) {
+	t.Helper()
+
+	returned := make(chan struct{})
+	go func() {
+		fn()
+		close(returned)
+	}()
+
+	select {
+	case <-returned:
+	case <-time.After(teardownWait):
+		require.Fail(t, msg)
+	}
 }

--- a/api/websh/websh_test.go
+++ b/api/websh/websh_test.go
@@ -20,6 +20,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// A blocked goroutine never returns, so any bound proves the point.
+const teardownWait = 2 * time.Second
+
 func TestGetSessionList(t *testing.T) {
 	closedTime := "2026-03-01T00:00:00Z"
 
@@ -277,12 +280,7 @@ func TestGetSessionRecords_QueryHitsSearchEndpoint(t *testing.T) {
 	assert.Len(t, records, 1)
 }
 
-// teardownWait bounds how long a goroutine may take to return once its exit
-// condition is met. A blocked send never returns, so any value proves the point.
-const teardownWait = 2 * time.Second
-
-// dialTestServer opens a real websocket connection to a server that reads until
-// the peer goes away, so a closed connection produces genuine write failures.
+// dialTestServer returns a live connection, so closing it produces genuine write failures.
 func dialTestServer(t *testing.T) *websocket.Conn {
 	t.Helper()
 
@@ -327,7 +325,6 @@ func pipeStdin(t *testing.T) *os.File {
 	return pipeWrite
 }
 
-// awaitReturn runs fn and fails the test if it has not returned in time.
 func awaitReturn(t *testing.T, msg string, fn func()) {
 	t.Helper()
 

--- a/api/websh/websh_test.go
+++ b/api/websh/websh_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
-	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -16,6 +15,7 @@ import (
 	"github.com/alpacax/alpacon-cli/api"
 	"github.com/alpacax/alpacon-cli/api/types"
 	"github.com/alpacax/alpacon-cli/client"
+	"github.com/alpacax/alpacon-cli/pkg/testutil"
 	"github.com/gorilla/websocket"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -358,16 +358,17 @@ func TestReadFromServerReportsReadFailure(t *testing.T) {
 
 func TestReadFromServerPrintsEveryMessage(t *testing.T) {
 	conn, _ := dialTestServer(t, "hi ", "there")
-	stdout := captureStdout(t)
 
 	wsClient := newWebsocketClient(nil)
 	wsClient.conn = conn
 
-	awaitReturn(t, "readFromServer parked after the server went away", func() {
-		wsClient.readFromServer()
+	stdout := testutil.CaptureStdout(t, func() {
+		awaitReturn(t, "readFromServer parked after the server went away", func() {
+			wsClient.readFromServer()
+		})
 	})
 
-	assert.Equal(t, "hi there", stdout()) // the loop must survive a successful read
+	assert.Equal(t, "hi there", stdout) // the loop must survive a successful read
 	assertReported(t, wsClient)
 	assert.Error(t, wsClient.err)
 }
@@ -540,29 +541,6 @@ func dialTestServer(t *testing.T, send ...string) (*websocket.Conn, <-chan strin
 	t.Cleanup(func() { _ = conn.Close() })
 
 	return conn, received
-}
-
-// captureStdout points os.Stdout at a pipe. The returned function closes the write
-// end and yields everything written to it.
-func captureStdout(t *testing.T) func() string {
-	t.Helper()
-
-	pipeRead, pipeWrite, err := os.Pipe()
-	require.NoError(t, err)
-
-	realStdout := os.Stdout
-	os.Stdout = pipeWrite
-	t.Cleanup(func() {
-		os.Stdout = realStdout
-		_ = pipeRead.Close()
-	})
-
-	return func() string {
-		require.NoError(t, pipeWrite.Close())
-		out, err := io.ReadAll(pipeRead)
-		require.NoError(t, err)
-		return string(out)
-	}
 }
 
 // pipeStdin points os.Stdin at a pipe and returns its write end. Closing that end

--- a/api/websh/websh_test.go
+++ b/api/websh/websh_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -20,8 +21,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// A blocked goroutine never returns, so any bound proves the point.
-const teardownWait = 2 * time.Second
+const (
+	// A blocked goroutine never returns, so any bound proves the point.
+	teardownWait = 2 * time.Second
+
+	receivedBufferSize = 8
+)
 
 func TestGetSessionList(t *testing.T) {
 	closedTime := "2026-03-01T00:00:00Z"
@@ -319,7 +324,7 @@ func TestWriteToServerReturnsWhenDoneIsClosed(t *testing.T) {
 }
 
 func TestWriteToServerReportsWriteFailure(t *testing.T) {
-	conn := dialTestServer(t)
+	conn, _ := dialTestServer(t)
 	require.NoError(t, conn.Close()) // every later WriteMessage fails
 
 	wsClient := newWebsocketClient(nil)
@@ -337,7 +342,7 @@ func TestWriteToServerReportsWriteFailure(t *testing.T) {
 }
 
 func TestReadFromServerReportsReadFailure(t *testing.T) {
-	conn := dialTestServer(t)
+	conn, _ := dialTestServer(t)
 	require.NoError(t, conn.Close()) // every later ReadMessage fails
 
 	wsClient := newWebsocketClient(nil)
@@ -349,6 +354,66 @@ func TestReadFromServerReportsReadFailure(t *testing.T) {
 
 	assertReported(t, wsClient)
 	assert.Error(t, wsClient.err)
+}
+
+func TestReadFromServerPrintsEveryMessage(t *testing.T) {
+	conn, _ := dialTestServer(t, "hi ", "there")
+	stdout := captureStdout(t)
+
+	wsClient := newWebsocketClient(nil)
+	wsClient.conn = conn
+
+	awaitReturn(t, "readFromServer parked after the server went away", func() {
+		wsClient.readFromServer()
+	})
+
+	assert.Equal(t, "hi there", stdout()) // the loop must survive a successful read
+	assertReported(t, wsClient)
+	assert.Error(t, wsClient.err)
+}
+
+func TestReadUserInputForwardsToTheWriter(t *testing.T) {
+	pipeWrite := pipeStdin(t)
+	_, err := pipeWrite.WriteString("l")
+	require.NoError(t, err)
+
+	wsClient := newWebsocketClient(nil)
+	t.Cleanup(func() { wsClient.finish(nil) })
+
+	inputChan := make(chan string, 1)
+	go wsClient.readUserInput(inputChan)
+
+	select {
+	case got := <-inputChan:
+		assert.Equal(t, "l", got)
+	case <-time.After(teardownWait):
+		require.Fail(t, "readUserInput never forwarded the rune it read")
+	}
+}
+
+func TestWriteToServerFlushesBufferedInput(t *testing.T) {
+	conn, received := dialTestServer(t)
+
+	wsClient := newWebsocketClient(nil)
+	wsClient.conn = conn
+	t.Cleanup(func() { wsClient.finish(nil) })
+
+	inputChan := make(chan string, 2)
+	inputChan <- "l"
+	inputChan <- "s"
+	go wsClient.writeToServer(inputChan)
+
+	// The two runes may land in one flush or two, but every byte has to arrive.
+	var got string
+	deadline := time.After(teardownWait)
+	for got != "ls" {
+		select {
+		case message := <-received:
+			got += message
+		case <-deadline:
+			require.Fail(t, "writeToServer never flushed the buffered input", "received %q", got)
+		}
+	}
 }
 
 func TestWatchInterruptEndsTheSessionOnSignal(t *testing.T) {
@@ -435,10 +500,13 @@ func TestDialHelperProcess(t *testing.T) {
 	newWebsocketClient(nil).dial(os.Getenv("WEBSH_TEST_URL"))
 }
 
-// dialTestServer returns a live connection, so closing it produces genuine write failures.
-func dialTestServer(t *testing.T) *websocket.Conn {
+// dialTestServer returns a live connection, so closing it produces genuine write
+// failures, along with the messages the server received. The server sends each of
+// send and then goes away, which is how a real session ends.
+func dialTestServer(t *testing.T, send ...string) (*websocket.Conn, <-chan string) {
 	t.Helper()
 
+	received := make(chan string, receivedBufferSize)
 	upgrader := websocket.Upgrader{}
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		conn, err := upgrader.Upgrade(w, r, nil)
@@ -446,9 +514,22 @@ func dialTestServer(t *testing.T) *websocket.Conn {
 			return
 		}
 		defer func() { _ = conn.Close() }()
-		for {
-			if _, _, err := conn.ReadMessage(); err != nil {
+		for _, message := range send {
+			if err := conn.WriteMessage(websocket.BinaryMessage, []byte(message)); err != nil {
 				return
+			}
+		}
+		if len(send) > 0 {
+			return
+		}
+		for {
+			_, message, err := conn.ReadMessage()
+			if err != nil {
+				return
+			}
+			select {
+			case received <- string(message):
+			default: // an unread message must not park the server past the test
 			}
 		}
 	}))
@@ -458,7 +539,30 @@ func dialTestServer(t *testing.T) *websocket.Conn {
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = conn.Close() })
 
-	return conn
+	return conn, received
+}
+
+// captureStdout points os.Stdout at a pipe. The returned function closes the write
+// end and yields everything written to it.
+func captureStdout(t *testing.T) func() string {
+	t.Helper()
+
+	pipeRead, pipeWrite, err := os.Pipe()
+	require.NoError(t, err)
+
+	realStdout := os.Stdout
+	os.Stdout = pipeWrite
+	t.Cleanup(func() {
+		os.Stdout = realStdout
+		_ = pipeRead.Close()
+	})
+
+	return func() string {
+		require.NoError(t, pipeWrite.Close())
+		out, err := io.ReadAll(pipeRead)
+		require.NoError(t, err)
+		return string(out)
+	}
 }
 
 // pipeStdin points os.Stdin at a pipe and returns its write end. Closing that end

--- a/api/websh/websh_test.go
+++ b/api/websh/websh_test.go
@@ -352,6 +352,20 @@ func TestSessionGoroutines_ReturnAfterTheOutcomeIsTaken(t *testing.T) {
 	}
 }
 
+func TestReadUserInput_ReportsEOFAsACleanEnd(t *testing.T) {
+	pipeWrite := pipeStdin(t)
+	require.NoError(t, pipeWrite.Close()) // what Ctrl+D leaves behind
+
+	wsClient := newWebsocketClient(nil)
+
+	awaitReturn(t, "readUserInput parked on EOF", func() {
+		wsClient.readUserInput(make(chan string, 1))
+	})
+
+	assertReported(t, wsClient)
+	assert.NoError(t, wsClient.err) // Ctrl+D is how a session is meant to end
+}
+
 func TestReadCtrlC_EndsTheSessionOnCtrlC(t *testing.T) {
 	pipeWrite := pipeStdin(t)
 	// The leading byte proves the loop goes around rather than ending on any input.

--- a/cmd/websh/websh.go
+++ b/cmd/websh/websh.go
@@ -319,7 +319,9 @@ Note: All flags must be placed before the server name.
 			}
 		}()
 
-		_ = websh.OpenNewTerminal(alpaconClient, session)
+		if err = websh.OpenNewTerminal(alpaconClient, session); err != nil {
+			utils.CliErrorWithExitCode(1, "Websh session terminated with error: %s.", err)
+		}
 	},
 }
 

--- a/cmd/websh/websh.go
+++ b/cmd/websh/websh.go
@@ -320,7 +320,7 @@ Note: All flags must be placed before the server name.
 		}()
 
 		if err = websh.OpenNewTerminal(alpaconClient, session); err != nil {
-			utils.CliErrorWithExitCode(1, "Websh session terminated with error: %s.", err)
+			utils.CliErrorWithExitCode(utils.ExitCodeGeneralError, "Websh session ended with error: %s.", err)
 		}
 	},
 }

--- a/cmd/websh/websh_join.go
+++ b/cmd/websh/websh_join.go
@@ -29,7 +29,7 @@ var webshJoinCmd = &cobra.Command{
 		}
 
 		if err = websh.OpenNewTerminal(alpaconClient, session); err != nil {
-			utils.CliErrorWithExitCode(1, "Websh session terminated with error: %s.", err)
+			utils.CliErrorWithExitCode(utils.ExitCodeGeneralError, "Websh session ended with error: %s.", err)
 		}
 	},
 }

--- a/cmd/websh/websh_join.go
+++ b/cmd/websh/websh_join.go
@@ -29,7 +29,7 @@ var webshJoinCmd = &cobra.Command{
 		}
 
 		if err = websh.OpenNewTerminal(alpaconClient, session); err != nil {
-			utils.CliErrorWithExit("Websh session terminated with error: %s.", err)
+			utils.CliErrorWithExitCode(1, "Websh session terminated with error: %s.", err)
 		}
 	},
 }

--- a/cmd/websh/websh_watch.go
+++ b/cmd/websh/websh_watch.go
@@ -42,7 +42,7 @@ var webshWatchCmd = &cobra.Command{
 		}
 
 		if err = websh.OpenReadOnlyTerminal(alpaconClient, session); err != nil {
-			utils.CliErrorWithExit("websh watch session ended with error: %s.", err)
+			utils.CliErrorWithExitCode(1, "websh watch session ended with error: %s.", err)
 		}
 	},
 }

--- a/cmd/websh/websh_watch.go
+++ b/cmd/websh/websh_watch.go
@@ -42,7 +42,7 @@ var webshWatchCmd = &cobra.Command{
 		}
 
 		if err = websh.OpenReadOnlyTerminal(alpaconClient, session); err != nil {
-			utils.CliErrorWithExitCode(1, "websh watch session ended with error: %s.", err)
+			utils.CliErrorWithExitCode(utils.ExitCodeGeneralError, "Websh watch session ended with error: %s.", err)
 		}
 	},
 }

--- a/utils/error.go
+++ b/utils/error.go
@@ -33,6 +33,11 @@ const (
 	WorkSessionServerNotAllowed = "work_session_server_not_allowed"
 	WorkSessionAssigneeMismatch = "work_session_assignee_mismatch"
 
+	// ExitCodeGeneralError is the process exit code for an ordinary failure—what
+	// CliErrorWithExit already exits with. Name it when calling CliErrorWithExitCode
+	// so the general case reads like the specific ones beside it.
+	ExitCodeGeneralError = 1
+
 	// ExitCodeWorkSessionDenied is the process exit code for WorkSession gate refusals.
 	ExitCodeWorkSessionDenied = 3
 


### PR DESCRIPTION
## Background

A websh session runs three goroutines—`readFromServer`, `readUserInput`, and `writeToServer` on the interactive path, and the signal watcher, the Ctrl+C reader, and `readFromServer` on the read-only one. They reported the end of the session by sending into a buffered `Done` channel that was received exactly once. Ordinary teardown filled that slot and the receiver returned, so the next send parked its goroutine for good: `readFromServer` reports the remote close, `writeToServer`'s write then fails into the drained slot, and `readUserInput` blocks when stdin finally yields EOF. The signal watcher parked for a different reason—`signal.Stop` disarms delivery without closing `sigChan`, which was all it waited on. The Ctrl+C reader never looked at the outcome at all and went on consuming stdin after its caller had returned.

The goroutines die with the process today, since both entry points exit right after. The contract should not depend on that. Neither should the terminal: only the read-only path watched for signals, so a SIGTERM to an interactive session killed the process straight from the handler, no deferred restore ran, and the user was left in raw mode until they ran `reset`.

The session outcome was wrong at both ends besides. The proxy closes a user channel with 4000 at the end of a session, and any deliberate close reached the caller as a `*websocket.CloseError`, so typing `exit` printed a red `Error` plus the "report on github issues" footer and exited 1; on the main path the outcome was discarded entirely. Three errors on this path also named the wrong thing: `checkTerminal` failures surfaced with the dial handler's wording, `checkTerminal`'s own message named neither the stream nor the fix, and gorilla reports every rejected upgrade as `bad handshake`.

## Changes

Teardown now rests on one channel that only closes, the outcome it carries is reported rather than exited on, and both entry points tear down the same way.

| Location | What changes |
|---|---|
| `types.go` | `Done chan error` becomes an unexported `done chan struct{}` plus `err error` and `finishOnce sync.Once`. `Header` is unexported with them, since nothing outside the package reads it |
| `finish` | Records the first outcome under a `sync.Once`: writes `err`, then closes `done`. A channel that only closes cannot park a sender, so the hazard is structural rather than resting on the `sync.Once`. A deliberate close is normalized to `nil`; every other close code stays an error |
| `sessionEndCloseCode` | 4000—what the proxy actually closes a user channel with (`sendCloseFrame`, proxy-server `internal/ws/channel.go:337`), and what alpamon sends for the same meaning. Without it the normalization would have passed its tests and changed nothing in production, since a websh session never ends with 1000 |
| `readFromServer`, `readUserInput`, `writeToServer`, `watchInterrupt`, `readCtrlC` | Report through `finish` and return. The watcher selects on `done` as well, so it leaves with the rest of teardown. `readUserInput` also selects on `done` while sending to `inputChan`, since the writer is gone by then |
| `readCtrlC` | The anonymous Ctrl+C reader becomes a named method that checks `done` between reads instead of consuming stdin past the end of the session, and guards on `n > 0` so a `(0, nil)` read cannot re-judge the previous byte |
| `notifySignals`, `runWsClient` | The interactive path installs the same signal watcher the read-only path had, so a SIGTERM ends the session through the normal teardown and the deferred restore runs. Raw mode disables ISIG, so Ctrl+C is still a byte for the remote shell rather than a local signal |
| `runWsClient`, `OpenReadOnlyTerminal` | Wait on `<-done` and return `wsClient.err`, read after the close |
| `newWebsocketClient`, `dial` | The client literal and the dial block, both duplicated in the two entry points, become a constructor and a method. `dial` returns its error rather than ending the process, and the message carries the handshake status the response already returned, sanitized |
| `enterRawMode` | The raw-mode setup duplicated across both entry points becomes one function returning the restore to defer. Its failure returns too, so the `signal.Stop` and `conn.Close` defers still run when the terminal cannot be set up |
| `cmd/websh` | `websh SERVER` surfaces the session outcome instead of discarding it. All three sites exit with `utils.ExitCodeGeneralError` and no bug-report footer: a session ending badly is the network, the server, or the terminal, not a CLI defect to report |
| `ctrlC`, `writeFlushInterval` | The raw-mode `0x03` and the 5ms flush tick become named constants |
| `writeToServer` | Flushes on a `time.Ticker` instead of `time.After`, which was reallocated every pass and restarted on every arriving rune—so a steady stream of input deferred the flush until it stopped, and a pasted block went out as a single `WriteMessage` |
| `readFromServer` | `os.Stdout.Write(message)` instead of `fmt.Print(string(message))`, dropping a copy and a trip through reflection on the path server output floods through |

The non-blocking `select`/`default` the issue proposed was rejected: it covers the `Done` sends but leaves `inputChan` needing a second mechanism, and keeps which outcome wins dependent on arrival order.

## Known limits

Two blocking terminal reads cannot be released by teardown, because nothing but closing stdin releases a read parked in the kernel, and that races the `term.Restore` deferred right above it. Both are documented on the functions.

- `readUserInput` stays in `ReadRune` until the next keystroke. `websh SERVER` waits up to three seconds for its sudo listener after the session ends, and a key pressed in that window is eaten by this goroutine instead of reaching the shell—one character, once.
- `readCtrlC` notices `done` only after the read it is already parked in returns.

One race is left unfixed rather than fixed badly: if `writeToServer` is holding buffered input when the remote closes normally, its failing write can reach `finish` before `readFromServer` reports the close, turning a clean exit into code 1. Making the close win needs a priority rule between outcomes, which contradicts the "keep the first outcome" contract `TestFinish_KeepsTheFirstOutcome` pins. The buffer is normally empty at exit, so the window is small.

## Safety

The status line the new message quotes is written by whoever answered the handshake, so it reaches the terminal through `utils.SanitizeTerminalText` like every other server-supplied string this CLI prints.

## Testing

Every goroutine that could park now has a test that fails if it does—`awaitReturn` gives it two seconds and reports the park instead of hanging. One table drives the five teardown cases: `readUserInput` reporting EOF, `readUserInput` sending to `inputChan`, `writeToServer` waiting to flush, `watchInterrupt` waiting for a signal, and `readCtrlC` waiting for the next byte. `readFromServer` is covered separately, since it ends on its own failing read.

Also covered: EOF reported as a clean end, so Ctrl+D exits 0 rather than 1; `readCtrlC` ending the session on the Ctrl+C byte after a byte that is not one; `finish` keeping the first outcome; `finish` normalizing 4000, 1000 and 1001 while keeping 1006 and a transport failure as errors; and `OpenReadOnlyTerminal` leaving no goroutine behind when raw mode fails after a successful dial. That last one polls the goroutine count inline rather than through `assert.Eventually`, which evaluates its condition in a goroutine of its own and so can never watch the count come back down, and it primes `signal.Notify` first because the first call anywhere starts one process-wide goroutine that never exits.

`dial` and `runWsClient` return their setup errors, so both assert in process and the subprocess helpers are gone.

The normal path is covered too, since a loop that stops correctly is still worthless if it does the wrong thing while running: a keystroke reaches the server, server output reaches the screen, and the dial failure carries the handshake status.

Each was checked by mutation: breaking the guard it covers makes that test and no other fail. Removing the close normalization fails only the normalized cases of `TestFinish_NormalizesARemoteCloseToASuccess`; dropping 4000 from it fails only the `session end` case; breaking the EOF normalization fails only `TestReadUserInput_ReportsEOFAsACleanEnd`; moving a `go` statement back above `enterRawMode` fails only `TestOpenReadOnlyTerminal_LeavesNoGoroutineWhenSetupFails`.

The interactive signal path is the one change with no automated test—driving either entry point past `enterRawMode` needs a pty. Deleting its `go` statement does fail the build, since `sigChan` goes unused, but deleting the `notifySignals` call with it would not.

`gofmt -l .` clean, `go vet ./...` clean, `golangci-lint run ./...` clean, `go test -race -count=1 ./...` passing.

Closes #300
Closes #301
