### PR TITLE
build(deps): bump golang.org/x/sys to clear GO-2026-5024

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,8 +7,8 @@ require (
 	github.com/spf13/cobra v1.10.2
 	github.com/stretchr/testify v1.11.1
 	github.com/xtaci/smux v1.5.56
-	golang.org/x/sys v0.41.0
-	golang.org/x/term v0.40.0
+	golang.org/x/sys v0.47.0
+	golang.org/x/term v0.45.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -17,10 +17,10 @@ github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD
 github.com/xtaci/smux v1.5.56 h1:Eyv/dUULmkGZZNucLUisnkzJ/4UQ5YZTschhugFBM0U=
 github.com/xtaci/smux v1.5.56/go.mod h1:IGQ9QYrBphmb/4aTnLEcJby0TNr3NV+OslIOMrX825Q=
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
-golang.org/x/sys v0.41.0 h1:Ivj+2Cp/ylzLiEU89QhWblYnOE9zerudt9Ftecq2C6k=
-golang.org/x/sys v0.41.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
-golang.org/x/term v0.40.0 h1:36e4zGLqU4yhjlmxEaagx2KuYbJq3EwY8K943ZsHcvg=
-golang.org/x/term v0.40.0/go.mod h1:w2P8uVp06p2iyKKuvXIm7N/y0UCRt3UfJTfZ7oOpglM=
+golang.org/x/sys v0.47.0 h1:o7XGOvZQCADBQQ4Y7VNq2dRWQR7JmOUW8Kxx4ZsNgWs=
+golang.org/x/sys v0.47.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
+golang.org/x/term v0.45.0 h1:NwWyBmoJCbfTHpxrWoZ9C6/VxOf7ic219I8xZZFdrf0=
+golang.org/x/term v0.45.0/go.mod h1:9aqxs0blBcrm/n0L9QW0aRVD+ktan8ssZromtqJC43w=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=


### PR DESCRIPTION
## Background

`govulncheck ./...` on go 1.25.12 reports one finding, at module level:

```
Vulnerability #1: GO-2026-5024
    Invoking integer overflow in NewNTUnicodeString in golang.org/x/sys/windows
    Found in: golang.org/x/sys@v0.41.0
    Fixed in: golang.org/x/sys@v0.44.0
    Platforms: windows
```

No code in this repo calls `NewNTUnicodeString`, so there is no reachable call path. The module still ships inside the GoReleaser windows binary, which is why it is worth clearing rather than ignoring.

## Changes

`go.mod` and `go.sum` only.

| Module | From | To |
|---|---|---|
| `golang.org/x/sys` | v0.41.0 | v0.47.0 |
| `golang.org/x/term` | v0.40.0 | v0.45.0 |

v0.44.0 is the minimum fix; v0.47.0 is the current release. `golang.org/x/term` moves in the same commit because `x/term@v0.45.0` requires `x/sys v0.47.0`, so the two cannot be bumped independently.

`github.com/xtaci/smux` (v1.5.57) and `github.com/spf13/pflag` (v1.0.10) are also behind, but neither carries an advisory, so they are left out of this PR.

## Testing

```
govulncheck ./...       No vulnerabilities found.
go vet ./...            clean
go test -race ./...     exit 0, 38 packages ok, 0 failures
go build .              ok
GOOS=windows go build   ok
GOOS=linux go build     ok
```

No source files changed, so no new tests.
