### PR TITLE
fix(event): pace the command poll and back off when throttled

### DIFF
--- a/api/event/commandoutput_listener.go
+++ b/api/event/commandoutput_listener.go
@@ -22,8 +22,9 @@ type ChunkEvent struct {
 	Content string
 }
 
-// CommandOutputListener subscribes to a single command's chunk stream over
-// the event WebSocket and exposes received chunks via the Chunks() channel.
+// CommandOutputListener subscribes to a single command's chunk stream over the
+// event WebSocket, exposing chunks on Chunks() and the command's fin on
+// Finished().
 //
 // Lifecycle: NewCommandOutputListener -> Start -> (consume Chunks) -> Stop.
 // Stop is idempotent and safe to call from any goroutine.

--- a/api/event/commandoutput_listener.go
+++ b/api/event/commandoutput_listener.go
@@ -35,8 +35,8 @@ type CommandOutputListener struct {
 	finished  chan struct{}
 }
 
-// commandOutputEnvelope is the WS message format emitted by alpacon-server. Both
-// payload shapes share the struct: command_output names the command in command_id,
+// commandOutputEnvelope is the WS message format emitted by alpacon-server. One
+// struct for both payloads: command_output names the command in command_id,
 // command_fin in id.
 type commandOutputEnvelope struct {
 	EventType EventType `json:"event_type"`
@@ -64,8 +64,8 @@ func NewCommandOutputListener(ac *client.AlpaconClient, wsURL, commandID string)
 // Chunks returns a receive-only channel of parsed chunk events.
 func (l *CommandOutputListener) Chunks() <-chan ChunkEvent { return l.chunks }
 
-// Finished fires once the command reaches a terminal state, which chunks alone
-// never tell: they carry no end marker. Buffered for one—a repeat says nothing new.
+// Finished fires when the command reaches a terminal state, which the chunks
+// never say: they carry no end marker.
 func (l *CommandOutputListener) Finished() <-chan struct{} { return l.finished }
 
 // handleMessage parses one WS frame and routes it: a chunk onto chunks, a fin onto

--- a/api/event/commandoutput_listener.go
+++ b/api/event/commandoutput_listener.go
@@ -32,15 +32,19 @@ type CommandOutputListener struct {
 	cmdMu     sync.Mutex // guards commandID
 	commandID string
 	chunks    chan ChunkEvent
+	finished  chan struct{}
 }
 
-// commandOutputEnvelope is the WS message format emitted by alpacon-server.
+// commandOutputEnvelope is the WS message format emitted by alpacon-server. Both
+// payload shapes share the struct: command_output names the command in command_id,
+// command_fin in id.
 type commandOutputEnvelope struct {
 	EventType EventType `json:"event_type"`
 	Payload   struct {
 		CommandID string `json:"command_id"`
 		Seq       int    `json:"seq"`
 		Content   string `json:"content"`
+		ID        string `json:"id"`
 	} `json:"payload"`
 }
 
@@ -51,6 +55,7 @@ func NewCommandOutputListener(ac *client.AlpaconClient, wsURL, commandID string)
 		wsListener: newWSListener(ac, wsURL, commandOutputConnectTimeout),
 		commandID:  commandID,
 		chunks:     make(chan ChunkEvent, commandOutputChunkBuffer),
+		finished:   make(chan struct{}, 1),
 	}
 	l.handleFrame = l.handleMessage
 	return l
@@ -59,27 +64,40 @@ func NewCommandOutputListener(ac *client.AlpaconClient, wsURL, commandID string)
 // Chunks returns a receive-only channel of parsed chunk events.
 func (l *CommandOutputListener) Chunks() <-chan ChunkEvent { return l.chunks }
 
-// handleMessage parses one WS frame and pushes a matching chunk onto chunks.
-// Non-matching frames (wrong event_type, wrong command_id, parse failure) are
-// silently dropped.
+// Finished fires once the command reaches a terminal state, which chunks alone
+// never tell: they carry no end marker. Buffered for one—a repeat says nothing new.
+func (l *CommandOutputListener) Finished() <-chan struct{} { return l.finished }
+
+// handleMessage parses one WS frame and routes it: a chunk onto chunks, a fin onto
+// finished. Non-matching frames (other event types, another command's id, parse
+// failure) are silently dropped.
 func (l *CommandOutputListener) handleMessage(raw []byte) {
 	var env commandOutputEnvelope
 	if err := json.Unmarshal(raw, &env); err != nil {
 		return
 	}
-	if env.EventType != EventTypeCommandOutput {
-		return
-	}
 	l.cmdMu.Lock()
 	cid := l.commandID
 	l.cmdMu.Unlock()
-	if env.Payload.CommandID != cid {
-		return
-	}
 
-	select {
-	case l.chunks <- ChunkEvent{Seq: env.Payload.Seq, Content: env.Payload.Content}:
-	case <-l.done:
+	switch env.EventType {
+	case EventTypeCommandOutput:
+		if env.Payload.CommandID != cid {
+			return
+		}
+		select {
+		case l.chunks <- ChunkEvent{Seq: env.Payload.Seq, Content: env.Payload.Content}:
+		case <-l.done:
+		}
+	case EventTypeCommandFin:
+		// Subscribed per server, so every other command on it lands here too.
+		if env.Payload.ID != cid {
+			return
+		}
+		select {
+		case l.finished <- struct{}{}:
+		default:
+		}
 	}
 }
 

--- a/api/event/commandoutput_listener_test.go
+++ b/api/event/commandoutput_listener_test.go
@@ -63,6 +63,47 @@ func TestCommandOutputListener_HandleMessage_FiltersAndEmits(t *testing.T) {
 	}
 }
 
+// The fin subscription targets the server, so every command on it reports here.
+func TestCommandOutputListener_HandleMessage_FinishedIsPerCommand(t *testing.T) {
+	tests := []struct {
+		name         string
+		payload      string
+		wantFinished bool
+	}{
+		{
+			name:         "fin for this command",
+			payload:      `{"event_type":"command_fin","payload":{"type":"event","id":"cmd-1"}}`,
+			wantFinished: true,
+		},
+		{
+			name:    "fin for another command on the same server",
+			payload: `{"event_type":"command_fin","payload":{"type":"event","id":"cmd-OTHER"}}`,
+		},
+		{
+			name:    "chunk does not finish the command",
+			payload: `{"event_type":"command_output","payload":{"command_id":"cmd-1","seq":0,"content":"hi"}}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			l := NewCommandOutputListener(nil, "", "cmd-1")
+			l.handleMessage([]byte(tt.payload))
+
+			select {
+			case <-l.Finished():
+				if !tt.wantFinished {
+					t.Fatal("expected no finish signal")
+				}
+			case <-time.After(50 * time.Millisecond):
+				if tt.wantFinished {
+					t.Fatal("expected a finish signal but got nothing")
+				}
+			}
+		})
+	}
+}
+
 func TestCommandOutputListener_Start_DeliversChunks(t *testing.T) {
 	upgrader := websocket.Upgrader{}
 	cmdID := "cmd-uuid"

--- a/api/event/event.go
+++ b/api/event/event.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/http"
 	"os"
 	"path"
 	"time"
@@ -18,6 +19,17 @@ import (
 
 const (
 	getEventURL = "/api/events/commands/"
+
+	// Poll pacing, in multiples of the caller's base tick, widening as the command
+	// ages and again once the server pushes back. A fixed 1s tick burns alpacon-server's
+	// default 1000/hour service-token throttle in ~17 minutes, then starves itself—each
+	// freed slot goes to a request that is throttled again.
+	pollFastWindow     = 10
+	pollMediumWindow   = 60
+	pollMediumTick     = 5
+	pollSlowTick       = 10
+	pollBackoffFactor  = 2
+	pollMaxBackoffTick = 60
 )
 
 // maxGapWidth caps enumerated missing seqs (per gap and cumulatively) so a buggy or
@@ -37,6 +49,12 @@ var (
 
 // gapFillNow is a seam so tests drive backoff timing deterministically.
 var gapFillNow = time.Now
+
+// pollNow and pollSleep are seams so tests run the loop on a fake clock.
+var (
+	pollNow   = time.Now
+	pollSleep = time.Sleep
+)
 
 // gapFillState throttles gap-fill re-fetches while lastSeq is not advancing and
 // records seqs given up on so they can be retried once at command end.
@@ -239,48 +257,79 @@ func execTimeout() time.Duration {
 	return 30 * time.Minute
 }
 
-// waitApproval keeps polling through the awaiting_approval hold (bounded by
-// timeout, no reset) so an approved job resumes streaming; otherwise that hold
-// is terminal and surfaces as a PendingApprovalError via errorFromDetails.
+func nextPollTick(tick, elapsed time.Duration) time.Duration {
+	switch {
+	case elapsed < time.Duration(pollFastWindow)*tick:
+		return tick
+	case elapsed < time.Duration(pollMediumWindow)*tick:
+		return time.Duration(pollMediumTick) * tick
+	default:
+		return time.Duration(pollSlowTick) * tick
+	}
+}
+
+// nextPollBackoff returns the gap after a failed poll; attempt is the failure
+// count so far, 0 for the first. A server-sent retryAfter wins but shares the
+// cap, so a hostile value cannot park the loop until the deadline.
+func nextPollBackoff(tick time.Duration, attempt int, retryAfter time.Duration) time.Duration {
+	maxDelay := time.Duration(pollMaxBackoffTick) * tick
+	if retryAfter > 0 {
+		return min(retryAfter, maxDelay)
+	}
+	delay := tick
+	for range attempt {
+		delay *= time.Duration(pollBackoffFactor)
+		if delay >= maxDelay {
+			return maxDelay
+		}
+	}
+	return delay
+}
+
+// waitApproval polls through the awaiting_approval hold—bounded by timeout, which
+// the hold never resets and only a throttled wait extends—so an approved job
+// resumes streaming. Without it the hold is terminal (PendingApprovalError).
 func pollCommandExecution(ac *client.AlpaconClient, cmdId string, timeout, tick time.Duration, waitApproval bool) (EventDetails, error) {
 	var response EventDetails
 
-	timer := time.NewTimer(timeout)
-	defer timer.Stop()
-	ticker := time.NewTicker(tick)
-	defer ticker.Stop()
+	started := pollNow()
+	deadline := started.Add(timeout)
+	delay := tick
+	failures := 0
 
 	for {
-		select {
-		case <-timer.C:
+		pollSleep(delay)
+		if pollNow().After(deadline) {
 			return response, &ClientTimeoutError{}
-		case <-ticker.C:
-			responseBody, err := ac.SendGetRequest(utils.BuildURL(getEventURL, cmdId, nil))
-			if err != nil {
-				continue
-			}
-			if err = json.Unmarshal(responseBody, &response); err != nil {
-				return response, err
-			}
-
-			if IsRunningStatus(response.Status) {
-				// Drain timer.C before Reset to prevent a spurious ClientTimeoutError if the timer fires between Stop and Reset.
-				if !timer.Stop() {
-					select {
-					case <-timer.C:
-					default:
-					}
-				}
-				timer.Reset(timeout)
-				continue
-			}
-			// Approval-resume keeps polling through the hold and the transient
-			// "error" compute_status the server emits in the approve→deliver window.
-			if waitApproval && (IsAwaitingApprovalStatus(response.Status) || response.Status == "error") {
-				continue
-			}
-			return response, nil
 		}
+
+		responseBody, err := ac.SendGetRequest(utils.BuildURL(getEventURL, cmdId, nil))
+		if err != nil {
+			delay = nextPollBackoff(tick, failures, utils.RetryAfter(err))
+			failures++
+			if utils.HTTPStatusCode(err) == http.StatusTooManyRequests {
+				// The server is alive: the command may be done, only its result GET refused.
+				deadline = deadline.Add(delay)
+			}
+			continue
+		}
+		failures = 0
+		if err = json.Unmarshal(responseBody, &response); err != nil {
+			return response, err
+		}
+
+		if IsRunningStatus(response.Status) {
+			deadline = pollNow().Add(timeout)
+			delay = nextPollTick(tick, pollNow().Sub(started))
+			continue
+		}
+		// Approval-resume keeps polling through the hold and the transient
+		// "error" compute_status the server emits in the approve→deliver window.
+		if waitApproval && (IsAwaitingApprovalStatus(response.Status) || response.Status == "error") {
+			delay = nextPollTick(tick, pollNow().Sub(started))
+			continue
+		}
+		return response, nil
 	}
 }
 

--- a/api/event/event.go
+++ b/api/event/event.go
@@ -54,11 +54,36 @@ var (
 // gapFillNow is a seam so tests drive backoff timing deterministically.
 var gapFillNow = time.Now
 
-// pollNow and pollSleep are seams so tests run the loop on a fake clock.
-var (
-	pollNow   = time.Now
-	pollSleep = time.Sleep
-)
+// errPollCancelled ends a poll whose caller has already finished—a stream that
+// exited on the fin event—so it stops instead of spending another request of the
+// throttle budget this pacing exists to protect.
+var errPollCancelled = errors.New("poll cancelled")
+
+// pollSeams are the hooks only a stream or a test supplies: cancellation, and a
+// clock in place of real time. The zero value polls uncancellably on the real one.
+// Passed rather than kept in package vars—a poll outlives the stream that started
+// it by an in-flight request, and a test swapping a var would swap it under a
+// loop still running.
+type pollSeams struct {
+	cancel <-chan struct{}
+	now    func() time.Time
+	after  func(time.Duration) <-chan time.Time
+}
+
+func (s pollSeams) Now() time.Time {
+	if s.now == nil {
+		return time.Now()
+	}
+	return s.now()
+}
+
+// After hands back a channel rather than blocking, so a wait can lose to cancel.
+func (s pollSeams) After(d time.Duration) <-chan time.Time {
+	if s.after == nil {
+		return time.After(d)
+	}
+	return s.after(d)
+}
 
 // gapFillState throttles gap-fill re-fetches while lastSeq is not advancing and
 // records seqs given up on so they can be retried once at command end.
@@ -248,7 +273,7 @@ func GetCommandByID(ac *client.AlpaconClient, cmdID string) (EventDetails, error
 
 // PollCommandExecution polls with default timeout/tick; tests use pollCommandExecution directly.
 func PollCommandExecution(ac *client.AlpaconClient, cmdId string) (EventDetails, error) {
-	return pollCommandExecution(ac, cmdId, execTimeout(), 1*time.Second, false)
+	return pollCommandExecution(ac, cmdId, execTimeout(), 1*time.Second, false, pollSeams{})
 }
 
 func execTimeout() time.Duration {
@@ -301,11 +326,12 @@ func isPollWaitStatus(status string, waitApproval bool) bool {
 // waitApproval polls through the awaiting_approval hold—bounded by timeout, which
 // the hold never resets and throttled waits extend by at most one timeout plus one
 // backoff wait—so an approved job resumes streaming. Without it the hold is
-// terminal (PendingApprovalError).
-func pollCommandExecution(ac *client.AlpaconClient, cmdId string, timeout, tick time.Duration, waitApproval bool) (EventDetails, error) {
+// terminal (PendingApprovalError). A closed seams.cancel ends the poll with
+// errPollCancelled.
+func pollCommandExecution(ac *client.AlpaconClient, cmdId string, timeout, tick time.Duration, waitApproval bool, seams pollSeams) (EventDetails, error) {
 	var response EventDetails
 
-	started := pollNow()
+	started := seams.Now()
 	deadline := started.Add(timeout)
 	delay := tick
 	failures := 0
@@ -313,13 +339,22 @@ func pollCommandExecution(ac *client.AlpaconClient, cmdId string, timeout, tick 
 	throttleWarned := false
 
 	for {
+		select {
+		case <-seams.cancel:
+			return response, errPollCancelled
+		default:
+		}
 		// Never sleep past the deadline, or the timeout lands a whole gap late—10
 		// ticks at the slow pace, 60 once throttled. An extended deadline always
 		// leaves the whole wait, so a throttled retry still gets its poll.
-		if wait := min(delay, deadline.Sub(pollNow())); wait > 0 {
-			pollSleep(wait)
+		if wait := min(delay, deadline.Sub(seams.Now())); wait > 0 {
+			select {
+			case <-seams.After(wait):
+			case <-seams.cancel:
+				return response, errPollCancelled
+			}
 		}
-		if !pollNow().Before(deadline) {
+		if !seams.Now().Before(deadline) {
 			return response, &ClientTimeoutError{}
 		}
 
@@ -351,18 +386,18 @@ func pollCommandExecution(ac *client.AlpaconClient, cmdId string, timeout, tick 
 		}
 
 		if IsRunningStatus(response.Status) {
-			deadline = pollNow().Add(timeout)
+			deadline = seams.Now().Add(timeout)
 			// The refreshed deadline gets its throttle allowance back with it, so a
 			// throttle late in a long command is not paid for by an earlier one—and
 			// the warning with it, so a later stretch is not silent.
 			throttledWait = 0
 			throttleWarned = false
-			delay = nextPollTick(tick, pollNow().Sub(started))
+			delay = nextPollTick(tick, seams.Now().Sub(started))
 			continue
 		}
 		// Running is handled above, so what is left here is the approval hold.
 		if isPollWaitStatus(response.Status, waitApproval) {
-			delay = nextPollTick(tick, pollNow().Sub(started))
+			delay = nextPollTick(tick, seams.Now().Sub(started))
 			continue
 		}
 		return response, nil
@@ -459,13 +494,19 @@ func streamSubscribed(ac *client.AlpaconClient, session *EventSessionResponse, l
 
 	pollResult := make(chan EventDetails, 1)
 	pollErr := make(chan error, 1)
+	// The poll ends when this function does: an exit on the fin event would
+	// otherwise leave it polling a command that is already over.
+	pollCancel := make(chan struct{})
+	defer close(pollCancel)
 	go func() {
-		details, err := pollCommandExecution(ac, cmdID, timeout, tick, waitApproval)
-		if err != nil {
+		details, err := pollCommandExecution(ac, cmdID, timeout, tick, waitApproval, pollSeams{cancel: pollCancel})
+		switch {
+		case errors.Is(err, errPollCancelled): // the stream is gone; nobody reads these
+		case err != nil:
 			pollErr <- err
-			return
+		default:
+			pollResult <- details
 		}
-		pollResult <- details
 	}()
 
 	// Runs on whichever terminal signal arrives first, the fin event or the poll.
@@ -673,7 +714,7 @@ func runCommandFallback(ac *client.AlpaconClient, serverName, command, username,
 // blocking through an awaiting_approval hold so --wait is honored on this path.
 func runCommandFallbackFromID(ac *client.AlpaconClient, cmdID string, out io.Writer, waitApproval bool, cause error) error {
 	utils.CliWarning("real-time output unavailable (%v); falling back to polling", cause)
-	details, err := pollCommandExecution(ac, cmdID, execTimeout(), 1*time.Second, waitApproval)
+	details, err := pollCommandExecution(ac, cmdID, execTimeout(), 1*time.Second, waitApproval, pollSeams{})
 	if err != nil {
 		return err
 	}

--- a/api/event/event.go
+++ b/api/event/event.go
@@ -32,8 +32,7 @@ const (
 	pollMaxBackoffTick = 60
 
 	// Base gap the pacing above multiplies, for the poll running behind a live
-	// stream. Passed to streamSubscribed rather than read there, so a test can
-	// widen it away and leave the fin event as the only thing that ends a run.
+	// stream.
 	streamPollTick = time.Second
 )
 
@@ -338,8 +337,7 @@ func pollCommandExecution(ac *client.AlpaconClient, cmdId string, timeout, tick 
 				// The server is alive: the command may be done, only its result GET refused.
 				// Budgeted so a token stuck over quota gives up—extending by exactly the
 				// wait would keep the deadline ahead forever. The last extension is granted
-				// whole rather than trimmed, so every mandated wait still buys its poll:
-				// the ceiling is one timeout plus one backoff wait.
+				// whole rather than trimmed, so every mandated wait still buys its poll.
 				if throttledWait < timeout {
 					deadline = deadline.Add(delay)
 					throttledWait += delay

--- a/api/event/event.go
+++ b/api/event/event.go
@@ -287,8 +287,8 @@ func nextPollBackoff(tick time.Duration, attempt int, retryAfter time.Duration) 
 }
 
 // waitApproval polls through the awaiting_approval hold—bounded by timeout, which
-// the hold never resets and throttled waits extend by at most one more timeout—so
-// an approved job resumes streaming. Without it the hold is terminal (PendingApprovalError).
+// the hold never resets and throttled waits extend by at most one timeout plus one
+// backoff wait—so an approved job resumes streaming. Without it the hold is terminal (PendingApprovalError).
 func pollCommandExecution(ac *client.AlpaconClient, cmdId string, timeout, tick time.Duration, waitApproval bool) (EventDetails, error) {
 	var response EventDetails
 
@@ -317,8 +317,11 @@ func pollCommandExecution(ac *client.AlpaconClient, cmdId string, timeout, tick 
 					utils.CliWarning("rate limited by the server, retrying in %s", delay)
 				}
 				// The server is alive: the command may be done, only its result GET refused.
-				// Capped at one more timeout, so a token stuck over quota still gives up:
-				// extending by exactly the wait would otherwise keep the deadline ahead forever.
+				// Budgeted so a token stuck over quota gives up: extending by exactly the
+				// wait would keep the deadline ahead of the clock forever. The extension
+				// that exhausts the budget is granted whole rather than trimmed to what is
+				// left, so every wait the server mandates still buys the poll it waited
+				// for—the ceiling is one timeout plus one backoff wait.
 				if throttledWait < timeout {
 					deadline = deadline.Add(delay)
 					throttledWait += delay

--- a/api/event/event.go
+++ b/api/event/event.go
@@ -20,8 +20,8 @@ import (
 const (
 	getEventURL = "/api/events/commands/"
 
-	// Poll pacing, in multiples of the caller's base tick, widening as the command
-	// ages and again once the server pushes back. A fixed 1s tick burns alpacon-server's
+	// Poll pacing, in multiples of the caller's base tick, widening as the poll ages
+	// and again once the server pushes back. A fixed 1s tick burns alpacon-server's
 	// default 1000/hour service-token throttle in ~17 minutes, then starves itself—each
 	// freed slot goes to a request that is throttled again.
 	pollFastWindow     = 10
@@ -35,8 +35,9 @@ const (
 	// duration: a duration budget is spent at whatever pace the server asks for, so a
 	// flat Retry-After: 1 buys a second window of one-second polls. 60 grants at the
 	// capped 60-tick wait is 3,600 ticks—a whole quota window at the default
-	// one-second tick—so the duration budget binds first at the cap and this bound
-	// only catches a throttle asking for less.
+	// one-second tick—so at the default timeout the duration budget binds first at the
+	// cap and this bound only catches a throttle asking for less. Past an hour's
+	// timeout the count binds at the cap too.
 	pollMaxThrottleExtensions = 60
 
 	// Base gap the pacing above multiplies, for the poll running behind a live

--- a/api/event/event.go
+++ b/api/event/event.go
@@ -32,6 +32,11 @@ const (
 	pollMaxBackoffTick = 60
 )
 
+// streamPollTick is the base gap for the status poll behind a live stream, the
+// one the pacing above multiplies. Passed in rather than read here so a test can
+// widen it away and leave the fin event as the only thing that can end a run.
+const streamPollTick = 1 * time.Second
+
 // maxGapWidth caps enumerated missing seqs (per gap and cumulatively) so a buggy or
 // hostile server can't spin the CLI or grow the skipped/missing slices without bound.
 // var, not const, so tests can lower it.
@@ -384,7 +389,7 @@ func runCommandStreamingWithWriter(ac *client.AlpaconClient, serverName, command
 	}
 	listener.setCommandID(cmdResp.ID)
 
-	return streamSubscribed(ac, session, listener, cmdResp.ID, cmdResp.Server.ID, out, execTimeout(), false)
+	return streamSubscribed(ac, session, listener, cmdResp.ID, cmdResp.Server.ID, out, execTimeout(), streamPollTick, false)
 }
 
 // StreamApprovedCommand resubscribes to an already-submitted command and streams
@@ -409,13 +414,13 @@ func StreamApprovedCommand(ac *client.AlpaconClient, cmdID string, out io.Writer
 	if details, derr := GetCommandByID(ac, cmdID); derr == nil {
 		serverID = details.Server.ID
 	}
-	return streamSubscribed(ac, session, listener, cmdID, serverID, out, timeout, true)
+	return streamSubscribed(ac, session, listener, cmdID, serverID, out, timeout, streamPollTick, true)
 }
 
 // streamSubscribed subscribes to cmdID's output channel, warm-fires persisted
 // chunks, then writes live chunks to out until the command reaches a terminal
 // state. Shared by the fresh-submit and approval-resume paths.
-func streamSubscribed(ac *client.AlpaconClient, session *EventSessionResponse, listener *CommandOutputListener, cmdID, serverID string, out io.Writer, timeout time.Duration, waitApproval bool) error {
+func streamSubscribed(ac *client.AlpaconClient, session *EventSessionResponse, listener *CommandOutputListener, cmdID, serverID string, out io.Writer, timeout, tick time.Duration, waitApproval bool) error {
 	if err := SubscribeEvent(ac, session.ChannelID, EventTypeCommandOutput, cmdID); err != nil {
 		listener.Stop()
 		return runCommandFallbackFromID(ac, cmdID, out, waitApproval, err)
@@ -448,7 +453,7 @@ func streamSubscribed(ac *client.AlpaconClient, session *EventSessionResponse, l
 	pollResult := make(chan EventDetails, 1)
 	pollErr := make(chan error, 1)
 	go func() {
-		details, err := pollCommandExecution(ac, cmdID, timeout, 1*time.Second, waitApproval)
+		details, err := pollCommandExecution(ac, cmdID, timeout, tick, waitApproval)
 		if err != nil {
 			pollErr <- err
 			return

--- a/api/event/event.go
+++ b/api/event/event.go
@@ -280,8 +280,8 @@ func GetCommandByID(ac *client.AlpaconClient, cmdID string) (EventDetails, error
 }
 
 // PollCommandExecution polls with default timeout/tick; tests use pollCommandExecution directly.
-func PollCommandExecution(ac *client.AlpaconClient, cmdId string) (EventDetails, error) {
-	return pollCommandExecution(ac, cmdId, execTimeout(), 1*time.Second, false, pollSeams{})
+func PollCommandExecution(ac *client.AlpaconClient, cmdID string) (EventDetails, error) {
+	return pollCommandExecution(ac, cmdID, execTimeout(), 1*time.Second, false, pollSeams{})
 }
 
 func execTimeout() time.Duration {
@@ -336,7 +336,7 @@ func isPollWaitStatus(status string, waitApproval bool) bool {
 // pollMaxThrottleExtensions grants, whichever binds first, plus one backoff wait—so
 // an approved job resumes streaming. Without it the hold is terminal
 // (PendingApprovalError). A closed seams.cancel ends the poll with errPollCancelled.
-func pollCommandExecution(ac *client.AlpaconClient, cmdId string, timeout, tick time.Duration, waitApproval bool, seams pollSeams) (EventDetails, error) {
+func pollCommandExecution(ac *client.AlpaconClient, cmdID string, timeout, tick time.Duration, waitApproval bool, seams pollSeams) (EventDetails, error) {
 	var response EventDetails
 
 	started := seams.Now()
@@ -367,7 +367,7 @@ func pollCommandExecution(ac *client.AlpaconClient, cmdId string, timeout, tick 
 			return response, &ClientTimeoutError{}
 		}
 
-		responseBody, err := ac.SendGetRequest(utils.BuildURL(getEventURL, cmdId, nil))
+		responseBody, err := ac.SendGetRequest(utils.BuildURL(getEventURL, cmdID, nil))
 		if err != nil {
 			delay = nextPollBackoff(tick, failures, utils.RetryAfter(err))
 			failures++

--- a/api/event/event.go
+++ b/api/event/event.go
@@ -384,7 +384,7 @@ func runCommandStreamingWithWriter(ac *client.AlpaconClient, serverName, command
 	}
 	listener.setCommandID(cmdResp.ID)
 
-	return streamSubscribed(ac, session, listener, cmdResp.ID, out, execTimeout(), false)
+	return streamSubscribed(ac, session, listener, cmdResp.ID, cmdResp.Server.ID, out, execTimeout(), false)
 }
 
 // StreamApprovedCommand resubscribes to an already-submitted command and streams
@@ -403,16 +403,28 @@ func StreamApprovedCommand(ac *client.AlpaconClient, cmdID string, out io.Writer
 		listener.Stop()
 		return runCommandFallbackFromID(ac, cmdID, out, true, fmt.Errorf("event websocket connect timeout"))
 	}
-	return streamSubscribed(ac, session, listener, cmdID, out, timeout, true)
+	// The fin event targets the server, which only the command itself names here.
+	// A failed read just skips the subscription; the poll still ends the run.
+	serverID := ""
+	if details, derr := GetCommandByID(ac, cmdID); derr == nil {
+		serverID = details.Server.ID
+	}
+	return streamSubscribed(ac, session, listener, cmdID, serverID, out, timeout, true)
 }
 
 // streamSubscribed subscribes to cmdID's output channel, warm-fires persisted
 // chunks, then writes live chunks to out until the command reaches a terminal
 // state. Shared by the fresh-submit and approval-resume paths.
-func streamSubscribed(ac *client.AlpaconClient, session *EventSessionResponse, listener *CommandOutputListener, cmdID string, out io.Writer, timeout time.Duration, waitApproval bool) error {
+func streamSubscribed(ac *client.AlpaconClient, session *EventSessionResponse, listener *CommandOutputListener, cmdID, serverID string, out io.Writer, timeout time.Duration, waitApproval bool) error {
 	if err := SubscribeEvent(ac, session.ChannelID, EventTypeCommandOutput, cmdID); err != nil {
 		listener.Stop()
 		return runCommandFallbackFromID(ac, cmdID, out, waitApproval, err)
+	}
+	// Chunks carry no end marker, so without this the exit waits for the poll below
+	// to notice—a widening gap, up to 10 ticks once the command is a minute old.
+	// Best effort: on failure that poll stays the only terminal signal, as before.
+	if serverID != "" {
+		_ = SubscribeEvent(ac, session.ChannelID, EventTypeCommandFin, serverID)
 	}
 
 	// Warm-fire: drain any chunks already persisted. Advance lastSeq only over
@@ -444,23 +456,37 @@ func streamSubscribed(ac *client.AlpaconClient, session *EventSessionResponse, l
 		pollResult <- details
 	}()
 
+	// Runs on whichever terminal signal arrives first, the fin event or the poll.
+	finish := func(details EventDetails) error {
+		lastSeq = drainRemainingChunks(ac, cmdID, lastSeq, out)
+		gap.recoverSkipped(ac, cmdID, out)
+		listener.Stop()
+		// If nothing was ever streamed (no WS chunks, none persisted), fall back
+		// to the buffered Result so output is never silently dropped. On a normal
+		// streamed run lastSeq has advanced and this is skipped.
+		if lastSeq < 0 && details.Result != "" {
+			_, _ = fmt.Fprint(out, details.Result)
+		}
+		// Output is already streamed; errorFromDetails keeps it on the error
+		// for inspection (e.g. sudo-denial hint) but cmd/exec never reprints it.
+		return errorFromDetails(details)
+	}
+
 	for {
 		select {
 		case chunk := <-listener.Chunks():
 			lastSeq = applyChunk(ac, cmdID, lastSeq, chunk, out, gap)
-		case details := <-pollResult:
-			lastSeq = drainRemainingChunks(ac, cmdID, lastSeq, out)
-			gap.recoverSkipped(ac, cmdID, out)
-			listener.Stop()
-			// If nothing was ever streamed (no WS chunks, none persisted), fall back
-			// to the buffered Result so output is never silently dropped. On a normal
-			// streamed run lastSeq has advanced and this is skipped.
-			if lastSeq < 0 && details.Result != "" {
-				_, _ = fmt.Fprint(out, details.Result)
+		case <-listener.Finished():
+			// fin says only that it is over; the exit code lives on the command
+			// itself. A failed read, or one racing a state not yet written, leaves
+			// the poll as the net rather than reporting a half-finished run.
+			details, err := GetCommandByID(ac, cmdID)
+			if err != nil || IsRunningStatus(details.Status) {
+				continue
 			}
-			// Output is already streamed; errorFromDetails keeps it on the error
-			// for inspection (e.g. sudo-denial hint) but cmd/exec never reprints it.
-			return errorFromDetails(details)
+			return finish(details)
+		case details := <-pollResult:
+			return finish(details)
 		case err := <-pollErr:
 			listener.Stop()
 			// --wait elapsed while still parked: keep the exit-4 pending contract

--- a/api/event/event.go
+++ b/api/event/event.go
@@ -297,6 +297,7 @@ func pollCommandExecution(ac *client.AlpaconClient, cmdId string, timeout, tick 
 	delay := tick
 	failures := 0
 	throttledWait := time.Duration(0)
+	throttleWarned := false
 
 	for {
 		pollSleep(delay)
@@ -308,12 +309,20 @@ func pollCommandExecution(ac *client.AlpaconClient, cmdId string, timeout, tick 
 		if err != nil {
 			delay = nextPollBackoff(tick, failures, utils.RetryAfter(err))
 			failures++
-			if utils.HTTPStatusCode(err) == http.StatusTooManyRequests && throttledWait < timeout {
+			if utils.HTTPStatusCode(err) == http.StatusTooManyRequests {
+				if !throttleWarned {
+					// The wait can reach two timeouts, and nothing else on this path
+					// prints while it lasts.
+					throttleWarned = true
+					utils.CliWarning("rate limited by the server, retrying in %s", delay)
+				}
 				// The server is alive: the command may be done, only its result GET refused.
 				// Capped at one more timeout, so a token stuck over quota still gives up:
 				// extending by exactly the wait would otherwise keep the deadline ahead forever.
-				deadline = deadline.Add(delay)
-				throttledWait += delay
+				if throttledWait < timeout {
+					deadline = deadline.Add(delay)
+					throttledWait += delay
+				}
 			}
 			continue
 		}

--- a/api/event/event.go
+++ b/api/event/event.go
@@ -31,12 +31,12 @@ const (
 	pollBackoffFactor  = 2
 	pollMaxBackoffTick = 60
 
-	// Grants of extra deadline for time lost to 429s, bounded by count as well as by
-	// duration. A duration budget alone is spent at whatever pace the server asks
-	// for, so a flat Retry-After: 1 would buy a second full window of one-second
-	// polls—double the requests this pacing exists to cut. 60 grants covers an entire
-	// quota window at the capped 60-tick wait, so only a throttle asking for waits
-	// far shorter than it needs reaches this bound.
+	// Grants of extra deadline for time lost to 429s, capped by count as well as
+	// duration: a duration budget is spent at whatever pace the server asks for, so a
+	// flat Retry-After: 1 buys a second window of one-second polls. 60 grants at the
+	// capped 60-tick wait is 3,600 ticks—a whole quota window at the default
+	// one-second tick—so the duration budget binds first at the cap and this bound
+	// only catches a throttle asking for less.
 	pollMaxThrottleExtensions = 60
 
 	// Base gap the pacing above multiplies, for the poll running behind a live
@@ -333,10 +333,9 @@ func isPollWaitStatus(status string, waitApproval bool) bool {
 
 // waitApproval polls through the awaiting_approval hold—bounded by timeout, which
 // the hold never resets and throttled waits extend by at most one timeout or
-// pollMaxThrottleExtensions grants, whichever binds first, plus one backoff
-// wait—so an approved job resumes streaming. Without it the hold is
-// terminal (PendingApprovalError). A closed seams.cancel ends the poll with
-// errPollCancelled.
+// pollMaxThrottleExtensions grants, whichever binds first, plus one backoff wait—so
+// an approved job resumes streaming. Without it the hold is terminal
+// (PendingApprovalError). A closed seams.cancel ends the poll with errPollCancelled.
 func pollCommandExecution(ac *client.AlpaconClient, cmdId string, timeout, tick time.Duration, waitApproval bool, seams pollSeams) (EventDetails, error) {
 	var response EventDetails
 
@@ -381,11 +380,8 @@ func pollCommandExecution(ac *client.AlpaconClient, cmdId string, timeout, tick 
 				}
 				// The server is alive: the command may be done, only its result GET refused.
 				// Budgeted so a token stuck over quota gives up—extending by exactly the
-				// wait would keep the deadline ahead forever. Bounded on the number of
-				// grants too, since the duration budget alone lets a server that asks for
-				// short waits trade the whole extension for a request storm. The last
-				// extension is granted whole rather than trimmed, so every mandated wait
-				// still buys its poll.
+				// wait would keep the deadline ahead forever. The last extension is granted
+				// whole rather than trimmed, so every mandated wait still buys its poll.
 				if throttledWait < timeout && throttleExtensions < pollMaxThrottleExtensions {
 					deadline = deadline.Add(delay)
 					throttledWait += delay

--- a/api/event/event.go
+++ b/api/event/event.go
@@ -31,6 +31,14 @@ const (
 	pollBackoffFactor  = 2
 	pollMaxBackoffTick = 60
 
+	// Grants of extra deadline for time lost to 429s, bounded by count as well as by
+	// duration. A duration budget alone is spent at whatever pace the server asks
+	// for, so a flat Retry-After: 1 would buy a second full window of one-second
+	// polls—double the requests this pacing exists to cut. 60 grants covers an entire
+	// quota window at the capped 60-tick wait, so only a throttle asking for waits
+	// far shorter than it needs reaches this bound.
+	pollMaxThrottleExtensions = 60
+
 	// Base gap the pacing above multiplies, for the poll running behind a live
 	// stream.
 	streamPollTick = time.Second
@@ -324,8 +332,9 @@ func isPollWaitStatus(status string, waitApproval bool) bool {
 }
 
 // waitApproval polls through the awaiting_approval hold—bounded by timeout, which
-// the hold never resets and throttled waits extend by at most one timeout plus one
-// backoff wait—so an approved job resumes streaming. Without it the hold is
+// the hold never resets and throttled waits extend by at most one timeout or
+// pollMaxThrottleExtensions grants, whichever binds first, plus one backoff
+// wait—so an approved job resumes streaming. Without it the hold is
 // terminal (PendingApprovalError). A closed seams.cancel ends the poll with
 // errPollCancelled.
 func pollCommandExecution(ac *client.AlpaconClient, cmdId string, timeout, tick time.Duration, waitApproval bool, seams pollSeams) (EventDetails, error) {
@@ -336,6 +345,7 @@ func pollCommandExecution(ac *client.AlpaconClient, cmdId string, timeout, tick 
 	delay := tick
 	failures := 0
 	throttledWait := time.Duration(0)
+	throttleExtensions := 0
 	throttleWarned := false
 
 	for {
@@ -371,11 +381,15 @@ func pollCommandExecution(ac *client.AlpaconClient, cmdId string, timeout, tick 
 				}
 				// The server is alive: the command may be done, only its result GET refused.
 				// Budgeted so a token stuck over quota gives up—extending by exactly the
-				// wait would keep the deadline ahead forever. The last extension is granted
-				// whole rather than trimmed, so every mandated wait still buys its poll.
-				if throttledWait < timeout {
+				// wait would keep the deadline ahead forever. Bounded on the number of
+				// grants too, since the duration budget alone lets a server that asks for
+				// short waits trade the whole extension for a request storm. The last
+				// extension is granted whole rather than trimmed, so every mandated wait
+				// still buys its poll.
+				if throttledWait < timeout && throttleExtensions < pollMaxThrottleExtensions {
 					deadline = deadline.Add(delay)
 					throttledWait += delay
+					throttleExtensions++
 				}
 			}
 			continue
@@ -391,6 +405,7 @@ func pollCommandExecution(ac *client.AlpaconClient, cmdId string, timeout, tick 
 			// throttle late in a long command is not paid for by an earlier one—and
 			// the warning with it, so a later stretch is not silent.
 			throttledWait = 0
+			throttleExtensions = 0
 			throttleWarned = false
 			delay = nextPollTick(tick, seams.Now().Sub(started))
 			continue

--- a/api/event/event.go
+++ b/api/event/event.go
@@ -353,8 +353,10 @@ func pollCommandExecution(ac *client.AlpaconClient, cmdId string, timeout, tick 
 		if IsRunningStatus(response.Status) {
 			deadline = pollNow().Add(timeout)
 			// The refreshed deadline gets its throttle allowance back with it, so a
-			// throttle late in a long command is not paid for by an earlier one.
+			// throttle late in a long command is not paid for by an earlier one—and
+			// the warning with it, so a later stretch is not silent.
 			throttledWait = 0
+			throttleWarned = false
 			delay = nextPollTick(tick, pollNow().Sub(started))
 			continue
 		}

--- a/api/event/event.go
+++ b/api/event/event.go
@@ -30,12 +30,12 @@ const (
 	pollSlowTick       = 10
 	pollBackoffFactor  = 2
 	pollMaxBackoffTick = 60
-)
 
-// streamPollTick is the base gap for the status poll behind a live stream, the
-// one the pacing above multiplies. Passed in rather than read here so a test can
-// widen it away and leave the fin event as the only thing that can end a run.
-const streamPollTick = 1 * time.Second
+	// Base gap the pacing above multiplies, for the poll running behind a live
+	// stream. Passed to streamSubscribed rather than read there, so a test can
+	// widen it away and leave the fin event as the only thing that ends a run.
+	streamPollTick = time.Second
+)
 
 // maxGapWidth caps enumerated missing seqs (per gap and cumulatively) so a buggy or
 // hostile server can't spin the CLI or grow the skipped/missing slices without bound.
@@ -293,7 +293,8 @@ func nextPollBackoff(tick time.Duration, attempt int, retryAfter time.Duration) 
 
 // waitApproval polls through the awaiting_approval hold—bounded by timeout, which
 // the hold never resets and throttled waits extend by at most one timeout plus one
-// backoff wait—so an approved job resumes streaming. Without it the hold is terminal (PendingApprovalError).
+// backoff wait—so an approved job resumes streaming. Without it the hold is
+// terminal (PendingApprovalError).
 func pollCommandExecution(ac *client.AlpaconClient, cmdId string, timeout, tick time.Duration, waitApproval bool) (EventDetails, error) {
 	var response EventDetails
 
@@ -305,10 +306,9 @@ func pollCommandExecution(ac *client.AlpaconClient, cmdId string, timeout, tick 
 	throttleWarned := false
 
 	for {
-		// Never sleep past the deadline: at the slow tick that would report the
-		// timeout up to 10 ticks—up to one backoff wait, 60, once throttled—after
-		// the deadline it names. A throttle-extended deadline always leaves the
-		// whole wait, so the retry the wait was for still happens.
+		// Never sleep past the deadline, or the timeout lands a whole gap late—10
+		// ticks at the slow pace, 60 once throttled. An extended deadline always
+		// leaves the whole wait, so a throttled retry still gets its poll.
 		if wait := min(delay, deadline.Sub(pollNow())); wait > 0 {
 			pollSleep(wait)
 		}
@@ -328,11 +328,10 @@ func pollCommandExecution(ac *client.AlpaconClient, cmdId string, timeout, tick 
 					utils.CliWarning("rate limited by the server, retrying in %s", delay)
 				}
 				// The server is alive: the command may be done, only its result GET refused.
-				// Budgeted so a token stuck over quota gives up: extending by exactly the
-				// wait would keep the deadline ahead of the clock forever. The extension
-				// that exhausts the budget is granted whole rather than trimmed to what is
-				// left, so every wait the server mandates still buys the poll it waited
-				// for—the ceiling is one timeout plus one backoff wait.
+				// Budgeted so a token stuck over quota gives up—extending by exactly the
+				// wait would keep the deadline ahead forever. The last extension is granted
+				// whole rather than trimmed, so every mandated wait still buys its poll:
+				// the ceiling is one timeout plus one backoff wait.
 				if throttledWait < timeout {
 					deadline = deadline.Add(delay)
 					throttledWait += delay
@@ -410,24 +409,25 @@ func StreamApprovedCommand(ac *client.AlpaconClient, cmdID string, out io.Writer
 	}
 	// The fin event targets the server, which only the command itself names here.
 	// A failed read just skips the subscription; the poll still ends the run.
-	serverID := ""
-	if details, derr := GetCommandByID(ac, cmdID); derr == nil {
+	var serverID string
+	if details, err := GetCommandByID(ac, cmdID); err == nil {
 		serverID = details.Server.ID
 	}
 	return streamSubscribed(ac, session, listener, cmdID, serverID, out, timeout, streamPollTick, true)
 }
 
-// streamSubscribed subscribes to cmdID's output channel, warm-fires persisted
-// chunks, then writes live chunks to out until the command reaches a terminal
-// state. Shared by the fresh-submit and approval-resume paths.
+// streamSubscribed subscribes to cmdID's output channel and to serverID's fin
+// channel, warm-fires persisted chunks, then writes live chunks to out until the
+// fin event or the poll reports a terminal state. Shared by the fresh-submit and
+// approval-resume paths.
 func streamSubscribed(ac *client.AlpaconClient, session *EventSessionResponse, listener *CommandOutputListener, cmdID, serverID string, out io.Writer, timeout, tick time.Duration, waitApproval bool) error {
 	if err := SubscribeEvent(ac, session.ChannelID, EventTypeCommandOutput, cmdID); err != nil {
 		listener.Stop()
 		return runCommandFallbackFromID(ac, cmdID, out, waitApproval, err)
 	}
 	// Chunks carry no end marker, so without this the exit waits for the poll below
-	// to notice—a widening gap, up to 10 ticks once the command is a minute old.
-	// Best effort: on failure that poll stays the only terminal signal, as before.
+	// to notice—up to 10 ticks once the command is a minute old. Best effort: on
+	// failure that poll stays the only terminal signal, as before.
 	if serverID != "" {
 		_ = SubscribeEvent(ac, session.ChannelID, EventTypeCommandFin, serverID)
 	}
@@ -482,9 +482,9 @@ func streamSubscribed(ac *client.AlpaconClient, session *EventSessionResponse, l
 		case chunk := <-listener.Chunks():
 			lastSeq = applyChunk(ac, cmdID, lastSeq, chunk, out, gap)
 		case <-listener.Finished():
-			// fin says only that it is over; the exit code lives on the command
-			// itself. A failed read, or one racing a state not yet written, leaves
-			// the poll as the net rather than reporting a half-finished run.
+			// fin says only that it is over; the exit code lives on the command. A
+			// failed read, or one racing a state not yet written, leaves the poll as
+			// the net rather than reporting a half-finished run.
 			details, err := GetCommandByID(ac, cmdID)
 			if err != nil || IsRunningStatus(details.Status) {
 				continue

--- a/api/event/event.go
+++ b/api/event/event.go
@@ -291,6 +291,14 @@ func nextPollBackoff(tick time.Duration, attempt int, retryAfter time.Duration) 
 	return delay
 }
 
+// isPollWaitStatus reports a status the poll keeps waiting on: running, or—when
+// resuming through an approval hold—the hold itself and the transient "error"
+// compute_status the server emits in the approve→deliver window.
+func isPollWaitStatus(status string, waitApproval bool) bool {
+	return IsRunningStatus(status) ||
+		(waitApproval && (IsAwaitingApprovalStatus(status) || status == "error"))
+}
+
 // waitApproval polls through the awaiting_approval hold—bounded by timeout, which
 // the hold never resets and throttled waits extend by at most one timeout plus one
 // backoff wait—so an approved job resumes streaming. Without it the hold is
@@ -352,9 +360,8 @@ func pollCommandExecution(ac *client.AlpaconClient, cmdId string, timeout, tick 
 			delay = nextPollTick(tick, pollNow().Sub(started))
 			continue
 		}
-		// Approval-resume keeps polling through the hold and the transient
-		// "error" compute_status the server emits in the approve→deliver window.
-		if waitApproval && (IsAwaitingApprovalStatus(response.Status) || response.Status == "error") {
+		// Running is handled above, so what is left here is the approval hold.
+		if isPollWaitStatus(response.Status, waitApproval) {
 			delay = nextPollTick(tick, pollNow().Sub(started))
 			continue
 		}
@@ -486,7 +493,7 @@ func streamSubscribed(ac *client.AlpaconClient, session *EventSessionResponse, l
 			// failed read, or one racing a state not yet written, leaves the poll as
 			// the net rather than reporting a half-finished run.
 			details, err := GetCommandByID(ac, cmdID)
-			if err != nil || IsRunningStatus(details.Status) {
+			if err != nil || isPollWaitStatus(details.Status, waitApproval) {
 				continue
 			}
 			return finish(details)

--- a/api/event/event.go
+++ b/api/event/event.go
@@ -300,8 +300,14 @@ func pollCommandExecution(ac *client.AlpaconClient, cmdId string, timeout, tick 
 	throttleWarned := false
 
 	for {
-		pollSleep(delay)
-		if pollNow().After(deadline) {
+		// Never sleep past the deadline: at the slow tick that would report the
+		// timeout up to 10 ticks—up to one backoff wait, 60, once throttled—after
+		// the deadline it names. A throttle-extended deadline always leaves the
+		// whole wait, so the retry the wait was for still happens.
+		if wait := min(delay, deadline.Sub(pollNow())); wait > 0 {
+			pollSleep(wait)
+		}
+		if !pollNow().Before(deadline) {
 			return response, &ClientTimeoutError{}
 		}
 

--- a/api/event/event.go
+++ b/api/event/event.go
@@ -287,8 +287,8 @@ func nextPollBackoff(tick time.Duration, attempt int, retryAfter time.Duration) 
 }
 
 // waitApproval polls through the awaiting_approval hold—bounded by timeout, which
-// the hold never resets and only a throttled wait extends—so an approved job
-// resumes streaming. Without it the hold is terminal (PendingApprovalError).
+// the hold never resets and throttled waits extend by at most one more timeout—so
+// an approved job resumes streaming. Without it the hold is terminal (PendingApprovalError).
 func pollCommandExecution(ac *client.AlpaconClient, cmdId string, timeout, tick time.Duration, waitApproval bool) (EventDetails, error) {
 	var response EventDetails
 
@@ -296,6 +296,7 @@ func pollCommandExecution(ac *client.AlpaconClient, cmdId string, timeout, tick 
 	deadline := started.Add(timeout)
 	delay := tick
 	failures := 0
+	throttledWait := time.Duration(0)
 
 	for {
 		pollSleep(delay)
@@ -307,9 +308,12 @@ func pollCommandExecution(ac *client.AlpaconClient, cmdId string, timeout, tick 
 		if err != nil {
 			delay = nextPollBackoff(tick, failures, utils.RetryAfter(err))
 			failures++
-			if utils.HTTPStatusCode(err) == http.StatusTooManyRequests {
+			if utils.HTTPStatusCode(err) == http.StatusTooManyRequests && throttledWait < timeout {
 				// The server is alive: the command may be done, only its result GET refused.
+				// Capped at one more timeout, so a token stuck over quota still gives up:
+				// extending by exactly the wait would otherwise keep the deadline ahead forever.
 				deadline = deadline.Add(delay)
+				throttledWait += delay
 			}
 			continue
 		}

--- a/api/event/event.go
+++ b/api/event/event.go
@@ -333,6 +333,9 @@ func pollCommandExecution(ac *client.AlpaconClient, cmdId string, timeout, tick 
 
 		if IsRunningStatus(response.Status) {
 			deadline = pollNow().Add(timeout)
+			// The refreshed deadline gets its throttle allowance back with it, so a
+			// throttle late in a long command is not paid for by an earlier one.
+			throttledWait = 0
 			delay = nextPollTick(tick, pollNow().Sub(started))
 			continue
 		}

--- a/api/event/event_test.go
+++ b/api/event/event_test.go
@@ -741,6 +741,42 @@ func TestRunCommandStreaming_NormalFlow(t *testing.T) {
 	assert.Equal(t, "hello\nworld\n", stdoutBuf.String())
 }
 
+// Chunks carry no end marker, so the poll is otherwise the only thing that notices
+// a finished command—a tick away at best, ten once the command is a minute old. The
+// fin event ends the run as soon as the server reports it.
+func TestRunCommandStreaming_FinEventEndsRunBeforeNextPoll(t *testing.T) {
+	stdoutBuf := &bytes.Buffer{}
+	var mu sync.Mutex
+	var subscriptions [][2]string
+	ac := newStreamingServers(t, streamingServerConfig{
+		cmdID:    "cmd-uuid",
+		serverID: "srv-uuid",
+		wsFinFor: "cmd-uuid",
+		onSubscribe: func(eventType, targetID string) {
+			mu.Lock()
+			defer mu.Unlock()
+			subscriptions = append(subscriptions, [2]string{eventType, targetID})
+		},
+		// A command that prints nothing—the case that started #309—so the run can
+		// only end on a terminal signal, never on output.
+		terminal: EventDetails{Status: "completed", Success: boolPtr(true), Result: "done\n"},
+	})
+
+	started := time.Now()
+	err := runCommandStreamingWithWriter(ac, "srv", "manage.py migrate", "", "", nil, "", stdoutBuf)
+	require.NoError(t, err)
+	assert.Equal(t, "done\n", stdoutBuf.String())
+	// The poll sleeps a tick before its first request, so a run that took one ended
+	// on the poll and the fin event bought nothing.
+	assert.Less(t, time.Since(started), 500*time.Millisecond,
+		"the fin event must end the run without waiting for the poll tick")
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Contains(t, subscriptions, [2]string{EventTypeCommandFin, "srv-uuid"},
+		"fin is published against the server, so that is what the subscription targets")
+}
+
 func TestRunCommandStreaming_GapFilledByREST(t *testing.T) {
 	stdoutBuf := &bytes.Buffer{}
 	ac := newStreamingServers(t, streamingServerConfig{
@@ -1084,10 +1120,12 @@ type streamingServerConfig struct {
 	cmdID        string
 	serverID     string
 	wsChunks     []ChunkEvent      // emitted over the WS once subscribed
+	wsFinFor     string            // command id of a command_fin frame sent after the chunks; none when empty
 	chunksFor    func(int) []Chunk // REST chunk endpoint, keyed by seq__gte (warm-fire / gap-fill / drain)
-	heldPolls    int               // number of "awaiting_approval" detail polls before running
-	runningPolls int               // number of "running" detail polls before the terminal one
-	terminal     EventDetails      // returned by the detail poll once held+running elapse
+	onSubscribe  func(eventType, targetID string)
+	heldPolls    int          // number of "awaiting_approval" detail polls before running
+	runningPolls int          // number of "running" detail polls before the terminal one
+	terminal     EventDetails // returned by the detail poll once held+running elapse
 }
 
 // newStreamingServers starts a WS + API server pair and returns a client for
@@ -1116,6 +1154,13 @@ func newStreamingServers(t *testing.T, cfg streamingServerConfig) *client.Alpaco
 			b, _ := json.Marshal(env)
 			_ = conn.WriteMessage(websocket.TextMessage, b)
 		}
+		if cfg.wsFinFor != "" {
+			b, _ := json.Marshal(map[string]any{
+				"event_type": "command_fin",
+				"payload":    map[string]any{"type": "event", "id": cfg.wsFinFor},
+			})
+			_ = conn.WriteMessage(websocket.TextMessage, b)
+		}
 		for {
 			if _, _, err := conn.ReadMessage(); err != nil {
 				return
@@ -1135,8 +1180,13 @@ func newStreamingServers(t *testing.T, cfg streamingServerConfig) *client.Alpaco
 		case r.URL.Path == "/api/events/sessions/" && r.Method == http.MethodPost:
 			_, _ = w.Write([]byte(`{"id":"s","websocket_url":"` + wsURL + `","channel_id":"ch"}`))
 		case r.URL.Path == "/api/events/commands/" && r.Method == http.MethodPost:
-			_, _ = w.Write([]byte(`[{"id":"` + cfg.cmdID + `"}]`))
+			_, _ = w.Write([]byte(`[{"id":"` + cfg.cmdID + `","server":{"id":"` + cfg.serverID + `"}}]`))
 		case r.URL.Path == "/api/events/subscriptions/" && r.Method == http.MethodPost:
+			if cfg.onSubscribe != nil {
+				var req EventSubscriptionRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				cfg.onSubscribe(string(req.EventType), req.TargetID)
+			}
 			subOnce.Do(func() { close(subscribed) })
 			w.WriteHeader(http.StatusCreated)
 			_, _ = w.Write([]byte(`{}`))
@@ -1153,15 +1203,16 @@ func newStreamingServers(t *testing.T, cfg streamingServerConfig) *client.Alpaco
 			n := pollCount
 			mu.Unlock()
 			if n <= cfg.heldPolls {
-				_, _ = w.Write([]byte(`{"id":"` + cfg.cmdID + `","status":"awaiting_approval"}`))
+				_, _ = w.Write([]byte(`{"id":"` + cfg.cmdID + `","status":"awaiting_approval","server":{"id":"` + cfg.serverID + `"}}`))
 				return
 			}
 			if n <= cfg.heldPolls+cfg.runningPolls {
-				_, _ = w.Write([]byte(`{"id":"` + cfg.cmdID + `","status":"running"}`))
+				_, _ = w.Write([]byte(`{"id":"` + cfg.cmdID + `","status":"running","server":{"id":"` + cfg.serverID + `"}}`))
 				return
 			}
 			term := cfg.terminal
 			term.ID = cfg.cmdID
+			term.Server.ID = cfg.serverID
 			_ = json.NewEncoder(w).Encode(term)
 		default:
 			t.Logf("unexpected request: %s %s", r.Method, r.URL.Path)

--- a/api/event/event_test.go
+++ b/api/event/event_test.go
@@ -353,10 +353,17 @@ func TestPollCommandExecution_WaitApprovalResumesAfterApproval(t *testing.T) {
 
 func TestStreamApprovedCommand_StreamsAfterApproval(t *testing.T) {
 	stdoutBuf := &bytes.Buffer{}
+	var mu sync.Mutex
+	var subscriptions [][2]string
 	ac := newStreamingServers(t, streamingServerConfig{
 		cmdID:    "cmd-uuid",
 		serverID: "srv-uuid",
 		wsChunks: []ChunkEvent{{Seq: 0, Content: "approved\n"}},
+		onSubscribe: func(eventType, targetID string) {
+			mu.Lock()
+			defer mu.Unlock()
+			subscriptions = append(subscriptions, [2]string{eventType, targetID})
+		},
 		// One for StreamApprovedCommand's server-id lookup, two for the poll loop.
 		heldPolls:    3,
 		runningPolls: 1,
@@ -366,6 +373,14 @@ func TestStreamApprovedCommand_StreamsAfterApproval(t *testing.T) {
 	err := StreamApprovedCommand(ac, "cmd-uuid", stdoutBuf, 30*time.Second)
 	require.NoError(t, err)
 	assert.Equal(t, "approved\n", stdoutBuf.String())
+
+	mu.Lock()
+	defer mu.Unlock()
+	// The server comes from the lookup, the only thing on this path that names it.
+	assert.Equal(t, [][2]string{
+		{EventTypeCommandOutput, "cmd-uuid"},
+		{EventTypeCommandFin, "srv-uuid"},
+	}, subscriptions)
 }
 
 // The fin subscription needs the server the command ran on, which only a read of
@@ -855,6 +870,34 @@ func TestStreamSubscribed_FinCancelsThePoll(t *testing.T) {
 	atEnd := details.Load()
 	time.Sleep(5 * tick)
 	assert.Equal(t, atEnd, details.Load(), "the poll must stop with the run, not keep requesting")
+}
+
+// The fin channel is the command's server, which on this path only the submit
+// response names—the command's own id would subscribe to nothing that fires.
+func TestRunCommandStreaming_FinSubscriptionTargetsTheCommandsServer(t *testing.T) {
+	var mu sync.Mutex
+	var subscriptions [][2]string
+	ac := newStreamingServers(t, streamingServerConfig{
+		cmdID:    "cmd-uuid",
+		serverID: "srv-uuid",
+		wsFinFor: "cmd-uuid",
+		onSubscribe: func(eventType, targetID string) {
+			mu.Lock()
+			defer mu.Unlock()
+			subscriptions = append(subscriptions, [2]string{eventType, targetID})
+		},
+		terminal: EventDetails{Status: "completed", Success: boolPtr(true), Result: "done\n"},
+	})
+
+	err := runCommandStreamingWithWriter(ac, "srv", "echo hi", "", "", nil, "", &bytes.Buffer{})
+	require.NoError(t, err)
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Equal(t, [][2]string{
+		{EventTypeCommandOutput, "cmd-uuid"},
+		{EventTypeCommandFin, "srv-uuid"},
+	}, subscriptions)
 }
 
 // A fin racing a status the server has not written yet must not end the run on a

--- a/api/event/event_test.go
+++ b/api/event/event_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -371,8 +372,8 @@ func strPtr(s string) *string { return &s }
 
 func TestPollCommandExecution_ClientTimeout(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// Always fail GETs so SendGetRequest returns an error and the poll
-		// loop never resets its timer.
+		// Always fail GETs so SendGetRequest returns an error, and with a status
+		// that is not 429 so the poll loop never extends its deadline.
 		http.Error(w, "boom", http.StatusInternalServerError)
 	}))
 	defer ts.Close()
@@ -383,7 +384,7 @@ func TestPollCommandExecution_ClientTimeout(t *testing.T) {
 
 	var clientTimeout *ClientTimeoutError
 	require.True(t, errors.As(err, &clientTimeout),
-		"timer expiry must surface a *ClientTimeoutError, got %T: %v", err, err)
+		"deadline expiry must surface a *ClientTimeoutError, got %T: %v", err, err)
 }
 
 func TestNextPollTick(t *testing.T) {
@@ -523,6 +524,25 @@ func TestPollCommandExecution_ThrottleDoesNotStarveDeadline(t *testing.T) {
 	assert.Equal(t, int32(2), reqCount.Load(),
 		"the result must come from the retry after the throttled wait, not from retrying through it")
 	assert.Equal(t, []time.Duration{5 * time.Millisecond, 300 * time.Millisecond}, delays())
+}
+
+// Extending the deadline by exactly the wait keeps it ahead of the clock forever,
+// so the extension is capped: a token stuck over quota has to give up.
+func TestPollCommandExecution_ThrottleExtensionIsBounded(t *testing.T) {
+	ts, reqCount := throttleServer(t, math.MaxInt, "1")
+	defer ts.Close()
+
+	delays := fakePollClock(t)
+
+	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
+	_, err := pollCommandExecution(ac, "cmd-1", 100*time.Millisecond, 5*time.Millisecond, false)
+
+	var clientTimeout *ClientTimeoutError
+	require.True(t, errors.As(err, &clientTimeout),
+		"a permanently throttled poll must surface a *ClientTimeoutError, got %T: %v", err, err)
+	// One 300ms extension spends the 100ms budget; the second wait runs past the deadline.
+	assert.Equal(t, int32(2), reqCount.Load())
+	assert.Equal(t, []time.Duration{5 * time.Millisecond, 300 * time.Millisecond, 300 * time.Millisecond}, delays())
 }
 
 func TestPollCommandExecution_TerminalStatusReturnsBeforeTimeout(t *testing.T) {

--- a/api/event/event_test.go
+++ b/api/event/event_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -575,6 +576,38 @@ func TestPollCommandExecution_ProgressRestoresThrottleAllowance(t *testing.T) {
 	assert.Equal(t, []time.Duration{
 		5 * time.Millisecond, 300 * time.Millisecond, 50 * time.Millisecond, 300 * time.Millisecond,
 	}, delays())
+}
+
+// The loop paces by how long the poll has been running, not by the gap since the
+// last poll—measured the latter way a command never leaves the fast window.
+func TestPollCommandExecution_PacingWidensWithCommandAge(t *testing.T) {
+	tick := 10 * time.Millisecond
+	// The 21st request answers terminal, so the reply that earns the slow tick is
+	// still polled for.
+	const running = 20
+
+	reqCount := &atomic.Int32{}
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		status := "completed"
+		if int(reqCount.Add(1)) <= running {
+			status = "running"
+		}
+		_ = json.NewEncoder(w).Encode(EventDetails{ID: "cmd-1", Status: status})
+	}))
+	defer ts.Close()
+
+	delays := fakePollClock(t)
+
+	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
+	resp, err := pollCommandExecution(ac, "cmd-1", time.Hour, tick, false)
+	require.NoError(t, err)
+	assert.Equal(t, "completed", resp.Status)
+	assert.Equal(t, slices.Concat(
+		slices.Repeat([]time.Duration{tick}, 10),
+		slices.Repeat([]time.Duration{5 * tick}, 10),
+		[]time.Duration{10 * tick},
+	), delays())
 }
 
 func TestPollCommandExecution_TerminalStatusReturnsBeforeTimeout(t *testing.T) {

--- a/api/event/event_test.go
+++ b/api/event/event_test.go
@@ -697,7 +697,7 @@ func TestPollCommandExecution_ProgressRestoresThrottleExtensions(t *testing.T) {
 
 // The loop paces by how long the poll has been running, not by the gap since the
 // last poll—measured the latter way a command never leaves the fast window.
-func TestPollCommandExecution_PacingWidensWithCommandAge(t *testing.T) {
+func TestPollCommandExecution_PacingWidensWithPollAge(t *testing.T) {
 	tick := 10 * time.Millisecond
 	// The 21st request answers terminal, so the reply that earns the slow tick is
 	// still polled for.

--- a/api/event/event_test.go
+++ b/api/event/event_test.go
@@ -742,10 +742,41 @@ func TestRunCommandStreaming_NormalFlow(t *testing.T) {
 	assert.Equal(t, "hello\nworld\n", stdoutBuf.String())
 }
 
+// startStream wires a session and listener the way the streaming entry points do,
+// so a test can hand streamSubscribed a poll tick of its own choosing.
+func startStream(t *testing.T, ac *client.AlpaconClient, cmdID, serverID string, out io.Writer, tick time.Duration) <-chan error {
+	t.Helper()
+	session, err := CreateEventSession(ac)
+	require.NoError(t, err)
+	listener := NewCommandOutputListener(ac, session.WebsocketURL, cmdID)
+	listener.Start()
+	require.True(t, listener.WaitConnected(commandOutputConnectTimeout), "listener should connect")
+
+	done := make(chan error, 1)
+	go func() {
+		done <- streamSubscribed(ac, session, listener, cmdID, serverID, out, 30*time.Second, tick, false)
+	}()
+	return done
+}
+
+// awaitStream fails the test rather than letting a run that never ends hang until
+// the package timeout.
+func awaitStream(t *testing.T, done <-chan error) error {
+	t.Helper()
+	select {
+	case err := <-done:
+		return err
+	case <-time.After(10 * time.Second):
+		t.Fatal("the run never ended")
+		return nil
+	}
+}
+
 // Chunks carry no end marker, so the poll is otherwise the only thing that notices
 // a finished command—a tick away at best, ten once the command is a minute old. The
-// fin event ends the run as soon as the server reports it.
-func TestRunCommandStreaming_FinEventEndsRunBeforeNextPoll(t *testing.T) {
+// fin event ends the run as soon as the server reports it. The poll tick here is
+// longer than the test can possibly run, so nothing but the fin can end this.
+func TestStreamSubscribed_FinEndsRunWithoutThePoll(t *testing.T) {
 	stdoutBuf := &bytes.Buffer{}
 	var mu sync.Mutex
 	var subscriptions [][2]string
@@ -763,14 +794,9 @@ func TestRunCommandStreaming_FinEventEndsRunBeforeNextPoll(t *testing.T) {
 		terminal: EventDetails{Status: "completed", Success: boolPtr(true), Result: "done\n"},
 	})
 
-	started := time.Now()
-	err := runCommandStreamingWithWriter(ac, "srv", "manage.py migrate", "", "", nil, "", stdoutBuf)
+	err := awaitStream(t, startStream(t, ac, "cmd-uuid", "srv-uuid", stdoutBuf, time.Hour))
 	require.NoError(t, err)
 	assert.Equal(t, "done\n", stdoutBuf.String())
-	// The poll sleeps a tick before its first request, so a run that took one ended
-	// on the poll and the fin event bought nothing.
-	assert.Less(t, time.Since(started), 500*time.Millisecond,
-		"the fin event must end the run without waiting for the poll tick")
 
 	mu.Lock()
 	defer mu.Unlock()
@@ -779,44 +805,46 @@ func TestRunCommandStreaming_FinEventEndsRunBeforeNextPoll(t *testing.T) {
 }
 
 // A fin racing a status the server has not written yet must not end the run on a
-// half-finished read: the poll picks it up a tick later instead.
-func TestRunCommandStreaming_FinOnStillRunningStatusWaitsForPoll(t *testing.T) {
+// half-finished read: the poll picks it up on its next tick instead.
+func TestStreamSubscribed_FinOnStillRunningStatusWaitsForPoll(t *testing.T) {
 	stdoutBuf := &bytes.Buffer{}
+	details := &atomic.Int32{}
 	ac := newStreamingServers(t, streamingServerConfig{
 		cmdID:    "cmd-uuid",
 		serverID: "srv-uuid",
 		wsFinFor: "cmd-uuid",
+		onDetail: func(int) { details.Add(1) },
 		// The fin arrives before the first poll, so this "running" is the read the
 		// fin triggers; the terminal one goes to the poll.
 		runningPolls: 1,
 		terminal:     EventDetails{Status: "completed", Success: boolPtr(true), Result: "done\n"},
 	})
 
-	started := time.Now()
-	err := runCommandStreamingWithWriter(ac, "srv", "manage.py migrate", "", "", nil, "", stdoutBuf)
+	err := awaitStream(t, startStream(t, ac, "cmd-uuid", "srv-uuid", stdoutBuf, 100*time.Millisecond))
 	require.NoError(t, err)
 	assert.Equal(t, "done\n", stdoutBuf.String())
-	assert.GreaterOrEqual(t, time.Since(started), time.Second,
-		"the run must have ended on the poll, one tick later, not on the running read")
+	assert.GreaterOrEqual(t, details.Load(), int32(2),
+		"the running read must not have ended the run: a second read, the poll's, did")
 }
 
 // Same fallback when the read the fin triggers fails outright.
-func TestRunCommandStreaming_FinWithFailedReadWaitsForPoll(t *testing.T) {
+func TestStreamSubscribed_FinWithFailedReadWaitsForPoll(t *testing.T) {
 	stdoutBuf := &bytes.Buffer{}
+	details := &atomic.Int32{}
 	ac := newStreamingServers(t, streamingServerConfig{
 		cmdID:       "cmd-uuid",
 		serverID:    "srv-uuid",
 		wsFinFor:    "cmd-uuid",
+		onDetail:    func(int) { details.Add(1) },
 		detailFails: 1,
 		terminal:    EventDetails{Status: "completed", Success: boolPtr(true), Result: "done\n"},
 	})
 
-	started := time.Now()
-	err := runCommandStreamingWithWriter(ac, "srv", "manage.py migrate", "", "", nil, "", stdoutBuf)
+	err := awaitStream(t, startStream(t, ac, "cmd-uuid", "srv-uuid", stdoutBuf, 100*time.Millisecond))
 	require.NoError(t, err)
 	assert.Equal(t, "done\n", stdoutBuf.String())
-	assert.GreaterOrEqual(t, time.Since(started), time.Second,
-		"a failed read must leave the poll to end the run, not surface as the result")
+	assert.GreaterOrEqual(t, details.Load(), int32(2),
+		"a failed read must not surface as the result: a second read, the poll's, ended the run")
 }
 
 func TestRunCommandStreaming_GapFilledByREST(t *testing.T) {
@@ -1165,7 +1193,8 @@ type streamingServerConfig struct {
 	wsFinFor    string            // command id of a command_fin frame sent after the chunks; none when empty
 	chunksFor   func(int) []Chunk // REST chunk endpoint, keyed by seq__gte (warm-fire / gap-fill / drain)
 	onSubscribe func(eventType, targetID string)
-	detailFails int // leading detail GETs answered 500, before the held/running sequence starts
+	onDetail    func(n int) // every detail-endpoint request, failing ones included
+	detailFails int         // leading detail GETs answered 500, before the held/running sequence starts
 	// Detail-endpoint responses in order: heldPolls "awaiting_approval", then
 	// runningPolls "running", then terminal. The approval-resume path spends the
 	// first one on its server-id lookup, so its poll loop sees one held fewer.
@@ -1244,6 +1273,9 @@ func newStreamingServers(t *testing.T, cfg streamingServerConfig) *client.Alpaco
 			}
 			_ = json.NewEncoder(w).Encode(api.ListResponse[Chunk]{Count: len(results), Results: results})
 		case r.URL.Path == "/api/events/commands/"+cfg.cmdID+"/" && r.Method == http.MethodGet:
+			if cfg.onDetail != nil {
+				cfg.onDetail(1)
+			}
 			mu.Lock()
 			failing := failCount < cfg.detailFails
 			if failing {

--- a/api/event/event_test.go
+++ b/api/event/event_test.go
@@ -541,7 +541,8 @@ func TestPollCommandExecution_ThrottleExtensionIsBounded(t *testing.T) {
 	var clientTimeout *ClientTimeoutError
 	require.True(t, errors.As(err, &clientTimeout),
 		"a permanently throttled poll must surface a *ClientTimeoutError, got %T: %v", err, err)
-	// One 300ms extension spends the 100ms budget; the second wait runs past the deadline.
+	// One 300ms extension spends the 100ms budget whole—the ceiling is the timeout plus
+	// one backoff wait, not the timeout—and the second wait then runs past the deadline.
 	assert.Equal(t, int32(2), reqCount.Load())
 	assert.Equal(t, []time.Duration{5 * time.Millisecond, 300 * time.Millisecond, 300 * time.Millisecond}, delays())
 }

--- a/api/event/event_test.go
+++ b/api/event/event_test.go
@@ -774,7 +774,7 @@ func TestRunCommandStreaming_NormalFlow(t *testing.T) {
 
 // startStream wires a session and listener the way the streaming entry points do,
 // so a test can hand streamSubscribed a poll tick of its own choosing.
-func startStream(t *testing.T, ac *client.AlpaconClient, cmdID, serverID string, out io.Writer, tick time.Duration) <-chan error {
+func startStream(t *testing.T, ac *client.AlpaconClient, cmdID, serverID string, out io.Writer, tick time.Duration, waitApproval bool) <-chan error {
 	t.Helper()
 	session, err := CreateEventSession(ac)
 	require.NoError(t, err)
@@ -784,7 +784,7 @@ func startStream(t *testing.T, ac *client.AlpaconClient, cmdID, serverID string,
 
 	done := make(chan error, 1)
 	go func() {
-		done <- streamSubscribed(ac, session, listener, cmdID, serverID, out, 30*time.Second, tick, false)
+		done <- streamSubscribed(ac, session, listener, cmdID, serverID, out, 30*time.Second, tick, waitApproval)
 	}()
 	return done
 }
@@ -823,7 +823,7 @@ func TestStreamSubscribed_FinEndsRunWithoutThePoll(t *testing.T) {
 		terminal: EventDetails{Status: "completed", Success: boolPtr(true), Result: "done\n"},
 	})
 
-	err := awaitStream(t, startStream(t, ac, "cmd-uuid", "srv-uuid", stdoutBuf, time.Hour))
+	err := awaitStream(t, startStream(t, ac, "cmd-uuid", "srv-uuid", stdoutBuf, time.Hour, false))
 	require.NoError(t, err)
 	assert.Equal(t, "done\n", stdoutBuf.String())
 
@@ -849,7 +849,7 @@ func TestStreamSubscribed_FinOnStillRunningStatusWaitsForPoll(t *testing.T) {
 		terminal:     EventDetails{Status: "completed", Success: boolPtr(true), Result: "done\n"},
 	})
 
-	err := awaitStream(t, startStream(t, ac, "cmd-uuid", "srv-uuid", stdoutBuf, 100*time.Millisecond))
+	err := awaitStream(t, startStream(t, ac, "cmd-uuid", "srv-uuid", stdoutBuf, 100*time.Millisecond, false))
 	require.NoError(t, err)
 	assert.Equal(t, "done\n", stdoutBuf.String())
 	assert.GreaterOrEqual(t, details.Load(), int32(2),
@@ -869,11 +869,38 @@ func TestStreamSubscribed_FinWithFailedReadWaitsForPoll(t *testing.T) {
 		terminal:    EventDetails{Status: "completed", Success: boolPtr(true), Result: "done\n"},
 	})
 
-	err := awaitStream(t, startStream(t, ac, "cmd-uuid", "srv-uuid", stdoutBuf, 100*time.Millisecond))
+	err := awaitStream(t, startStream(t, ac, "cmd-uuid", "srv-uuid", stdoutBuf, 100*time.Millisecond, false))
 	require.NoError(t, err)
 	assert.Equal(t, "done\n", stdoutBuf.String())
 	assert.GreaterOrEqual(t, details.Load(), int32(2),
 		"a failed read must not surface as the result: a second read, the poll's, ended the run")
+}
+
+// Resuming through an approval hold, the poll waits out the hold and the transient
+// "error" the approve→deliver window emits. The fin path reads the same command, so
+// it has to wait on the same statuses or it reports a run that has not started.
+func TestStreamSubscribed_FinOnApprovalHoldWaitsForPoll(t *testing.T) {
+	for _, status := range []string{"awaiting_approval", "error"} {
+		t.Run(status, func(t *testing.T) {
+			stdoutBuf := &bytes.Buffer{}
+			details := &atomic.Int32{}
+			ac := newStreamingServers(t, streamingServerConfig{
+				cmdID:      "cmd-uuid",
+				serverID:   "srv-uuid",
+				wsFinFor:   "cmd-uuid",
+				onDetail:   func(int) { details.Add(1) },
+				heldPolls:  1,
+				heldStatus: status,
+				terminal:   EventDetails{Status: "completed", Success: boolPtr(true), Result: "done\n"},
+			})
+
+			err := awaitStream(t, startStream(t, ac, "cmd-uuid", "srv-uuid", stdoutBuf, 100*time.Millisecond, true))
+			require.NoError(t, err)
+			assert.Equal(t, "done\n", stdoutBuf.String())
+			assert.GreaterOrEqual(t, details.Load(), int32(2),
+				"the held read must not have ended the run: the poll's second read did")
+		})
+	}
 }
 
 func TestRunCommandStreaming_GapFilledByREST(t *testing.T) {
@@ -1228,6 +1255,7 @@ type streamingServerConfig struct {
 	// runningPolls "running", then terminal. The approval-resume path spends the
 	// first one on its server-id lookup, so its poll loop sees one held fewer.
 	heldPolls    int
+	heldStatus   string // status the held responses carry; "awaiting_approval" when empty
 	runningPolls int
 	terminal     EventDetails // returned by the detail poll once held+running elapse
 }
@@ -1319,7 +1347,11 @@ func newStreamingServers(t *testing.T, cfg streamingServerConfig) *client.Alpaco
 				return
 			}
 			if n <= cfg.heldPolls {
-				_, _ = w.Write([]byte(`{"id":"` + cfg.cmdID + `","status":"awaiting_approval","server":{"id":"` + cfg.serverID + `"}}`))
+				held := cfg.heldStatus
+				if held == "" {
+					held = "awaiting_approval"
+				}
+				_, _ = w.Write([]byte(`{"id":"` + cfg.cmdID + `","status":"` + held + `","server":{"id":"` + cfg.serverID + `"}}`))
 				return
 			}
 			if n <= cfg.heldPolls+cfg.runningPolls {

--- a/api/event/event_test.go
+++ b/api/event/event_test.go
@@ -842,7 +842,7 @@ func TestStreamSubscribed_FinOnStillRunningStatusWaitsForPoll(t *testing.T) {
 		cmdID:    "cmd-uuid",
 		serverID: "srv-uuid",
 		wsFinFor: "cmd-uuid",
-		onDetail: func(int) { details.Add(1) },
+		onDetail: func() { details.Add(1) },
 		// The fin arrives before the first poll, so this "running" is the read the
 		// fin triggers; the terminal one goes to the poll.
 		runningPolls: 1,
@@ -864,7 +864,7 @@ func TestStreamSubscribed_FinWithFailedReadWaitsForPoll(t *testing.T) {
 		cmdID:       "cmd-uuid",
 		serverID:    "srv-uuid",
 		wsFinFor:    "cmd-uuid",
-		onDetail:    func(int) { details.Add(1) },
+		onDetail:    func() { details.Add(1) },
 		detailFails: 1,
 		terminal:    EventDetails{Status: "completed", Success: boolPtr(true), Result: "done\n"},
 	})
@@ -888,7 +888,7 @@ func TestStreamSubscribed_FinOnApprovalHoldWaitsForPoll(t *testing.T) {
 				cmdID:      "cmd-uuid",
 				serverID:   "srv-uuid",
 				wsFinFor:   "cmd-uuid",
-				onDetail:   func(int) { details.Add(1) },
+				onDetail:   func() { details.Add(1) },
 				heldPolls:  1,
 				heldStatus: status,
 				terminal:   EventDetails{Status: "completed", Success: boolPtr(true), Result: "done\n"},
@@ -1249,8 +1249,8 @@ type streamingServerConfig struct {
 	wsFinFor    string            // command id of a command_fin frame sent after the chunks; none when empty
 	chunksFor   func(int) []Chunk // REST chunk endpoint, keyed by seq__gte (warm-fire / gap-fill / drain)
 	onSubscribe func(eventType, targetID string)
-	onDetail    func(n int) // every detail-endpoint request, failing ones included
-	detailFails int         // leading detail GETs answered 500, before the held/running sequence starts
+	onDetail    func() // every detail-endpoint request, failing ones included
+	detailFails int    // leading detail GETs answered 500, before the held/running sequence starts
 	// Detail-endpoint responses in order: heldPolls "awaiting_approval", then
 	// runningPolls "running", then terminal. The approval-resume path spends the
 	// first one on its server-id lookup, so its poll loop sees one held fewer.
@@ -1331,7 +1331,7 @@ func newStreamingServers(t *testing.T, cfg streamingServerConfig) *client.Alpaco
 			_ = json.NewEncoder(w).Encode(api.ListResponse[Chunk]{Count: len(results), Results: results})
 		case r.URL.Path == "/api/events/commands/"+cfg.cmdID+"/" && r.Method == http.MethodGet:
 			if cfg.onDetail != nil {
-				cfg.onDetail(1)
+				cfg.onDetail()
 			}
 			mu.Lock()
 			failing := failCount < cfg.detailFails

--- a/api/event/event_test.go
+++ b/api/event/event_test.go
@@ -1499,7 +1499,7 @@ func TestGiveUpGap_BoundsCumulativeSkipped(t *testing.T) {
 	out := &bytes.Buffer{}
 	last := 0
 	stderr := captureStderr(t, func() {
-		for i := 0; i < 4; i++ {
+		for range 4 {
 			next := last + 3 + 1 // gap of 3 seqs, each under maxGapWidth=4
 			last = g.giveUpGap(last, next, nil, out)
 		}

--- a/api/event/event_test.go
+++ b/api/event/event_test.go
@@ -369,8 +369,7 @@ func TestStreamApprovedCommand_StreamsAfterApproval(t *testing.T) {
 }
 
 // The fin subscription needs the server the command ran on, which only a read of
-// the command itself names. A failed read costs the run its fin event—the poll
-// ends it as it did before—but must not cost it the run.
+// the command names. A failed read costs the run its fin event, not the run.
 func TestStreamApprovedCommand_ServerLookupFailureSkipsFinSubscription(t *testing.T) {
 	stdoutBuf := &bytes.Buffer{}
 	var mu sync.Mutex
@@ -804,9 +803,8 @@ func awaitStream(t *testing.T, done <-chan error) error {
 }
 
 // Chunks carry no end marker, so the poll is otherwise the only thing that notices
-// a finished command—a tick away at best, ten once the command is a minute old. The
-// fin event ends the run as soon as the server reports it. The poll tick here is
-// longer than the test can possibly run, so nothing but the fin can end this.
+// a finished command—a tick away at best, ten once it is a minute old. The tick here
+// is longer than the test can run, so nothing but the fin event can end this one.
 func TestStreamSubscribed_FinEndsRunWithoutThePoll(t *testing.T) {
 	stdoutBuf := &bytes.Buffer{}
 	var mu sync.Mutex

--- a/api/event/event_test.go
+++ b/api/event/event_test.go
@@ -577,7 +577,7 @@ func TestPollCommandExecution_ThrottleDoesNotStarveDeadline(t *testing.T) {
 
 // Extending the deadline by exactly the wait keeps it ahead of the clock forever,
 // so the extension is capped: a token stuck over quota has to give up.
-func TestPollCommandExecution_ThrottleExtensionIsBounded(t *testing.T) {
+func TestPollCommandExecution_ThrottleExtensionIsBoundedByDuration(t *testing.T) {
 	ts, reqCount := throttleServer(t, math.MaxInt, "1")
 	defer ts.Close()
 
@@ -594,6 +594,36 @@ func TestPollCommandExecution_ThrottleExtensionIsBounded(t *testing.T) {
 	// to the 95ms left, so the timeout is reported at the deadline, not 300ms past it.
 	assert.Equal(t, int32(2), reqCount.Load())
 	assert.Equal(t, []time.Duration{5 * time.Millisecond, 300 * time.Millisecond, 95 * time.Millisecond}, delays())
+}
+
+// The duration budget alone is spent at whatever pace the server asks for, so a
+// throttle sending waits far shorter than the quota window would trade the whole
+// extension for a request storm—the pattern this pacing exists to stop.
+func TestPollCommandExecution_ThrottleExtensionIsBoundedByCount(t *testing.T) {
+	ts, _ := throttleServer(t, math.MaxInt, "1")
+	defer ts.Close()
+
+	// Retry-After 1s capped to 60 ticks = 6ms a wait, against a timeout worth 120 of
+	// them: the duration budget would grant twice what the count bound does.
+	const tick = 100 * time.Microsecond
+	const timeout = 720 * time.Millisecond
+
+	seams, delays := fakePollClock()
+
+	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
+	_, err := pollCommandExecution(ac, "cmd-1", timeout, tick, false, seams)
+
+	var clientTimeout *ClientTimeoutError
+	require.True(t, errors.As(err, &clientTimeout),
+		"a permanently throttled poll must surface a *ClientTimeoutError, got %T: %v", err, err)
+	var elapsed time.Duration
+	for _, d := range delays() {
+		elapsed += d
+	}
+	// The loop never waits past its deadline, so the waits sum to exactly the timeout
+	// plus what the extensions added.
+	assert.Equal(t, timeout+pollMaxThrottleExtensions*(pollMaxBackoffTick*tick), elapsed,
+		"the deadline must grow by the capped number of grants, not by the whole duration budget")
 }
 
 // Reported progress refreshes the deadline, and the throttle allowance goes back
@@ -626,6 +656,47 @@ func TestPollCommandExecution_ProgressRestoresThrottleAllowance(t *testing.T) {
 	assert.Equal(t, []time.Duration{
 		5 * time.Millisecond, 300 * time.Millisecond, 50 * time.Millisecond, 300 * time.Millisecond,
 	}, delays())
+}
+
+// The count bound belongs to the deadline it protects, so progress hands it back
+// along with the duration budget. Kept alone, one early stretch would leave a long
+// command with no grants left for the next.
+func TestPollCommandExecution_ProgressRestoresThrottleExtensions(t *testing.T) {
+	const tick = 100 * time.Microsecond
+	// One timeout is worth exactly one full round of capped grants, so a second round
+	// is only reachable through the reset.
+	const timeout = pollMaxThrottleExtensions * (pollMaxBackoffTick * tick)
+
+	reqCount := &atomic.Int32{}
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		// Progress lands on the request after the grants run out.
+		if reqCount.Add(1) == pollMaxThrottleExtensions+1 {
+			_ = json.NewEncoder(w).Encode(EventDetails{ID: "cmd-1", Status: "running"})
+			return
+		}
+		w.Header().Set("Retry-After", "1")
+		w.WriteHeader(http.StatusTooManyRequests)
+		_ = json.NewEncoder(w).Encode(map[string]string{"detail": "Request was throttled."})
+	}))
+	defer ts.Close()
+
+	seams, delays := fakePollClock()
+
+	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
+	_, err := pollCommandExecution(ac, "cmd-1", timeout, tick, false, seams)
+
+	var clientTimeout *ClientTimeoutError
+	require.True(t, errors.As(err, &clientTimeout),
+		"a permanently throttled poll must surface a *ClientTimeoutError, got %T: %v", err, err)
+	var elapsed time.Duration
+	for _, d := range delays() {
+		elapsed += d
+	}
+	// The first tick, then a round of grants, then the deadline progress refreshed and
+	// the round it made room for: three timeouts. Without the reset it stops at two.
+	assert.Equal(t, tick+3*timeout, elapsed,
+		"the second throttled stretch must get its own grants back with the refreshed deadline")
 }
 
 // The loop paces by how long the poll has been running, not by the gap since the

--- a/api/event/event_test.go
+++ b/api/event/event_test.go
@@ -354,10 +354,11 @@ func TestPollCommandExecution_WaitApprovalResumesAfterApproval(t *testing.T) {
 func TestStreamApprovedCommand_StreamsAfterApproval(t *testing.T) {
 	stdoutBuf := &bytes.Buffer{}
 	ac := newStreamingServers(t, streamingServerConfig{
-		cmdID:        "cmd-uuid",
-		serverID:     "srv-uuid",
-		wsChunks:     []ChunkEvent{{Seq: 0, Content: "approved\n"}},
-		heldPolls:    2,
+		cmdID:    "cmd-uuid",
+		serverID: "srv-uuid",
+		wsChunks: []ChunkEvent{{Seq: 0, Content: "approved\n"}},
+		// One for StreamApprovedCommand's server-id lookup, two for the poll loop.
+		heldPolls:    3,
 		runningPolls: 1,
 		terminal:     EventDetails{Status: "completed", Success: boolPtr(true)},
 	})
@@ -777,6 +778,47 @@ func TestRunCommandStreaming_FinEventEndsRunBeforeNextPoll(t *testing.T) {
 		"fin is published against the server, so that is what the subscription targets")
 }
 
+// A fin racing a status the server has not written yet must not end the run on a
+// half-finished read: the poll picks it up a tick later instead.
+func TestRunCommandStreaming_FinOnStillRunningStatusWaitsForPoll(t *testing.T) {
+	stdoutBuf := &bytes.Buffer{}
+	ac := newStreamingServers(t, streamingServerConfig{
+		cmdID:    "cmd-uuid",
+		serverID: "srv-uuid",
+		wsFinFor: "cmd-uuid",
+		// The fin arrives before the first poll, so this "running" is the read the
+		// fin triggers; the terminal one goes to the poll.
+		runningPolls: 1,
+		terminal:     EventDetails{Status: "completed", Success: boolPtr(true), Result: "done\n"},
+	})
+
+	started := time.Now()
+	err := runCommandStreamingWithWriter(ac, "srv", "manage.py migrate", "", "", nil, "", stdoutBuf)
+	require.NoError(t, err)
+	assert.Equal(t, "done\n", stdoutBuf.String())
+	assert.GreaterOrEqual(t, time.Since(started), time.Second,
+		"the run must have ended on the poll, one tick later, not on the running read")
+}
+
+// Same fallback when the read the fin triggers fails outright.
+func TestRunCommandStreaming_FinWithFailedReadWaitsForPoll(t *testing.T) {
+	stdoutBuf := &bytes.Buffer{}
+	ac := newStreamingServers(t, streamingServerConfig{
+		cmdID:       "cmd-uuid",
+		serverID:    "srv-uuid",
+		wsFinFor:    "cmd-uuid",
+		detailFails: 1,
+		terminal:    EventDetails{Status: "completed", Success: boolPtr(true), Result: "done\n"},
+	})
+
+	started := time.Now()
+	err := runCommandStreamingWithWriter(ac, "srv", "manage.py migrate", "", "", nil, "", stdoutBuf)
+	require.NoError(t, err)
+	assert.Equal(t, "done\n", stdoutBuf.String())
+	assert.GreaterOrEqual(t, time.Since(started), time.Second,
+		"a failed read must leave the poll to end the run, not surface as the result")
+}
+
 func TestRunCommandStreaming_GapFilledByREST(t *testing.T) {
 	stdoutBuf := &bytes.Buffer{}
 	ac := newStreamingServers(t, streamingServerConfig{
@@ -1117,14 +1159,18 @@ func TestRunCommandStreaming_FallbackQuietWhenChunksUnavailable(t *testing.T) {
 
 // streamingServerConfig configures the fake event servers for streaming tests.
 type streamingServerConfig struct {
-	cmdID        string
-	serverID     string
-	wsChunks     []ChunkEvent      // emitted over the WS once subscribed
-	wsFinFor     string            // command id of a command_fin frame sent after the chunks; none when empty
-	chunksFor    func(int) []Chunk // REST chunk endpoint, keyed by seq__gte (warm-fire / gap-fill / drain)
-	onSubscribe  func(eventType, targetID string)
-	heldPolls    int          // number of "awaiting_approval" detail polls before running
-	runningPolls int          // number of "running" detail polls before the terminal one
+	cmdID       string
+	serverID    string
+	wsChunks    []ChunkEvent      // emitted over the WS once subscribed
+	wsFinFor    string            // command id of a command_fin frame sent after the chunks; none when empty
+	chunksFor   func(int) []Chunk // REST chunk endpoint, keyed by seq__gte (warm-fire / gap-fill / drain)
+	onSubscribe func(eventType, targetID string)
+	detailFails int // leading detail GETs answered 500, before the held/running sequence starts
+	// Detail-endpoint responses in order: heldPolls "awaiting_approval", then
+	// runningPolls "running", then terminal. The approval-resume path spends the
+	// first one on its server-id lookup, so its poll loop sees one held fewer.
+	heldPolls    int
+	runningPolls int
 	terminal     EventDetails // returned by the detail poll once held+running elapse
 }
 
@@ -1170,7 +1216,7 @@ func newStreamingServers(t *testing.T, cfg streamingServerConfig) *client.Alpaco
 	t.Cleanup(wsServer.Close)
 	wsURL := "ws" + strings.TrimPrefix(wsServer.URL, "http")
 
-	var pollCount int
+	var pollCount, failCount int
 	var mu sync.Mutex
 	apiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
@@ -1199,9 +1245,18 @@ func newStreamingServers(t *testing.T, cfg streamingServerConfig) *client.Alpaco
 			_ = json.NewEncoder(w).Encode(api.ListResponse[Chunk]{Count: len(results), Results: results})
 		case r.URL.Path == "/api/events/commands/"+cfg.cmdID+"/" && r.Method == http.MethodGet:
 			mu.Lock()
-			pollCount++
+			failing := failCount < cfg.detailFails
+			if failing {
+				failCount++
+			} else {
+				pollCount++
+			}
 			n := pollCount
 			mu.Unlock()
+			if failing {
+				http.Error(w, "boom", http.StatusInternalServerError)
+				return
+			}
 			if n <= cfg.heldPolls {
 				_, _ = w.Write([]byte(`{"id":"` + cfg.cmdID + `","status":"awaiting_approval","server":{"id":"` + cfg.serverID + `"}}`))
 				return

--- a/api/event/event_test.go
+++ b/api/event/event_test.go
@@ -596,15 +596,14 @@ func TestPollCommandExecution_ThrottleExtensionIsBoundedByDuration(t *testing.T)
 	assert.Equal(t, []time.Duration{5 * time.Millisecond, 300 * time.Millisecond, 95 * time.Millisecond}, delays())
 }
 
-// The duration budget alone is spent at whatever pace the server asks for, so a
-// throttle sending waits far shorter than the quota window would trade the whole
-// extension for a request storm—the pattern this pacing exists to stop.
+// A duration budget alone is spent at the server's pace, so short mandated waits
+// would trade the whole extension for a request storm.
 func TestPollCommandExecution_ThrottleExtensionIsBoundedByCount(t *testing.T) {
 	ts, _ := throttleServer(t, math.MaxInt, "1")
 	defer ts.Close()
 
-	// Retry-After 1s capped to 60 ticks = 6ms a wait, against a timeout worth 120 of
-	// them: the duration budget would grant twice what the count bound does.
+	// Retry-After 1s capped to 60 ticks = a 6ms wait, and a timeout worth 120 of them:
+	// the duration budget would grant twice what the count bound does.
 	const tick = 100 * time.Microsecond
 	const timeout = 720 * time.Millisecond
 
@@ -620,8 +619,7 @@ func TestPollCommandExecution_ThrottleExtensionIsBoundedByCount(t *testing.T) {
 	for _, d := range delays() {
 		elapsed += d
 	}
-	// The loop never waits past its deadline, so the waits sum to exactly the timeout
-	// plus what the extensions added.
+	// The loop never waits past its deadline, so the waits sum to it exactly.
 	assert.Equal(t, timeout+pollMaxThrottleExtensions*(pollMaxBackoffTick*tick), elapsed,
 		"the deadline must grow by the capped number of grants, not by the whole duration budget")
 }
@@ -658,19 +656,17 @@ func TestPollCommandExecution_ProgressRestoresThrottleAllowance(t *testing.T) {
 	}, delays())
 }
 
-// The count bound belongs to the deadline it protects, so progress hands it back
-// along with the duration budget. Kept alone, one early stretch would leave a long
-// command with no grants left for the next.
+// The count belongs to the deadline it protects: held across a refresh, one early
+// stretch would leave a long command no grants for the next.
 func TestPollCommandExecution_ProgressRestoresThrottleExtensions(t *testing.T) {
 	const tick = 100 * time.Microsecond
-	// One timeout is worth exactly one full round of capped grants, so a second round
-	// is only reachable through the reset.
+	// One timeout is worth exactly one round of capped grants, so a second round is
+	// only reachable through the reset.
 	const timeout = pollMaxThrottleExtensions * (pollMaxBackoffTick * tick)
 
 	reqCount := &atomic.Int32{}
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		// Progress lands on the request after the grants run out.
 		if reqCount.Add(1) == pollMaxThrottleExtensions+1 {
 			_ = json.NewEncoder(w).Encode(EventDetails{ID: "cmd-1", Status: "running"})
 			return
@@ -693,8 +689,8 @@ func TestPollCommandExecution_ProgressRestoresThrottleExtensions(t *testing.T) {
 	for _, d := range delays() {
 		elapsed += d
 	}
-	// The first tick, then a round of grants, then the deadline progress refreshed and
-	// the round it made room for: three timeouts. Without the reset it stops at two.
+	// One round of grants, then the refreshed deadline and the round it made room for:
+	// three timeouts on top of the first tick. Without the reset, two.
 	assert.Equal(t, tick+3*timeout, elapsed,
 		"the second throttled stretch must get its own grants back with the refreshed deadline")
 }

--- a/api/event/event_test.go
+++ b/api/event/event_test.go
@@ -542,9 +542,10 @@ func TestPollCommandExecution_ThrottleExtensionIsBounded(t *testing.T) {
 	require.True(t, errors.As(err, &clientTimeout),
 		"a permanently throttled poll must surface a *ClientTimeoutError, got %T: %v", err, err)
 	// One 300ms extension spends the 100ms budget whole—the ceiling is the timeout plus
-	// one backoff wait, not the timeout—and the second wait then runs past the deadline.
+	// one backoff wait, not the timeout. The second wait gets no extension and is cut
+	// to the 95ms left, so the timeout is reported at the deadline, not 300ms past it.
 	assert.Equal(t, int32(2), reqCount.Load())
-	assert.Equal(t, []time.Duration{5 * time.Millisecond, 300 * time.Millisecond, 300 * time.Millisecond}, delays())
+	assert.Equal(t, []time.Duration{5 * time.Millisecond, 300 * time.Millisecond, 95 * time.Millisecond}, delays())
 }
 
 // Reported progress refreshes the deadline, and the throttle allowance goes back

--- a/api/event/event_test.go
+++ b/api/event/event_test.go
@@ -545,6 +545,38 @@ func TestPollCommandExecution_ThrottleExtensionIsBounded(t *testing.T) {
 	assert.Equal(t, []time.Duration{5 * time.Millisecond, 300 * time.Millisecond, 300 * time.Millisecond}, delays())
 }
 
+// Reported progress refreshes the deadline, and the throttle allowance goes back
+// with it: a throttle late in a long command must not be refused an extension
+// because an unrelated one early on spent the budget.
+func TestPollCommandExecution_ProgressRestoresThrottleAllowance(t *testing.T) {
+	reqCount := &atomic.Int32{}
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch reqCount.Add(1) {
+		case 1, 3:
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			_ = json.NewEncoder(w).Encode(map[string]string{"detail": "Request was throttled."})
+		case 2:
+			_ = json.NewEncoder(w).Encode(EventDetails{ID: "cmd-1", Status: "running"})
+		default:
+			_ = json.NewEncoder(w).Encode(EventDetails{ID: "cmd-1", Status: "completed"})
+		}
+	}))
+	defer ts.Close()
+
+	delays := fakePollClock(t)
+
+	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
+	resp, err := pollCommandExecution(ac, "cmd-1", 100*time.Millisecond, 5*time.Millisecond, false)
+	require.NoError(t, err)
+	assert.Equal(t, "completed", resp.Status)
+	assert.Equal(t, int32(4), reqCount.Load())
+	assert.Equal(t, []time.Duration{
+		5 * time.Millisecond, 300 * time.Millisecond, 50 * time.Millisecond, 300 * time.Millisecond,
+	}, delays())
+}
+
 func TestPollCommandExecution_TerminalStatusReturnsBeforeTimeout(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")

--- a/api/event/event_test.go
+++ b/api/event/event_test.go
@@ -368,6 +368,37 @@ func TestStreamApprovedCommand_StreamsAfterApproval(t *testing.T) {
 	assert.Equal(t, "approved\n", stdoutBuf.String())
 }
 
+// The fin subscription needs the server the command ran on, which only a read of
+// the command itself names. A failed read costs the run its fin event—the poll
+// ends it as it did before—but must not cost it the run.
+func TestStreamApprovedCommand_ServerLookupFailureSkipsFinSubscription(t *testing.T) {
+	stdoutBuf := &bytes.Buffer{}
+	var mu sync.Mutex
+	var subscriptions [][2]string
+	ac := newStreamingServers(t, streamingServerConfig{
+		cmdID:    "cmd-uuid",
+		serverID: "srv-uuid",
+		wsChunks: []ChunkEvent{{Seq: 0, Content: "approved\n"}},
+		onSubscribe: func(eventType, targetID string) {
+			mu.Lock()
+			defer mu.Unlock()
+			subscriptions = append(subscriptions, [2]string{eventType, targetID})
+		},
+		// The lookup is the first read of the command, so this is the one that fails.
+		detailFails: 1,
+		terminal:    EventDetails{Status: "completed", Success: boolPtr(true)},
+	})
+
+	err := StreamApprovedCommand(ac, "cmd-uuid", stdoutBuf, 30*time.Second)
+	require.NoError(t, err)
+	assert.Equal(t, "approved\n", stdoutBuf.String())
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Equal(t, [][2]string{{EventTypeCommandOutput, "cmd-uuid"}}, subscriptions,
+		"with no server to target, the fin subscription must be skipped rather than sent empty")
+}
+
 func boolPtr(b bool) *bool    { return &b }
 func intPtr(i int) *int       { return &i }
 func strPtr(s string) *string { return &s }

--- a/api/event/event_test.go
+++ b/api/event/event_test.go
@@ -386,6 +386,145 @@ func TestPollCommandExecution_ClientTimeout(t *testing.T) {
 		"timer expiry must surface a *ClientTimeoutError, got %T: %v", err, err)
 }
 
+func TestNextPollTick(t *testing.T) {
+	base := time.Second
+	tests := []struct {
+		name    string
+		elapsed time.Duration
+		want    time.Duration
+	}{
+		{name: "base tick while the command is young", elapsed: 0, want: base},
+		{name: "still base at the end of the fast window", elapsed: 9 * base, want: base},
+		{name: "widens once the fast window closes", elapsed: 10 * base, want: 5 * base},
+		{name: "holds through the medium window", elapsed: 59 * base, want: 5 * base},
+		{name: "widest once the medium window closes", elapsed: 60 * base, want: 10 * base},
+		{name: "stays widest", elapsed: 3000 * base, want: 10 * base},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, nextPollTick(base, tt.elapsed))
+		})
+	}
+}
+
+func TestNextPollBackoff(t *testing.T) {
+	base := time.Second
+	tests := []struct {
+		name       string
+		attempt    int
+		retryAfter time.Duration
+		want       time.Duration
+	}{
+		{name: "first failure keeps the base tick", attempt: 0, want: base},
+		{name: "doubles per consecutive failure", attempt: 1, want: 2 * base},
+		{name: "still doubling", attempt: 3, want: 8 * base},
+		{name: "capped once doubling passes the cap", attempt: 6, want: 60 * base},
+		{name: "stays capped", attempt: 20, want: 60 * base},
+		{name: "server's Retry-After wins over the schedule", attempt: 0, retryAfter: 3 * base, want: 3 * base},
+		{name: "Retry-After wins even when it is shorter", attempt: 5, retryAfter: 3 * base, want: 3 * base},
+		{name: "Retry-After is capped too", attempt: 0, retryAfter: 3000 * base, want: 60 * base},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, nextPollBackoff(base, tt.attempt, tt.retryAfter))
+		})
+	}
+}
+
+// throttleServer replies 429 to the first throttled requests, then serves a
+// terminal status. The returned counter holds the requests it has seen.
+func throttleServer(t *testing.T, throttled int, retryAfter string) (*httptest.Server, *atomic.Int32) {
+	t.Helper()
+	reqCount := &atomic.Int32{}
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if int(reqCount.Add(1)) <= throttled {
+			if retryAfter != "" {
+				w.Header().Set("Retry-After", retryAfter)
+			}
+			w.WriteHeader(http.StatusTooManyRequests)
+			_ = json.NewEncoder(w).Encode(map[string]string{"detail": "Request was throttled."})
+			return
+		}
+		_ = json.NewEncoder(w).Encode(EventDetails{ID: "cmd-1", Status: "completed", Result: "done"})
+	}))
+	return ts, reqCount
+}
+
+// fakePollClock runs the poll loop on a clock only its own delays advance, and
+// returns the delays it chose. Timing the loop instead would be flaky: a slow
+// machine stretches every wait, which makes a loop without backoff look
+// better-behaved than it is and can expire a deadline the loop meant to extend.
+func fakePollClock(t *testing.T) func() []time.Duration {
+	t.Helper()
+	now := time.Now()
+	var delays []time.Duration
+	restoreNow, restoreSleep := pollNow, pollSleep
+	pollNow = func() time.Time { return now }
+	pollSleep = func(d time.Duration) {
+		delays = append(delays, d)
+		now = now.Add(d)
+	}
+	t.Cleanup(func() { pollNow, pollSleep = restoreNow, restoreSleep })
+	return func() []time.Duration { return delays }
+}
+
+// A throttled poll must space its requests out instead of spending one per tick.
+func TestPollCommandExecution_ThrottleBacksOff(t *testing.T) {
+	tick := 10 * time.Millisecond
+	tests := []struct {
+		name       string
+		retryAfter string
+		want       []time.Duration
+	}{
+		{
+			name: "no Retry-After: exponential backoff",
+			want: []time.Duration{tick, tick, 2 * tick, 4 * tick, 8 * tick},
+		},
+		{
+			name:       "Retry-After honored, capped",
+			retryAfter: "1",
+			want:       []time.Duration{tick, 60 * tick, 60 * tick, 60 * tick, 60 * tick},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ts, _ := throttleServer(t, 4, tt.retryAfter)
+			defer ts.Close()
+
+			delays := fakePollClock(t)
+
+			ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
+			resp, err := pollCommandExecution(ac, "cmd-1", time.Minute, tick, false)
+			require.NoError(t, err)
+			assert.Equal(t, "completed", resp.Status)
+			assert.Equal(t, tt.want, delays())
+		})
+	}
+}
+
+// A 429 must not starve the deadline: the command may already have finished,
+// with only its result GET throttled.
+func TestPollCommandExecution_ThrottleDoesNotStarveDeadline(t *testing.T) {
+	ts, reqCount := throttleServer(t, 1, "1")
+	defer ts.Close()
+
+	// The Retry-After wait (1s, capped to 60 ticks = 300ms) outlasts the 100ms
+	// deadline: reachable only if throttled time is not charged to it.
+	delays := fakePollClock(t)
+
+	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
+	resp, err := pollCommandExecution(ac, "cmd-1", 100*time.Millisecond, 5*time.Millisecond, false)
+	require.NoError(t, err)
+	assert.Equal(t, "completed", resp.Status)
+	assert.Equal(t, int32(2), reqCount.Load(),
+		"the result must come from the retry after the throttled wait, not from retrying through it")
+	assert.Equal(t, []time.Duration{5 * time.Millisecond, 300 * time.Millisecond}, delays())
+}
+
 func TestPollCommandExecution_TerminalStatusReturnsBeforeTimeout(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")

--- a/api/event/event_test.go
+++ b/api/event/event_test.go
@@ -156,7 +156,7 @@ func TestPollCommandExecution(t *testing.T) {
 				BaseURL:    ts.URL,
 			}
 
-			result, err := pollCommandExecution(ac, "cmd-1", 30*time.Second, 5*time.Millisecond, false)
+			result, err := pollCommandExecution(ac, "cmd-1", 30*time.Second, 5*time.Millisecond, false, pollSeams{})
 			require.NoError(t, err)
 			assert.Equal(t, tt.wantStatus, result.Status)
 			assert.Equal(t, tt.wantResult, result.Result)
@@ -346,7 +346,7 @@ func TestPollCommandExecution_WaitApprovalResumesAfterApproval(t *testing.T) {
 	defer ts.Close()
 
 	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
-	resp, err := pollCommandExecution(ac, "cmd-1", time.Second, 5*time.Millisecond, true)
+	resp, err := pollCommandExecution(ac, "cmd-1", time.Second, 5*time.Millisecond, true, pollSeams{})
 	require.NoError(t, err)
 	assert.Equal(t, "completed", resp.Status)
 }
@@ -411,7 +411,7 @@ func TestPollCommandExecution_ClientTimeout(t *testing.T) {
 	defer ts.Close()
 
 	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
-	_, err := pollCommandExecution(ac, "cmd-1", 50*time.Millisecond, 10*time.Millisecond, false)
+	_, err := pollCommandExecution(ac, "cmd-1", 50*time.Millisecond, 10*time.Millisecond, false, pollSeams{})
 	require.Error(t, err)
 
 	var clientTimeout *ClientTimeoutError
@@ -486,22 +486,24 @@ func throttleServer(t *testing.T, throttled int, retryAfter string) (*httptest.S
 	return ts, reqCount
 }
 
-// fakePollClock runs the poll loop on a clock only its own delays advance, and
-// returns the delays it chose. Timing the loop instead would be flaky: a slow
-// machine stretches every wait, which makes a loop without backoff look
+// fakePollClock returns seams that run the poll loop on a clock only its own
+// delays advance, and the delays it chose. Timing the loop instead would be flaky:
+// a slow machine stretches every wait, which makes a loop without backoff look
 // better-behaved than it is and can expire a deadline the loop meant to extend.
-func fakePollClock(t *testing.T) func() []time.Duration {
-	t.Helper()
+func fakePollClock() (pollSeams, func() []time.Duration) {
 	now := time.Now()
 	var delays []time.Duration
-	restoreNow, restoreSleep := pollNow, pollSleep
-	pollNow = func() time.Time { return now }
-	pollSleep = func(d time.Duration) {
-		delays = append(delays, d)
-		now = now.Add(d)
+	seams := pollSeams{
+		now: func() time.Time { return now },
+		after: func(d time.Duration) <-chan time.Time {
+			delays = append(delays, d)
+			now = now.Add(d)
+			ch := make(chan time.Time, 1)
+			ch <- now
+			return ch
+		},
 	}
-	t.Cleanup(func() { pollNow, pollSleep = restoreNow, restoreSleep })
-	return func() []time.Duration { return delays }
+	return seams, func() []time.Duration { return delays }
 }
 
 // A throttled poll must space its requests out instead of spending one per tick.
@@ -528,10 +530,10 @@ func TestPollCommandExecution_ThrottleBacksOff(t *testing.T) {
 			ts, _ := throttleServer(t, 4, tt.retryAfter)
 			defer ts.Close()
 
-			delays := fakePollClock(t)
+			seams, delays := fakePollClock()
 
 			ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
-			resp, err := pollCommandExecution(ac, "cmd-1", time.Minute, tick, false)
+			resp, err := pollCommandExecution(ac, "cmd-1", time.Minute, tick, false, seams)
 			require.NoError(t, err)
 			assert.Equal(t, "completed", resp.Status)
 			assert.Equal(t, tt.want, delays())
@@ -547,10 +549,10 @@ func TestPollCommandExecution_ThrottleDoesNotStarveDeadline(t *testing.T) {
 
 	// The Retry-After wait (1s, capped to 60 ticks = 300ms) outlasts the 100ms
 	// deadline: reachable only if throttled time is not charged to it.
-	delays := fakePollClock(t)
+	seams, delays := fakePollClock()
 
 	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
-	resp, err := pollCommandExecution(ac, "cmd-1", 100*time.Millisecond, 5*time.Millisecond, false)
+	resp, err := pollCommandExecution(ac, "cmd-1", 100*time.Millisecond, 5*time.Millisecond, false, seams)
 	require.NoError(t, err)
 	assert.Equal(t, "completed", resp.Status)
 	assert.Equal(t, int32(2), reqCount.Load(),
@@ -564,10 +566,10 @@ func TestPollCommandExecution_ThrottleExtensionIsBounded(t *testing.T) {
 	ts, reqCount := throttleServer(t, math.MaxInt, "1")
 	defer ts.Close()
 
-	delays := fakePollClock(t)
+	seams, delays := fakePollClock()
 
 	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
-	_, err := pollCommandExecution(ac, "cmd-1", 100*time.Millisecond, 5*time.Millisecond, false)
+	_, err := pollCommandExecution(ac, "cmd-1", 100*time.Millisecond, 5*time.Millisecond, false, seams)
 
 	var clientTimeout *ClientTimeoutError
 	require.True(t, errors.As(err, &clientTimeout),
@@ -599,10 +601,10 @@ func TestPollCommandExecution_ProgressRestoresThrottleAllowance(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	delays := fakePollClock(t)
+	seams, delays := fakePollClock()
 
 	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
-	resp, err := pollCommandExecution(ac, "cmd-1", 100*time.Millisecond, 5*time.Millisecond, false)
+	resp, err := pollCommandExecution(ac, "cmd-1", 100*time.Millisecond, 5*time.Millisecond, false, seams)
 	require.NoError(t, err)
 	assert.Equal(t, "completed", resp.Status)
 	assert.Equal(t, int32(4), reqCount.Load())
@@ -630,10 +632,10 @@ func TestPollCommandExecution_PacingWidensWithCommandAge(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	delays := fakePollClock(t)
+	seams, delays := fakePollClock()
 
 	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
-	resp, err := pollCommandExecution(ac, "cmd-1", time.Hour, tick, false)
+	resp, err := pollCommandExecution(ac, "cmd-1", time.Hour, tick, false, seams)
 	require.NoError(t, err)
 	assert.Equal(t, "completed", resp.Status)
 	assert.Equal(t, slices.Concat(
@@ -651,7 +653,7 @@ func TestPollCommandExecution_TerminalStatusReturnsBeforeTimeout(t *testing.T) {
 	defer ts.Close()
 
 	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
-	resp, err := pollCommandExecution(ac, "cmd-1", 50*time.Millisecond, 5*time.Millisecond, false)
+	resp, err := pollCommandExecution(ac, "cmd-1", 50*time.Millisecond, 5*time.Millisecond, false, pollSeams{})
 	require.NoError(t, err)
 	assert.Equal(t, "completed", resp.Status)
 }
@@ -831,6 +833,28 @@ func TestStreamSubscribed_FinEndsRunWithoutThePoll(t *testing.T) {
 	defer mu.Unlock()
 	assert.Contains(t, subscriptions, [2]string{EventTypeCommandFin, "srv-uuid"},
 		"fin is published against the server, so that is what the subscription targets")
+}
+
+// A run that ended on the fin must take its poll with it. Left alive, the poll goes
+// on requesting a command that is already over—spending the throttle budget this
+// pacing exists to protect, and outliving the process's other streams.
+func TestStreamSubscribed_FinCancelsThePoll(t *testing.T) {
+	tick := 20 * time.Millisecond
+	details := &atomic.Int32{}
+	ac := newStreamingServers(t, streamingServerConfig{
+		cmdID:    "cmd-uuid",
+		serverID: "srv-uuid",
+		wsFinFor: "cmd-uuid",
+		onDetail: func() { details.Add(1) },
+		terminal: EventDetails{Status: "completed", Success: boolPtr(true), Result: "done\n"},
+	})
+
+	err := awaitStream(t, startStream(t, ac, "cmd-uuid", "srv-uuid", &bytes.Buffer{}, tick, false))
+	require.NoError(t, err)
+
+	atEnd := details.Load()
+	time.Sleep(5 * tick)
+	assert.Equal(t, atEnd, details.Load(), "the poll must stop with the run, not keep requesting")
 }
 
 // A fin racing a status the server has not written yet must not end the run on a

--- a/api/event/subscribe.go
+++ b/api/event/subscribe.go
@@ -15,6 +15,9 @@ const (
 	// comparable to EventType.
 	EventTypeSudo          = "sudo"
 	EventTypeCommandOutput = "command_output"
+	// Targets the server, not the command: that is what the server publishes it
+	// against (Command.notify_command_event).
+	EventTypeCommandFin = "command_fin"
 )
 
 // EventType is a server event channel type, marshalled as a plain string. The server

--- a/api/event/subscribe.go
+++ b/api/event/subscribe.go
@@ -15,8 +15,8 @@ const (
 	// comparable to EventType.
 	EventTypeSudo          = "sudo"
 	EventTypeCommandOutput = "command_output"
-	// Targets the server, not the command: that is what the server publishes it
-	// against (Command.notify_command_event).
+	// Subscribed with a server id, not a command id: that is the channel
+	// alpacon-server publishes it on.
 	EventTypeCommandFin = "command_fin"
 )
 

--- a/client/client.go
+++ b/client/client.go
@@ -235,7 +235,8 @@ func readJSONResponse(resp *http.Response) ([]byte, error) {
 
 	// Empty content type is allowed for responses without content (e.g. PATCH).
 	if ct := resp.Header.Get("Content-Type"); ct != "" && !strings.Contains(ct, "application/json") {
-		return nil, withStatus(fmt.Errorf("unexpected response from server (HTTP %d, Content-Type: %s)", resp.StatusCode, ct), resp.StatusCode)
+		err := fmt.Errorf("unexpected response from server (HTTP %d, Content-Type: %s)", resp.StatusCode, ct)
+		return nil, withRetryAfter(withStatus(err, resp.StatusCode), resp.Header)
 	}
 	return body, nil
 }
@@ -334,7 +335,7 @@ func (ac *AlpaconClient) SendMultipartStreamRequest(url, contentType string, bod
 	}
 
 	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
-		return nil, withStatus(parseAPIError(respBody), resp.StatusCode)
+		return nil, withRetryAfter(withStatus(parseAPIError(respBody), resp.StatusCode), resp.Header)
 	}
 
 	return respBody, nil

--- a/client/client.go
+++ b/client/client.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 	"os"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -40,6 +41,17 @@ type statusError struct {
 func (e *statusError) Error() string       { return e.err.Error() }
 func (e *statusError) Unwrap() error       { return e.err }
 func (e *statusError) HTTPStatusCode() int { return e.statusCode }
+
+// retryAfterError carries the server's Retry-After hint so a retrying caller
+// (the exec/websh poll loop) waits as long as it asked instead of guessing.
+type retryAfterError struct {
+	err        error
+	retryAfter time.Duration
+}
+
+func (e *retryAfterError) Error() string             { return e.err.Error() }
+func (e *retryAfterError) Unwrap() error             { return e.err }
+func (e *retryAfterError) RetryAfter() time.Duration { return e.retryAfter }
 
 func NewAlpaconAPIClient() (*AlpaconClient, error) {
 	validConfig, err := config.LoadConfig()
@@ -241,7 +253,7 @@ func (ac *AlpaconClient) sendRequest(req *http.Request) ([]byte, error) {
 	}
 
 	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
-		return nil, withStatus(parseAPIError(respBody), resp.StatusCode)
+		return nil, withRetryAfter(withStatus(parseAPIError(respBody), resp.StatusCode), resp.Header)
 	}
 
 	return respBody, nil
@@ -438,6 +450,19 @@ func withStatus(err error, statusCode int) error {
 		return err
 	}
 	return &statusError{err: err, statusCode: statusCode}
+}
+
+// withRetryAfter tags err with the Retry-After delay. Only delta-seconds is parsed—
+// that is what DRF throttling sends, and misreading an HTTP-date would stall a poll.
+func withRetryAfter(err error, header http.Header) error {
+	if err == nil {
+		return nil
+	}
+	seconds, convErr := strconv.Atoi(strings.TrimSpace(header.Get("Retry-After")))
+	if convErr != nil || seconds <= 0 {
+		return err
+	}
+	return &retryAfterError{err: err, retryAfter: time.Duration(seconds) * time.Second}
 }
 
 // parseAPIError extracts a human-readable error message from a JSON API error response.

--- a/client/client.go
+++ b/client/client.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"net/http"
 	"net/url"
 	"os"
@@ -460,7 +461,9 @@ func withRetryAfter(err error, header http.Header) error {
 		return nil
 	}
 	seconds, convErr := strconv.Atoi(strings.TrimSpace(header.Get("Retry-After")))
-	if convErr != nil || seconds <= 0 {
+	// The upper bound is what a time.Duration can hold: past it the multiplication
+	// below wraps, and a wrapped delay is worse than no hint at all.
+	if convErr != nil || seconds <= 0 || int64(seconds) > math.MaxInt64/int64(time.Second) {
 		return err
 	}
 	return &retryAfterError{err: err, retryAfter: time.Duration(seconds) * time.Second}

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -137,6 +137,8 @@ func TestSendRequest_429ExposesRetryAfter(t *testing.T) {
 		{name: "zero is no hint", retryAfter: "0", want: 0},
 		// The poll loop's own backoff covers this; guessing a date would stall it.
 		{name: "HTTP-date is not parsed", retryAfter: "Wed, 21 Oct 2015 07:28:00 GMT", want: 0},
+		// Parses fine, but seconds*time.Second would wrap past a Duration's range.
+		{name: "too large for a Duration", retryAfter: "99999999999", want: 0},
 	}
 
 	for _, tt := range tests {

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/alpacax/alpacon-cli/utils"
 	"github.com/stretchr/testify/assert"
@@ -122,6 +123,46 @@ func TestSendRequest_401ExposesStatusCode(t *testing.T) {
 func TestHTTPStatusCode_NonAPIErrorIsZero(t *testing.T) {
 	assert.Equal(t, 0, utils.HTTPStatusCode(errors.New("boom")))
 	assert.Equal(t, 0, utils.HTTPStatusCode(nil))
+}
+
+func TestSendRequest_429ExposesRetryAfter(t *testing.T) {
+	tests := []struct {
+		name       string
+		retryAfter string
+		want       time.Duration
+	}{
+		{name: "delta-seconds", retryAfter: "29", want: 29 * time.Second},
+		{name: "padded delta-seconds", retryAfter: " 29 ", want: 29 * time.Second},
+		{name: "no header", retryAfter: "", want: 0},
+		{name: "zero is no hint", retryAfter: "0", want: 0},
+		// The poll loop's own backoff covers this; guessing a date would stall it.
+		{name: "HTTP-date is not parsed", retryAfter: "Wed, 21 Oct 2015 07:28:00 GMT", want: 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				if tt.retryAfter != "" {
+					w.Header().Set("Retry-After", tt.retryAfter)
+				}
+				w.WriteHeader(http.StatusTooManyRequests)
+				_, _ = w.Write([]byte(`{"detail": "Request was throttled."}`))
+			}))
+			defer ts.Close()
+
+			ac := newTestClient(ts.URL)
+			_, err := ac.SendGetRequest("/api/test/")
+			require.Error(t, err)
+			assert.Equal(t, http.StatusTooManyRequests, utils.HTTPStatusCode(err))
+			assert.Equal(t, tt.want, utils.RetryAfter(err))
+		})
+	}
+}
+
+func TestRetryAfter_ErrorWithoutHintIsZero(t *testing.T) {
+	assert.Equal(t, time.Duration(0), utils.RetryAfter(errors.New("boom")))
+	assert.Equal(t, time.Duration(0), utils.RetryAfter(nil))
 }
 
 func TestSendRequest_403SurfacesServerDetail(t *testing.T) {

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -160,6 +160,40 @@ func TestSendRequest_429ExposesRetryAfter(t *testing.T) {
 	}
 }
 
+// A proxy-level throttle answers with its own HTML, which readJSONResponse rejects
+// before the status check ever runs. The hint has to survive that path too.
+func TestSendRequest_429WithNonJSONBodyExposesRetryAfter(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		w.Header().Set("Retry-After", "29")
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte("<html>rate limited</html>"))
+	}))
+	defer ts.Close()
+
+	ac := newTestClient(ts.URL)
+	_, err := ac.SendGetRequest("/api/test/")
+	require.Error(t, err)
+	assert.Equal(t, http.StatusTooManyRequests, utils.HTTPStatusCode(err))
+	assert.Equal(t, 29*time.Second, utils.RetryAfter(err))
+}
+
+// Upload shares the throttle, so it must tag the hint the same way sendRequest does.
+func TestSendMultipartStreamRequest_429ExposesRetryAfter(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Retry-After", "29")
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte(`{"detail": "Request was throttled."}`))
+	}))
+	defer ts.Close()
+
+	ac := newTestClient(ts.URL)
+	_, err := ac.SendMultipartStreamRequest("/api/test/", "multipart/form-data", bytes.NewReader([]byte("x")), -1)
+	require.Error(t, err)
+	assert.Equal(t, 29*time.Second, utils.RetryAfter(err))
+}
+
 func TestRetryAfter_ErrorWithoutHintIsZero(t *testing.T) {
 	assert.Equal(t, time.Duration(0), utils.RetryAfter(errors.New("boom")))
 	assert.Equal(t, time.Duration(0), utils.RetryAfter(nil))

--- a/utils/error.go
+++ b/utils/error.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"net/http"
 	"strings"
+	"time"
 )
 
 const (
@@ -83,11 +84,25 @@ type statusCoder interface {
 	HTTPStatusCode() int
 }
 
+type retryAfterCarrier interface {
+	RetryAfter() time.Duration
+}
+
 // HTTPStatusCode returns the HTTP status carried by err, or 0 if none—lets callers tell 404 from 401.
 func HTTPStatusCode(err error) int {
 	for e := err; e != nil; e = errors.Unwrap(e) {
 		if sc, ok := e.(statusCoder); ok {
 			return sc.HTTPStatusCode()
+		}
+	}
+	return 0
+}
+
+// RetryAfter returns the delay the server asked for on err, or 0 if it sent none.
+func RetryAfter(err error) time.Duration {
+	for e := err; e != nil; e = errors.Unwrap(e) {
+		if ra, ok := e.(retryAfterCarrier); ok {
+			return ra.RetryAfter()
 		}
 	}
 	return 0


### PR DESCRIPTION
## Background

When the event WebSocket is unavailable, `exec` and `websh` fall back to polling the command's status on a fixed 1s tick. That is 3,600 requests an hour against alpacon-server's default `service_token: 1000/hour`, so the quota is gone in about 17 minutes—and once it is gone the loop starves itself, spending every freed slot on a request that is throttled again. #309 has the production CI evidence: a no-op `manage.py migrate` that finished server-side in seconds was reported as `[client_timeout]` after 30 minutes of throttled polling, and the exhausted quota then broke an unrelated `alpacon login` on the same account.

The loop also discarded the server's `Retry-After`, which the client layer never exposed in the first place.

## Changes

The poll gap now follows the command's age and the server's answers, the deadline is no longer spent on requests that were refused, and the streaming path stops waiting for a poll to notice the command is over.

| Location | What changes |
|---|---|
| `withRetryAfter`, `utils.RetryAfter` | `Retry-After` rides the error chain next to the status code, reachable the same way `utils.HTTPStatusCode` already reaches the status. Only the delta-seconds form is parsed—alpacon-server sends seconds through DRF throttling, and a misread HTTP-date would park a poll until the deadline. All three response paths tag it: JSON, non-JSON (a gateway throttle answers with its own HTML), and `SendMultipartStreamRequest`. A value too large for a `time.Duration` is treated as no hint rather than allowed to wrap |
| `nextPollTick` | The gap widens with the poll's age—base tick for the first 10 ticks, 5x through 60, 10x after. A 30-minute wait drops from ~1,800 requests to ~200. Age runs from where the poll starts rather than from submission, so a command resuming after an approval hold gets the fast window again; that is the forgiving direction and is left alone |
| `nextPollBackoff` | Doubles on consecutive failures up to 60 ticks, with the server's `Retry-After` preferred when it sends one. The same cap covers `Retry-After`, so a value the server picks cannot park the loop until the deadline |
| `pollCommandExecution` deadline | Time lost to a 429 extends the deadline instead of spending it: a throttled GET says nothing about the command, which may well have finished already. The extension has a budget of one more timeout, spent whole on the last extension rather than trimmed, so the ceiling is one timeout plus one backoff wait and a token permanently over quota gives up instead of extending forever. Trimming it would let a mandated wait expire the deadline mid-sleep, so the loop would serve the wait and never make the poll it waited for. The budget is capped by count as well—60 grants—because a duration alone converts to whatever request count the server's chosen wait dictates: 30 minutes of extension is 30 polls at the capped 60s wait and 1,800 at a flat `Retry-After: 1`. A running status refreshes both along with the deadline they belong to |
| `pollCommandExecution` warning | One warning per throttled stretch: the first 429 warns, and reported progress clears the flag along with the allowance it belongs to, so a second stretch minutes later is not silent either. With the extension budget the wait can approach two timeouts, and a silent `alpacon exec` is indistinguishable from a hung one |
| `pollCommandExecution` wait, `pollSeams` | The timer and ticker become one computed wait, which also drops the drain-before-`Reset` dance the running-status branch needed. It never runs past the deadline, so `[client_timeout]` is reported at the deadline it names rather than one gap later—10 ticks at the slow pace, 60 once a throttle widened it. The wait is a channel receive rather than a sleep so it can lose to a cancel, and `pollSeams` carries the clock behind it—passed in, not a package var, since a poll can outlive the stream that started it by an in-flight request |
| `errPollCancelled`, `streamSubscribed` cancel | The poll ends when the run does. A run that exits on the fin left its poll behind, and since the command is already over the orphan spends one more request of the very budget this pacing protects—twice over for a process that opens a second stream, which `cmd/exec`'s MFA retry does |
| `EventTypeCommandFin`, `CommandOutputListener.Finished` | A wider poll gap would otherwise show up as tail latency on the streaming path, where the poll is not the output carrier but the only thing that notices the command is over: chunks carry no end marker, so an `alpacon exec` could sit for up to 10 ticks after its output had already arrived. alpacon-server publishes `command_fin` when alpamon reports the command handled, on the same channel and frame shape as the chunks, so the listener reports that too. The subscription is per server, so the listener filters on the command id in the payload |
| `streamSubscribed` | The run ends on the fin. The fin only says it is over, so the exit code still comes from one GET; a read that fails, or that lands on a status the poll would keep waiting on, falls back to the poll rather than reporting a half-finished run. Both paths ask the same `isPollWaitStatus`, so the approval hold and the transient `error` of the approve-to-deliver window mean the same thing on either. The poll stays as the net for everything fin does not cover—a rejected command, an agent that never fins, a dropped WebSocket |

## Behaviour change

Under a permanent throttle the loop now spends up to two timeouts before returning `[client_timeout]`, where before it returned at one—an hour at the default `ALPACON_EXEC_TIMEOUT`. Two timeouts is what the duration budget buys at the default timeout when the server asks for waits at the cap; a throttle asking for shorter ones runs out of grants first and returns sooner. Past a timeout of an hour the count is what binds at the cap instead, so the extension is shorter than a timeout there. The rate-limit warning prints as soon as either begins, so the wait is not silent.

`cp` inherits the new pacing as well. `api/ftp/ftp.go:684` and `api/ftp/ftp.go:739` wait on the exported `PollCommandExecution`, whose signature is unchanged, so a transfer that outlives the fast and medium windows is noticed up to 10s after it actually finished instead of within 1s. The fin exit does not cover that path—it belongs to the streaming subscription, and `cp` only polls—so the tail latency is what buys `cp` the same quota relief.

## Left as they are

Three decisions that read like oversights on review, so the reasoning is written down.

| Decision | Why |
|---|---|
| A `Retry-After` replaces the exponential schedule outright rather than being combined with it | A server that answers every 429 with `Retry-After: 1` then holds the loop at one poll per second, which is the exhaustion pattern this PR is meant to fix. It is still the right default, and the "Retry-After wins even when it is shorter" case in `TestNextPollBackoff` pins it: the server knows when its own window frees up, and second-guessing it with `max(retryAfter, schedule)` means waiting longer than asked on the common path. alpacon-server sends the remaining window through DRF `SimpleRateThrottle.wait()`, which is a real number of seconds, not 1. A proxy throttle in front of it (nginx `limit_req`, a CDN) is where a flat `Retry-After: 1` is plausible, and that path is in range here since the non-JSON branch now tags the header too. What bounds that case is not `nextPollBackoff`'s cap—that bounds the gap, not the request count—but the extension count: 60 grants, so a flat `Retry-After: 1` adds 60 polls to the window instead of a second window's worth of them. Worth switching to `max` if it turns up in practice anyway |
| A fin whose GET fails leaves no trace in the output | The fin is consumed, so the run falls back to a poll that may be up to 10 ticks out, and from outside that is indistinguishable from a fin that never fired. A warning is wrong for a path that recovers by design, and the CLI has no debug level to put it at—`utils` prints errors, info, and warnings only. Adding one is a decision wider than this line |
| The GET the fin triggers runs inline in the streaming select | The loop stops draining `Chunks()` for the length of one round trip, and a full 256-chunk buffer would block the WebSocket read behind it. Nothing is lost—the drain that follows re-reads everything past `lastSeq` over REST—so the cost is that one round trip, and the same select already makes a synchronous REST call for gap filling. Moving it off the loop buys a round trip and pays a goroutine, a channel, and a shutdown race for it |

## Known limits

One race this does not close, and widens: alpamon posts a command's chunks (queue priority 10) before its fin (11), but its reporters run concurrently, so the fin can be persisted first—its own comment says as much, "retries and concurrent reporters can still race". The drain that follows a fin then misses a chunk still in flight, and with `lastSeq` already advanced the buffered `Result` is not printed either, so the tail is dropped silently.

The poll had the same single drain, only 0 to 10 ticks later, which hid it. Nothing in the CLI can tell the two apart: a chunk still inside the agent is absent from the server's `max_seq` too, and `result` is masked where live chunks are raw, so a byte comparison is not sound. The fix belongs in the fin payload, since the agent knows the last seq it sent, and is filed as alpacax/alpacon-server#2885. Until then this is the pre-existing behaviour with a narrower window in front of it.

One narrower limit on the extension count: it bounds the extra requests only while the mandated wait keeps its length. A throttle that answers with long waits until the duration budget is spent and then shortens them can still burn the extended window at the short pace. The extra wall-clock is bounded by one timeout either way, and it takes a server changing its own answer mid-stretch, so it is left as is.

## Testing

```
gofmt -l .                      no output
go vet ./...                    clean
golangci-lint run ./...         0 issues
go test -race ./...             38 packages ok, 0 failures
go test -race -shuffle=on ./... 38 packages ok, 0 failures
```

`api/event` was also run at `-shuffle=1` through `8` individually. The shuffled run is not decoration here: it is what caught the poll goroutine outliving its stream. Left alive it read clock seams a later test had swapped, and the race surfaced in whichever test happened to run next rather than in the one that leaked it—which is why the seams are now passed in instead of swapped.

New cases in `api/event/event_test.go`, `api/event/commandoutput_listener_test.go`, and `client/client_test.go` cover the poll schedule, the throttle backoff and its cap from both sides, the deadline extension and both of its bounds, the allowance reset on progress, `Retry-After` on each response path, the fin filter, and the fin-driven exit. Each one was confirmed to fail before its fix—the duration-bound case hangs until the test timeout without the cap, the pacing case sees only base ticks if the loop measures the gap since the previous poll instead of how long it has been polling, and the fin case never ends at all, since its poll tick is set an hour out.

The two count-bound cases were checked the same way, by breaking the production line and reading the number that moved. Dropping the count from the extension condition grows the window a permanently throttled poll gets from 1.08s to 1.44s, exactly the second budget the duration alone would have granted; dropping the count's reset from the progress branch stops it at 720.1ms, the refreshed deadline with no grants left to spend.

The fin exit is tested on a command that prints nothing, the case #309 opened with: with no output there is nothing but a terminal signal to end the run on. Its fallbacks are pinned as well—a read that races a status the server has not written yet, one that fails outright, one that lands on an approval hold or the transient `error` beside it, and, on the approval-resume path, a failed server lookup that leaves the fin subscription unsent—since each must leave the run to the poll rather than report what it read.

None of the three decides anything on elapsed time. The poll tick reaches `streamSubscribed` as a parameter, so the exit case sets it an hour out and the fin becomes the only thing that can end the run; the fallbacks count reads, where a second one means the first ended nothing. An assertion like "finished within 500ms" would only ever be measuring the distance to the 1s tick it was racing, and would fail on a loaded runner for reasons that have nothing to do with the code.

The throttle cases run on a fake clock rather than the wall clock. Timing real waits made the result depend on the machine: a slow runner stretches every wait, which makes a loop with no backoff look better-behaved than it is and can expire a deadline the loop meant to extend.

Also run against a live workspace, `alpacon exec web-editor "sleep 65; echo done"`, so the command outlives the fast and medium pacing windows:

```
before this PR's fin commits   77.2s
with them                      72.1s
alpacon exec ... "echo x"       5.1s   (same on both, the fixed setup cost)
```

Subtracting the 65s the command itself takes and the setup, the exit went from roughly 7s after the output to roughly 2s.

## Follow-up

This is the first CLI path to subscribe to `command_fin`, and the subscription has no permission branch on the server side: `EventSubscriptionSerializer.validate` covers `sudo`, `work_session`, `command_output`, and `notification`, not `command_fin`. Any authenticated user can subscribe with a server id they have no access to, and an omitted `target_id` wildcard-matches every server, since `get_subscribed_channels` only narrows by target when one is given. What that exposes is metadata—the payload is `{type, target, event, id}`, a command id and the fact that it finished, and `command_output` keeps its per-command requester check.

Filed against the server as a note on alpacax/alpacon-server#2885, which already carries the chunk-seq race below, with `command_reject` included: it shares the same `notify_command_event` publish path and has no branch either. The event type predates this PR, so the CLI is not opening the gap; it is the first consumer to put traffic on the channel.

The approval-wait loops in `cmd/exec/run.go` and `cmd/worksession/worksession_create.go` have the same fixed-tick problem and are deliberately out of scope here—filed as #312.

Closes #309
