### PR TITLE
docs: trim the comments and instructions the code already carries

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -22,7 +22,7 @@ Use: "tunnel [SERVER] -l LOCAL -r REMOTE [flags]"
 
 ## Subcommand alias convention
 
-- list → `Aliases: []string{"list", "all"}`
+- list → `Aliases: []string{"list"}`
 - delete → `Aliases: []string{"rm"}`
 - describe → `Aliases: []string{"desc"}`
 - Group commands may have semantic aliases (e.g., `workspace` → `ws`, `server` → `servers`)

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,63 +1,10 @@
 # GitHub Copilot instructions
 
-This repository is the Alpacon CLI (`alpacon`), built with Go and [Cobra](https://github.com/spf13/cobra).
+The repository's instructions live in `AGENTS.md` (a symlink to `CLAUDE.md`) and
+apply to every agent, Copilot included. Read that file—CLI usage string
+convention, Cobra command conventions, error handling, exit codes, and writing
+conventions are all there.
 
-## CLI usage string convention
-
-All Cobra command `Use` fields must follow POSIX/Cobra conventions:
-
-- **UPPERCASE** for user-supplied values (positional arguments): `SERVER`, `COMMAND`, `SOURCE`
-- **lowercase** for literal keywords or framework tokens: `[flags]`, `[command]`
-- **`[]`** for optional: `[USER@]`, `[flags]`
-- **`...`** for repeatable: `SOURCE...`, `COMMAND...`
-
-Examples:
-
-```go
-Use: "websh [flags] [USER@]SERVER [COMMAND]"
-Use: "cp [SOURCE...] [DESTINATION]"
-Use: "exec [USER@]SERVER COMMAND... [flags]"
-Use: "tunnel [SERVER] -l LOCAL -r REMOTE [flags]"
-```
-
-## Subcommand alias convention
-
-- list → `Aliases: []string{"list"}`
-- delete → `Aliases: []string{"rm"}`
-- describe → `Aliases: []string{"desc"}`
-- Group commands may have semantic aliases (e.g., `workspace` → `ws`, `server` → `servers`)
-- **Group commands**: `RunE`—returns error to trigger help when no subcommand is given
-- **Leaf commands**: `Run` + `utils.CliErrorWithExit`—preserves colored output; `RunE` would print plain text and may append usage on error
-
-## Code review guidelines
-
-- Cobra `Short` descriptions should be concise (under 50 chars) and start with a verb
-- Cobra `Long` descriptions should document SSH-like `user@host` syntax where supported
-- Cobra `Example` blocks should use realistic server names (e.g., `my-server`, not `[SERVER_NAME]`)
-- List commands should project API responses into `*Attributes` structs for `utils.PrintTable()`
-- Comments must be written in English
-
-## Exit codes
-
-`alpacon` uses a stable exit code convention:
-
-- `0` success
-- `1` general error
-- `2` usage error
-- `3` WorkSession gate denied (`utils.ExitCodeWorkSessionDenied`)
-- `4` Pending human approval, outcome still open (`utils.ExitCodePendingApproval`)
-- `5` Server busy with active user work (`utils.ExitCodeServerBusy`)
-- `6` Approval not granted—settled without the grant (`utils.ExitCodeNotApproved`)
-
-Keep these stable—scripts, CI, and AI agents branch on them. See README "Exit codes".
-
-## Writing conventions
-
-- Use **sentence case** for all headings and descriptions (capitalize only the first word and proper nouns)
-- Product and feature names:
-  - **Alpacon**—the platform (proper noun, always capitalized)
-  - **alpacon**—the CLI binary name (lowercase in code/commands)
-  - **Websh**—the browser-based terminal feature (proper noun). Never "WebSH" or "websh" in prose. Use `websh` only in code and CLI commands
-  - **Alpamon**—the agent (proper noun)
-  - **Auth0**—third-party service (their capitalization)
-- Use em-dashes (`—`) without surrounding spaces: `word—word`, not `word — word`
+This file used to carry its own copy of those rules. It drifted from the code it
+described, so it is now a pointer rather than a duplicate: fix conventions in
+`CLAUDE.md` and every tool sees the fix.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,51 +35,8 @@ go vet ./...
 
 ## Architecture
 
-### Project structure
-
-```
-main.go              # Entry point
-cmd/                 # Cobra command definitions
-  root.go            # Root command, registers all subcommands
-  login.go           # Login command
-  logout.go          # Logout command
-  version.go         # Version command
-  whoami.go          # Whoami command
-  agent/             # alpacon agent
-  approval/          # alpacon approval
-  audit/             # alpacon audit
-  authority/         # alpacon authority
-  cert/              # alpacon cert
-  csr/               # alpacon csr
-  edit/              # alpacon edit
-  event/             # alpacon event
-  exec/              # alpacon exec
-  ftp/               # alpacon cp (file transfer)
-  iam/               # alpacon user, alpacon group
-  log/               # alpacon log
-  note/              # alpacon note
-  packages/          # alpacon package
-  revoke/            # alpacon revoke
-  server/            # alpacon server
-  token/             # alpacon token
-  tunnel/            # alpacon tunnel
-  username/          # alpacon username
-  webftp/            # alpacon webftp
-  webhook/           # alpacon webhook
-  websh/             # alpacon websh
-  worksession/       # alpacon work-session
-  workspace/         # alpacon workspace
-api/                 # API client functions per domain
-client/              # HTTP client wrapper for Alpacon API
-config/              # Configuration management (credentials, workspace)
-pkg/                 # Internal packages (cert, testutil, tunnel)
-utils/               # Shared utilities (output, prompts, errors, SSH parsing)
-```
-
 ### Key patterns
 
-- **Command registration**: All commands are registered in `cmd/root.go` via `RootCmd.AddCommand()`
-- **API layer**: Each `cmd/` package calls corresponding `api/` package for HTTP requests
 - **SSH-like syntax**: `websh`, `exec`, `cp` support `user@host` syntax via `utils.ParseSSHTarget()`
 - **Error handling**: Common errors (MFA required, username required) are handled via `utils.HandleCommonErrors()` with retry callbacks
 - **Custom flag parsing**: `websh` and `exec` use `DisableFlagParsing: true` and parse flags manually. `exec` supports `--` separator for remote command flags
@@ -136,27 +93,7 @@ Top-level declarations within a file must follow: `const → var → type → fu
 
 ### Error handling
 
-- golangci-lint `errcheck` is enabled—all error returns must be explicitly handled
-- For deferred close calls, use the named discard pattern:
-
-```go
-// Good—errcheck satisfied
-defer func() { _ = resp.Body.Close() }()
-defer func() { _ = file.Close() }()
-
-// Bad—errcheck violation
-defer resp.Body.Close()
-defer file.Close()
-```
-
-- For write calls where the error is intentionally ignored:
-
-```go
-_, _ = stdout.Write(output)
-_ = json.NewEncoder(w).Encode(resp)
-```
-
-- Error strings should be lowercase and not end with punctuation (per Go convention / staticcheck ST1005)
+- `errcheck` is on. Discard an ignored error explicitly rather than dropping the call's result: `defer func() { _ = f.Close() }()`, `_, _ = stdout.Write(output)`
 
 ### Test patterns
 
@@ -191,6 +128,4 @@ _ = json.NewEncoder(w).Encode(resp)
 - **Linter**: golangci-lint v2 with errcheck, govet, ineffassign, staticcheck, unused (see `.golangci.yml`)
 - **Config file**: `~/.alpacon/config.json` (dir `0700`, file `0600`)
 - **Alias**: `alpacon` can also be invoked as `ac`
-- **File transfer**: The `cp` command lives in `cmd/ftp/` (package name `ftp`)
 - **Exit codes**: `0` success, `1` general error, `2` usage error, `3` WorkSession gate denied, `4` pending approval with the outcome still open, `5` server busy, `6` approval not granted (constants in `utils/error.go`). Keep these stable—scripts, CI, and AI agents branch on them. See README "Exit codes".
-- **IAM**: `user` and `group` commands both live in `cmd/iam/`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,10 +44,14 @@ cmd/                 # Cobra command definitions
   login.go           # Login command
   logout.go          # Logout command
   version.go         # Version command
+  whoami.go          # Whoami command
   agent/             # alpacon agent
+  approval/          # alpacon approval
+  audit/             # alpacon audit
   authority/         # alpacon authority
   cert/              # alpacon cert
   csr/               # alpacon csr
+  edit/              # alpacon edit
   event/             # alpacon event
   exec/              # alpacon exec
   ftp/               # alpacon cp (file transfer)
@@ -55,15 +59,20 @@ cmd/                 # Cobra command definitions
   log/               # alpacon log
   note/              # alpacon note
   packages/          # alpacon package
+  revoke/            # alpacon revoke
   server/            # alpacon server
   token/             # alpacon token
   tunnel/            # alpacon tunnel
+  username/          # alpacon username
+  webftp/            # alpacon webftp
+  webhook/           # alpacon webhook
   websh/             # alpacon websh
+  worksession/       # alpacon work-session
   workspace/         # alpacon workspace
 api/                 # API client functions per domain
 client/              # HTTP client wrapper for Alpacon API
 config/              # Configuration management (credentials, workspace)
-pkg/                 # Internal packages (cert, tunnel)
+pkg/                 # Internal packages (cert, testutil, tunnel)
 utils/               # Shared utilities (output, prompts, errors, SSH parsing)
 ```
 
@@ -74,7 +83,7 @@ utils/               # Shared utilities (output, prompts, errors, SSH parsing)
 - **SSH-like syntax**: `websh`, `exec`, `cp` support `user@host` syntax via `utils.ParseSSHTarget()`
 - **Error handling**: Common errors (MFA required, username required) are handled via `utils.HandleCommonErrors()` with retry callbacks
 - **Custom flag parsing**: `websh` and `exec` use `DisableFlagParsing: true` and parse flags manually. `exec` supports `--` separator for remote command flags
-- **Shared command execution**: `exec.RunCommandWithRetry()` wraps `event.RunCommand()` + `HandleCommonErrors()` with MFA/retry logic. Used by both `exec` and `websh`
+- **Shared command execution**: `exec.RunCommandWithRetry()` wraps `event.RunCommandStreaming()` + `HandleCommonErrors()` with MFA/retry logic. Used by both `exec` and `websh`
 - **Browser auto-open**: `utils.OpenBrowser()` opens auth URLs with SSH/headless detection, cross-process debounce (`~/.alpacon/.browser_lock`), and `ALPACON_NO_BROWSER` env var opt-out
 - **Output format flag**: `--output` persistent flag on `RootCmd` (`table` | `json`, default `table`), bound to `utils.OutputFormat` global in `cmd/root.go`. No short form—`-o` is reserved for subcommand-local `--out` flags (e.g., `cert download -o path`). `--output json` produces pretty-printed JSON (2-space indent) on stdout via `utils.PrintTable()` / `utils.PrintJson()`; default preserves existing behavior (table for list commands, pretty JSON for detail commands). Empty/nil slices emit `[]`
 - **Table output**: API response → `*Attributes` struct projection → `utils.PrintTable()`. All list commands follow this pattern
@@ -153,7 +162,7 @@ _ = json.NewEncoder(w).Encode(resp)
 
 - Table-driven tests with `testify/assert`
 - API tests use `httptest.NewServer` with a minimal `*client.AlpaconClient` pointing at `ts.URL`
-- Command logic is extracted to unexported helpers (e.g., `parseExecArgs`) for direct unit testing
+- Command logic is extracted to helpers (e.g., `ParseRemoteExecArgs`) for direct unit testing
 
 ### Comments
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
-# CLAUDE.md
+# Repository instructions
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+This file is the repository's guidance for AI coding agents working in this codebase. `AGENTS.md` is a symlink to it, and `.github/copilot-instructions.md` points here.
 
 ## Project overview
 

--- a/api/auth/auth.go
+++ b/api/auth/auth.go
@@ -84,7 +84,6 @@ func LoginAndSaveCredentials(loginReq *LoginRequest, token string, insecure bool
 		return err
 	}
 
-	// Log in to Alpacon server
 	httpReq, err := http.NewRequest(http.MethodPost, utils.BuildURL(workspaceURL, loginURL, nil), bytes.NewBuffer(reqBody))
 	if err != nil {
 		return err

--- a/api/auth/auth_test.go
+++ b/api/auth/auth_test.go
@@ -95,7 +95,6 @@ func TestLoginAndSaveCredentialsPasswordPreservesTargetMetadata(t *testing.T) {
 	}
 }
 
-// assertSavedTarget loads the persisted config and verifies the saved target metadata.
 func assertSavedTarget(t *testing.T, wantURL, wantName, wantBaseDomain, wantToken string) configpkg.Config {
 	t.Helper()
 

--- a/api/event/chunks_test.go
+++ b/api/event/chunks_test.go
@@ -49,8 +49,6 @@ func TestGetCommandChunks_PassesSeqGteAndReturnsResults(t *testing.T) {
 	assert.NotContains(t, capturedQuery, "seq__lte")
 }
 
-// TestGetCommandOutput_ConcatenatesChunksInSeqOrder verifies the full output is
-// reconstructed from chunks in seq order regardless of server ordering.
 func TestGetCommandOutput_ConcatenatesChunksInSeqOrder(t *testing.T) {
 	cmdID := "a1b2c3d4-1234-5678-abcd-000000000000"
 
@@ -75,8 +73,6 @@ func TestGetCommandOutput_ConcatenatesChunksInSeqOrder(t *testing.T) {
 	assert.Equal(t, "a\nb\nc\n", got)
 }
 
-// TestGetCommandChunks_SortsBySeq verifies out-of-order server results are
-// returned sorted by seq.
 func TestGetCommandChunks_SortsBySeq(t *testing.T) {
 	cmdID := "a1b2c3d4-1234-5678-abcd-000000000000"
 
@@ -105,8 +101,6 @@ func TestGetCommandChunks_SortsBySeq(t *testing.T) {
 	}, got)
 }
 
-// TestGetCommandChunks_SendsSeqLteWhenBounded verifies a non-negative toSeq is
-// sent as the seq__lte upper bound.
 func TestGetCommandChunks_SendsSeqLteWhenBounded(t *testing.T) {
 	cmdID := "a1b2c3d4-1234-5678-abcd-000000000000"
 	tests := []struct {

--- a/api/event/commandoutput_listener.go
+++ b/api/event/commandoutput_listener.go
@@ -16,7 +16,6 @@ const (
 	commandOutputConnectTimeout = 5 * time.Second
 )
 
-// ChunkEvent is a single command_output chunk emitted by the listener.
 type ChunkEvent struct {
 	Seq     int
 	Content string
@@ -62,7 +61,6 @@ func NewCommandOutputListener(ac *client.AlpaconClient, wsURL, commandID string)
 	return l
 }
 
-// Chunks returns a receive-only channel of parsed chunk events.
 func (l *CommandOutputListener) Chunks() <-chan ChunkEvent { return l.chunks }
 
 // Finished fires when the command reaches a terminal state, which the chunks

--- a/api/event/commandoutput_listener_test.go
+++ b/api/event/commandoutput_listener_test.go
@@ -115,7 +115,6 @@ func TestCommandOutputListener_Start_DeliversChunks(t *testing.T) {
 		}
 		defer func() { _ = conn.Close() }()
 
-		// Emit two chunks
 		for _, c := range []ChunkEvent{{Seq: 0, Content: "a"}, {Seq: 1, Content: "b"}} {
 			env := map[string]any{
 				"event_type": "command_output",
@@ -129,7 +128,6 @@ func TestCommandOutputListener_Start_DeliversChunks(t *testing.T) {
 			_ = conn.WriteMessage(websocket.TextMessage, b)
 		}
 
-		// Block until client disconnects
 		for {
 			if _, _, err := conn.ReadMessage(); err != nil {
 				return
@@ -173,13 +171,11 @@ func TestCommandOutputListener_Reconnects(t *testing.T) {
 		n := connectionCount.Add(1)
 
 		if n == 1 {
-			// First connection: emit one chunk and drop
 			env := `{"event_type":"command_output","payload":{"command_id":"` + cmdID + `","seq":0,"content":"first"}}`
 			_ = conn.WriteMessage(websocket.TextMessage, []byte(env))
 			_ = conn.Close()
 			return
 		}
-		// Second connection: emit second chunk and block
 		env := `{"event_type":"command_output","payload":{"command_id":"` + cmdID + `","seq":1,"content":"second"}}`
 		_ = conn.WriteMessage(websocket.TextMessage, []byte(env))
 		for {

--- a/api/event/sudolistener.go
+++ b/api/event/sudolistener.go
@@ -18,7 +18,6 @@ const (
 	// substituted into the path. Replaces the removed self-approve route.
 	sudoVerifyURLFmt = "/api/sudo/grants/%s/verify/"
 
-	// mfaPollingInterval is how often we check if MFA is completed.
 	mfaPollingInterval = 500 * time.Millisecond
 
 	// mfaPollingTimeout is the maximum time to wait for MFA completion.
@@ -133,7 +132,6 @@ func (sl *SudoListener) handleSudoMFA(event sudoMFAEvent) {
 	fmt.Fprintf(os.Stderr, "%s\r\n", mfaURL)
 	utils.OpenBrowser(mfaURL)
 
-	// Poll for MFA completion
 	completed := sl.pollMFACompletion()
 	if !completed {
 		fmt.Fprintf(os.Stderr, "\r\n\033[31mMFA verification timed out. Please re-run the sudo command.\033[0m\r\n")

--- a/api/event/sudolistener_test.go
+++ b/api/event/sudolistener_test.go
@@ -100,7 +100,6 @@ func TestSudoListener_StopClosesConnection(t *testing.T) {
 	sl := NewSudoListener(nil, wsURL, "")
 	sl.Start()
 
-	// Wait for connection to establish by polling sl.conn
 	require.Eventually(t, func() bool {
 		sl.mu.Lock()
 		defer sl.mu.Unlock()
@@ -109,7 +108,6 @@ func TestSudoListener_StopClosesConnection(t *testing.T) {
 
 	sl.Stop()
 
-	// Wait for listenLoop goroutine to exit via stopped channel
 	select {
 	case <-sl.stopped:
 		// goroutine exited and cleanup ran
@@ -152,7 +150,6 @@ func TestSudoListener_ConnectAndListen_ExitsOnDisconnect(t *testing.T) {
 		_ = sl.connectAndListen()
 	}()
 
-	// Wait for connection, then signal server to close
 	require.Eventually(t, func() bool {
 		sl.mu.Lock()
 		defer sl.mu.Unlock()

--- a/api/event/wslistener_test.go
+++ b/api/event/wslistener_test.go
@@ -36,7 +36,6 @@ func TestWSListener_StopIsIdempotent(t *testing.T) {
 func TestWSListener_WaitConnected_Success(t *testing.T) {
 	w := newWSListener(nil, "", 0)
 
-	// Simulate connection after short delay
 	go func() {
 		time.Sleep(50 * time.Millisecond)
 		close(w.connected)

--- a/api/ftp/ftp.go
+++ b/api/ftp/ftp.go
@@ -98,10 +98,8 @@ func alignedPollDelay(attempt int, elapsed time.Duration) time.Duration {
 	return backoff
 }
 
-// PollTransferStatus polls the transfer status API until success/failure or timeout.
-// transferType should be "upload" or "download", id is the transfer ID.
-// timeout controls how long to poll before giving up.
-// Returns true if transfer succeeded, false if failed, and error if polling timed out or failed.
+// PollTransferStatus polls until the transfer settles or timeout elapses.
+// transferType is "upload" or "download"; the bool reports whether it succeeded.
 func PollTransferStatus(ac *client.AlpaconClient, transferType, id string, timeout time.Duration) (bool, string, error) {
 	var statusURL string
 	if transferType == "upload" {
@@ -300,13 +298,11 @@ func executeBulkUpload(ac *client.AlpaconClient, request *BulkUploadRequest, fil
 		return fmt.Errorf("upload failed for %d file(s):\n  %s", len(uploadFailures), strings.Join(uploadFailures, "\n  "))
 	}
 
-	// Trigger server-side processing
 	triggerRequest := &BulkUploadTriggerRequest{IDs: ids}
 	if _, err := ac.SendPostRequest(uploadBulkTriggerURL, triggerRequest); err != nil {
 		return err
 	}
 
-	// Poll transfer status for each upload
 	var totalBytes int64
 	for _, s := range sizes {
 		totalBytes += s
@@ -785,7 +781,6 @@ func DownloadFile(ac *client.AlpaconClient, sources []string, dest, username, gr
 
 	serverName, firstPath := utils.SplitPath(sources[0])
 
-	// Extract remote paths and validate all sources are on the same server
 	remotePaths := make([]string, 0, len(sources))
 	remotePaths = append(remotePaths, strings.Trim(firstPath, "\""))
 	for _, src := range sources[1:] {

--- a/api/ftp/ftp_test.go
+++ b/api/ftp/ftp_test.go
@@ -458,13 +458,11 @@ func TestDownloadBulk(t *testing.T) {
 	err := downloadBulk(ac, []string{"/path/file1.txt", "/path/file2.txt"}, dest, "server-id", "admin", "developers", "")
 	require.NoError(t, err)
 
-	// Verify request body
 	assert.Equal(t, []string{"/path/file1.txt", "/path/file2.txt"}, bulkReq.Path)
 	assert.Equal(t, "server-id", bulkReq.Server)
 	assert.Equal(t, "admin", bulkReq.Username)
 	assert.Equal(t, "developers", bulkReq.Groupname)
 
-	// Verify extracted files exist
 	content1, err := os.ReadFile(filepath.Join(dest, "file1.txt"))
 	require.NoError(t, err)
 	assert.Equal(t, "hello", string(content1))
@@ -473,7 +471,6 @@ func TestDownloadBulk(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "world", string(content2))
 
-	// Verify temp zip was cleaned up
 	_, err = os.Stat(filepath.Join(dest, "archive.zip"))
 	assert.True(t, os.IsNotExist(err))
 }

--- a/api/iam/iam.go
+++ b/api/iam/iam.go
@@ -25,7 +25,6 @@ const (
 	codeUsernameApproval   = "approval_superuser_approve_required"
 )
 
-// UsernameSetSuccessFmt is the confirmation format shown after a username is set.
 const UsernameSetSuccessFmt = "Username set to %q"
 
 // usernameErrors maps each server username error code to its user-facing message and whether re-entering a different name can resolve it.

--- a/api/log/log_test.go
+++ b/api/log/log_test.go
@@ -20,7 +20,6 @@ func TestGetSystemLogList_NoExtraPagination(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 
-		// server ID lookup
 		if strings.HasPrefix(r.URL.Path, "/api/servers/servers") {
 			resp := api.ListResponse[server.ServerDetails]{
 				Count:   1,
@@ -30,7 +29,6 @@ func TestGetSystemLogList_NoExtraPagination(t *testing.T) {
 			return
 		}
 
-		// log endpoint
 		if strings.HasPrefix(r.URL.Path, "/api/history/logs") {
 			count := logRequestCount.Add(1)
 			if count > 1 {

--- a/api/note/note_test.go
+++ b/api/note/note_test.go
@@ -19,7 +19,6 @@ func TestGetNoteList_NoExtraPagination(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 
-		// note list endpoint
 		if strings.HasPrefix(r.URL.Path, "/api/servers/notes") {
 			count := noteRequestCount.Add(1)
 			if count > 1 {

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -212,7 +212,6 @@ func buildGroupUUIDToNameMap(ac *client.AlpaconClient) map[string]string {
 	return m
 }
 
-// DeleteRegistrationToken resolves a token name to its ID and sends a DELETE request.
 func DeleteRegistrationToken(ac *client.AlpaconClient, tokenName string) error {
 	token, err := GetRegistrationTokenByName(ac, tokenName)
 	if err != nil {

--- a/api/server/server_test.go
+++ b/api/server/server_test.go
@@ -309,7 +309,6 @@ func TestGetRegistrationTokenAttributes_MapsGroupNames(t *testing.T) {
 			_ = json.NewEncoder(w).Encode(resp)
 			return
 		}
-		// registration tokens
 		resp := api.ListResponse[RegistrationTokenDetails]{
 			Count: 1,
 			Results: []RegistrationTokenDetails{
@@ -483,7 +482,6 @@ func TestDeleteServer(t *testing.T) {
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodGet && strings.Contains(r.URL.RawQuery, "name=") {
-			// GetServerIDByName
 			resp := api.ListResponse[ServerDetails]{
 				Count:   1,
 				Results: []ServerDetails{{ID: serverID, Name: "target-server"}},

--- a/api/server/types.go
+++ b/api/server/types.go
@@ -54,7 +54,6 @@ type RegistrationTokenAttributes struct {
 	Enabled       bool   `json:"enabled"`
 }
 
-// RegistrationMethodGuideRequest is the request body for the guide API.
 type RegistrationMethodGuideRequest struct {
 	Platform          string `json:"platform"`
 	ServerName        string `json:"server_name,omitempty"`
@@ -73,7 +72,6 @@ type RegistrationGuideMeta struct {
 	AllowSudoWithMFA bool    `json:"allow_sudo_with_mfa"`
 }
 
-// RegistrationMethodGuideJsonResponse is the structured JSON response from the guide API.
 type RegistrationMethodGuideJsonResponse struct {
 	RegistrationGuideMeta
 	TokenKey        string   `json:"token_key"`
@@ -81,7 +79,6 @@ type RegistrationMethodGuideJsonResponse struct {
 	RegisterCommand string   `json:"register_command"`
 }
 
-// AnsibleGuideJsonResponse is the structured JSON response from the Ansible registration method guide API.
 type AnsibleGuideJsonResponse struct {
 	RegistrationGuideMeta
 	RegistrationToken string `json:"registration_token"`

--- a/api/tunnel/types.go
+++ b/api/tunnel/types.go
@@ -3,9 +3,9 @@ package tunnel
 import "github.com/alpacax/alpacon-cli/api/types"
 
 type TunnelSessionRequest struct {
-	Server      string `json:"server"`      // Server UUID
-	TargetPort  int    `json:"target_port"` // Target port on the remote server
-	Username    string `json:"username"`    // Username for the tunnel
+	Server      string `json:"server"` // Server UUID
+	TargetPort  int    `json:"target_port"`
+	Username    string `json:"username"`
 	Groupname   string `json:"groupname"`
 	ClientType  string `json:"client_type"`            // cli, web, proxy (default: cli)
 	WorkSession string `json:"work_session,omitempty"` // Optional work-session UUID; omitted when empty

--- a/api/websh/websh.go
+++ b/api/websh/websh.go
@@ -159,7 +159,6 @@ func BuildSessionRequest(serverID, username, groupname string, rows, cols int, w
 	}
 }
 
-// Create new websh session
 func CreateWebshSession(ac *client.AlpaconClient, serverName, username, groupname string, share, readOnly bool, workSessionID string) (SessionResponse, error) {
 	serverID, err := server.GetServerIDByName(ac, serverName)
 	if err != nil {
@@ -411,7 +410,6 @@ func (wsClient *WebsocketClient) writeToServer(inputChan <-chan string) {
 }
 
 func sharingInfo(response ShareResponse) {
-	// Sanitize credentials display based on environment
 	displayPassword := response.Password
 	hideCredentials := os.Getenv("ALPACON_HIDE_CREDENTIALS") == "true"
 	if hideCredentials {

--- a/api/workspace/access_control.go
+++ b/api/workspace/access_control.go
@@ -11,7 +11,6 @@ const (
 	accessControlURL = "/api/workspaces/access-control/-/"
 )
 
-// GetAccessControl retrieves the workspace access control settings.
 func GetAccessControl(ac *client.AlpaconClient) ([]byte, error) {
 	responseBody, err := ac.SendGetRequest(accessControlURL)
 	if err != nil {

--- a/api/workspace/authentication.go
+++ b/api/workspace/authentication.go
@@ -13,7 +13,6 @@ const (
 	authenticationURL = "/api/workspaces/security/-/"
 )
 
-// GetAuthentication retrieves the workspace authentication settings.
 func GetAuthentication(ac *client.AlpaconClient) ([]byte, error) {
 	responseBody, err := ac.SendGetRequest(authenticationURL)
 	if err != nil {

--- a/api/workspace/mfa_methods.go
+++ b/api/workspace/mfa_methods.go
@@ -12,7 +12,6 @@ const (
 	mfaMethodsURL = "/api/workspaces/security/-/mfa-methods/"
 )
 
-// GetMFAMethods retrieves the available MFA methods for the workspace.
 func GetMFAMethods(ac *client.AlpaconClient) ([]byte, error) {
 	responseBody, err := ac.SendGetRequest(mfaMethodsURL)
 	if err != nil {

--- a/api/workspace/notifications.go
+++ b/api/workspace/notifications.go
@@ -11,7 +11,6 @@ const (
 	notificationsURL = "/api/workspaces/notifications/"
 )
 
-// GetNotifications retrieves the workspace notification settings.
 func GetNotifications(ac *client.AlpaconClient) ([]byte, error) {
 	responseBody, err := ac.SendGetRequest(notificationsURL)
 	if err != nil {

--- a/api/workspace/preferences.go
+++ b/api/workspace/preferences.go
@@ -11,7 +11,6 @@ const (
 	preferencesURL = "/api/workspaces/preferences/-/"
 )
 
-// GetPreferences retrieves the workspace preferences.
 func GetPreferences(ac *client.AlpaconClient) ([]byte, error) {
 	responseBody, err := ac.SendGetRequest(preferencesURL)
 	if err != nil {

--- a/api/workspace/usage.go
+++ b/api/workspace/usage.go
@@ -74,20 +74,17 @@ func GetWorkspaceID(ac *client.AlpaconClient, paymentBaseURL, workspaceName stri
 	return "", fmt.Errorf("workspace %q not found in payment API", workspaceName)
 }
 
-// BillingPeriod represents the billing period for a workspace.
 type BillingPeriod struct {
 	Start     string `json:"start"`
 	End       string `json:"end"`
 	TotalDays int    `json:"total_days"`
 }
 
-// SubscriptionPeriod represents the subscription period.
 type SubscriptionPeriod struct {
 	Start string `json:"start"`
 	End   string `json:"end"`
 }
 
-// Subscription represents the subscription details.
 type Subscription struct {
 	ProductName  string             `json:"product_name"`
 	PlanName     string             `json:"plan_name"`
@@ -99,7 +96,6 @@ type Subscription struct {
 	Period       SubscriptionPeriod `json:"period"`
 }
 
-// ServiceUsage represents usage details for a single service.
 type ServiceUsage struct {
 	Name         string   `json:"name"`
 	Unit         string   `json:"unit"`
@@ -109,7 +105,6 @@ type ServiceUsage struct {
 	OverageCost  *string  `json:"overage_cost"`
 }
 
-// UsageMetadata holds account-level metadata for a workspace.
 type UsageMetadata struct {
 	Plan            string `json:"plan"`
 	IsSubscribed    bool   `json:"is_subscribed"`
@@ -118,7 +113,6 @@ type UsageMetadata struct {
 	AvailableCredit string `json:"available_credit"`
 }
 
-// UsageEstimate represents the full usage estimate response.
 type UsageEstimate struct {
 	BillingPeriod BillingPeriod           `json:"billing_period"`
 	Currency      string                  `json:"currency"`

--- a/api/workspace/workspace.go
+++ b/api/workspace/workspace.go
@@ -80,7 +80,6 @@ func ResolveWorkspaceURL(accessToken, targetName, baseDomain string) (newURL, ne
 	return "", "", fmt.Errorf("workspace %q not found in your account", targetName)
 }
 
-// ValidateAndBuildWorkspaceURL finds the target workspace in the JWT and builds its full URL.
 func ValidateAndBuildWorkspaceURL(cfg config.Config, targetName string) (newURL, newName string, err error) {
 	return ResolveWorkspaceURL(cfg.AccessToken, targetName, cfg.BaseDomain)
 }

--- a/api/workspace/workspace_test.go
+++ b/api/workspace/workspace_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// buildTestJWT creates a minimal JWT string with the given payload claims.
 func buildTestJWT(t *testing.T, claims map[string]any) string {
 	t.Helper()
 	header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"RS256","typ":"JWT"}`))

--- a/client/client.go
+++ b/client/client.go
@@ -261,7 +261,6 @@ func (ac *AlpaconClient) sendRequest(req *http.Request) ([]byte, error) {
 	return respBody, nil
 }
 
-// Get Request to Alpacon Server
 func (ac *AlpaconClient) SendGetRequest(url string) ([]byte, error) {
 	req, err := ac.createRequest(http.MethodGet, url, nil)
 	if err != nil {
@@ -270,7 +269,6 @@ func (ac *AlpaconClient) SendGetRequest(url string) ([]byte, error) {
 	return ac.sendRequest(req)
 }
 
-// POST Request to Alpacon Server
 func (ac *AlpaconClient) SendPostRequest(url string, body any) ([]byte, error) {
 	jsonValue, err := json.Marshal(body)
 	if err != nil {

--- a/cmd/exec/exec_test.go
+++ b/cmd/exec/exec_test.go
@@ -6,8 +6,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// TestExecCommandParsing validates backward compatibility with the original
-// parsing behavior using the new ParseRemoteExecArgs implementation.
 func TestExecCommandParsing(t *testing.T) {
 	tests := []struct {
 		name              string
@@ -117,7 +115,6 @@ func TestExecCommandParsingWithFlags(t *testing.T) {
 	}
 }
 
-// TestRequiredExecPattern validates the exact pattern from the issue description.
 func TestRequiredExecPattern(t *testing.T) {
 	args := []string{"root@prod-docker", "docker", "ps"}
 	result := ParseRemoteExecArgs(args)

--- a/cmd/exec/parse.go
+++ b/cmd/exec/parse.go
@@ -8,7 +8,6 @@ import (
 	"github.com/alpacax/alpacon-cli/utils"
 )
 
-// RemoteExecArgs holds parsed arguments for remote command execution.
 type RemoteExecArgs struct {
 	Username      string
 	Groupname     string
@@ -149,7 +148,6 @@ func ParseRemoteExecArgs(args []string) RemoteExecArgs {
 		}
 	}
 
-	// Parse SSH-like user@host syntax
 	if server != "" && strings.Contains(server, "@") && !strings.Contains(server, ":") {
 		sshTarget := utils.ParseSSHTarget(server)
 		if username == "" && sshTarget.User != "" {
@@ -269,16 +267,13 @@ func matchShortOrLongFlag(arg, short, long string) bool {
 // Returns the value, updated index, and an error message if no value was found.
 func extractFlagValue(args []string, i int, short string) (string, int, string) {
 	arg := args[i]
-	// --flag=value
 	if strings.Contains(arg, "=") {
 		parts := strings.SplitN(arg, "=", 2)
 		return parts[1], i, ""
 	}
-	// -uroot (short flag with attached value, no space)
 	if strings.HasPrefix(arg, short) && len(arg) > len(short) {
 		return arg[len(short):], i, ""
 	}
-	// -u root (next arg is the value)
 	if i+1 < len(args) {
 		return args[i+1], i + 1, ""
 	}

--- a/cmd/ftp/cp.go
+++ b/cmd/ftp/cp.go
@@ -81,7 +81,6 @@ Requires an active WorkSession when using Browser login (Auth0); Token auth (API
 				if username == "" && sshTarget.User != "" {
 					username = sshTarget.User
 				}
-				// Reconstruct the argument without the user part
 				if sshTarget.Path != "" {
 					args[i] = sshTarget.Host + ":" + sshTarget.Path
 				} else {
@@ -93,7 +92,6 @@ Requires an active WorkSession when using Browser login (Auth0); Token auth (API
 		sources := args[:len(args)-1]
 		dest := args[len(args)-1]
 
-		// Validate source and destination paths
 		if err := validatePaths(sources, dest); err != nil {
 			utils.CliErrorWithExit("%s", err.Error())
 			return
@@ -194,12 +192,10 @@ func init() {
 	CpCmd.Flags().String("work-session", "", "Attach this transfer to a work-session (overrides 'work-session use')")
 }
 
-// isRemotePath determines if the given path is a remote server path.
 func isRemotePath(path string) bool {
 	return utils.IsRemoteTarget(path)
 }
 
-// isLocalPath determines if the given path is a local file system path.
 func isLocalPath(path string) bool {
 	return utils.IsLocalTarget(path)
 }
@@ -214,7 +210,6 @@ func isLocalPaths(paths []string) bool {
 }
 
 func validatePaths(sources []string, dest string) error {
-	// Check for mixed local and remote sources (not allowed)
 	hasLocal := false
 	hasRemote := false
 
@@ -234,7 +229,6 @@ func validatePaths(sources []string, dest string) error {
 			"  • Cannot mix: alpacon cp file1.txt server:/file2.txt /dest/  ❌")
 	}
 
-	// Check for invalid remote path format
 	allPaths := make([]string, 0, len(sources)+1)
 	allPaths = append(allPaths, sources...)
 	allPaths = append(allPaths, dest)
@@ -265,7 +259,6 @@ func validatePaths(sources []string, dest string) error {
 func uploadObject(client *client.AlpaconClient, src []string, dest, username, groupname string, recursive, allowOverwrite bool, workSessionID string) error {
 	var err error
 
-	// Extract server name for better error messages
 	serverName, remotePath := utils.SplitPath(dest)
 
 	if recursive {
@@ -274,7 +267,6 @@ func uploadObject(client *client.AlpaconClient, src []string, dest, username, gr
 		err = ftp.UploadFile(client, src, dest, username, groupname, allowOverwrite, workSessionID)
 	}
 	if err != nil {
-		// Parse error and provide specific guidance
 		errStr := err.Error()
 		if strings.Contains(errStr, "no such file or directory") {
 			utils.CliErrorWithExit("Source file(s) not found: %s\n\n"+
@@ -304,13 +296,11 @@ func uploadObject(client *client.AlpaconClient, src []string, dest, username, gr
 }
 
 func downloadObject(client *client.AlpaconClient, sources []string, dest, username, groupname string, recursive bool, workSessionID string) error {
-	// Extract server name for better error messages
 	serverName, remotePath := utils.SplitPath(sources[0])
 	srcDisplay := strings.Join(sources, ", ")
 
 	err := ftp.DownloadFile(client, sources, dest, username, groupname, recursive, workSessionID)
 	if err != nil {
-		// Parse error and provide specific guidance
 		errStr := err.Error()
 		if strings.Contains(errStr, "no such file or directory") || strings.Contains(errStr, "file not found") {
 			utils.CliErrorWithExit("Source file not found: '%s' on server '%s'.\n\n"+

--- a/cmd/ftp/cp_test.go
+++ b/cmd/ftp/cp_test.go
@@ -146,7 +146,6 @@ func TestIsLocalPaths(t *testing.T) {
 	}
 }
 
-// Test the SSH parsing logic used in the cp command
 func TestCpCommandSSHParsing(t *testing.T) {
 	tests := []struct {
 		name         string
@@ -215,12 +214,10 @@ func TestCpCommandSSHParsing(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Simulate the parsing logic from the cp command
 			args := make([]string, len(tt.args))
 			copy(args, tt.args)
 			username := ""
 
-			// Apply the same parsing logic as in cp.go
 			for i, arg := range args {
 				if strings.Contains(arg, "@") && strings.Contains(arg, ":") {
 					sshTarget := utils.ParseSSHTarget(arg)
@@ -241,7 +238,6 @@ func TestCpCommandSSHParsing(t *testing.T) {
 	}
 }
 
-// Test scenarios covering the required patterns from the issue
 func TestRequiredCpPatterns(t *testing.T) {
 	patterns := []struct {
 		description    string
@@ -286,7 +282,6 @@ func TestRequiredCpPatterns(t *testing.T) {
 				sources := pattern.args[:len(pattern.args)-1]
 				dest := pattern.args[len(pattern.args)-1]
 
-				// Test the logic that determines upload vs download
 				isUpload := isLocalPaths(sources) && isRemotePath(dest)
 				isDownload := isRemotePath(sources[0]) && isLocalPath(dest)
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -76,95 +76,38 @@ func Execute() {
 }
 
 func init() {
-	// Global output format flag
 	RootCmd.PersistentFlags().StringVar(
 		&utils.OutputFormat, "output", utils.OutputFormatTable,
 		"Output format: table or json",
 	)
-
-	// version
 	RootCmd.AddCommand(versionCmd)
-
-	// login
 	RootCmd.AddCommand(loginCmd)
-
-	// logout
 	RootCmd.AddCommand(logoutCmd)
-
-	// iam
 	RootCmd.AddCommand(iam.UserCmd)
 	RootCmd.AddCommand(iam.GroupCmd)
-
-	// server
 	RootCmd.AddCommand(server.ServerCmd)
-
-	// agent
 	RootCmd.AddCommand(agent.AgentCmd)
-
-	// websh
 	RootCmd.AddCommand(websh.WebshCmd)
-
-	// exec
 	RootCmd.AddCommand(exec.ExecCmd)
-
-	// ftp
 	RootCmd.AddCommand(ftp.CpCmd)
-
-	// edit
 	RootCmd.AddCommand(edit.EditCmd)
-
-	// packages
 	RootCmd.AddCommand(packages.PackagesCmd)
-
-	// log
 	RootCmd.AddCommand(log.LogCmd)
-
-	// event
 	RootCmd.AddCommand(event.EventCmd)
-
-	// note
 	RootCmd.AddCommand(note.NoteCmd)
-
-	// authority
 	RootCmd.AddCommand(authority.AuthorityCmd)
-
-	// csr
 	RootCmd.AddCommand(csr.CsrCmd)
-
-	// certificate
 	RootCmd.AddCommand(cert.CertCmd)
-
-	// token
 	RootCmd.AddCommand(token.TokenCmd)
-
-	// tunnel
 	RootCmd.AddCommand(tunnel.TunnelCmd)
-
-	// username
 	RootCmd.AddCommand(username.UsernameCmd)
-
-	// workspace
 	RootCmd.AddCommand(workspace.WorkspaceCmd)
-
-	// revoke
 	RootCmd.AddCommand(revoke.RevokeCmd)
-
-	// audit
 	RootCmd.AddCommand(audit.AuditCmd)
-
-	// webhook
 	RootCmd.AddCommand(webhook.WebhookCmd)
-
-	// webftp
 	RootCmd.AddCommand(webftp.WebFTPCmd)
-
-	// work-session
 	RootCmd.AddCommand(worksession.WorkSessionCmd)
-
-	// approval
 	RootCmd.AddCommand(approval.ApprovalCmd)
-
-	// whoami
 	RootCmd.AddCommand(whoamiCmd)
 }
 

--- a/cmd/server/token_create_test.go
+++ b/cmd/server/token_create_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/alpacax/alpacon-cli/client"
 )
 
-// groupListResponse is a minimal helper type for mock IAM group responses.
 type groupListItem struct {
 	ID   string `json:"id"`
 	Name string `json:"name"`

--- a/cmd/token/token.go
+++ b/cmd/token/token.go
@@ -25,6 +25,5 @@ func init() {
 	TokenCmd.AddCommand(tokenDuplicateCmd)
 	TokenCmd.AddCommand(tokenScopesCmd)
 
-	// ACL
 	TokenCmd.AddCommand(AclCmd)
 }

--- a/cmd/username/username_set.go
+++ b/cmd/username/username_set.go
@@ -31,7 +31,6 @@ var usernameSetCmd = &cobra.Command{
 	},
 }
 
-// setUsernameErrorText maps a SetUsername error to the message shown to the user.
 func setUsernameErrorText(err error) string {
 	code, _ := utils.ParseErrorResponse(err)
 	if msg, ok := iam.UsernameErrorMessage(code); ok {

--- a/cmd/websh/websh.go
+++ b/cmd/websh/websh.go
@@ -236,7 +236,6 @@ Note: All flags must be placed before the server name.
 			utils.CliErrorWithExit("The --share flag cannot be used with remote commands. Use --share for interactive sessions only.")
 		}
 
-		// Parse SSH-like syntax for user@host
 		if strings.Contains(serverName, "@") && !strings.Contains(serverName, ":") {
 			sshTarget := utils.ParseSSHTarget(serverName)
 			if username == "" && sshTarget.User != "" {

--- a/cmd/whoami.go
+++ b/cmd/whoami.go
@@ -187,7 +187,6 @@ func getExpiresAt(cfg config.Config) string {
 	return ""
 }
 
-// applyApplicationPrincipal fills out's application fields from an application-principal whoami response.
 func applyApplicationPrincipal(out whoamiOutput, who *auth.WhoamiResponse) whoamiOutput {
 	out.PrincipalType = auth.PrincipalTypeApplication
 	if who.Application != nil {

--- a/cmd/worksession/resolve.go
+++ b/cmd/worksession/resolve.go
@@ -11,7 +11,6 @@ import (
 // no --work-session flag is given. Resolution order: flag > env var > config.
 const WorkSessionEnvVar = "ALPACON_WORK_SESSION"
 
-// Resolve returns the effective work-session UUID using flag > env var > config priority.
 func Resolve(flagValue string) (string, error) {
 	if flagValue != "" {
 		return flagValue, nil
@@ -22,7 +21,6 @@ func Resolve(flagValue string) (string, error) {
 	return config.GetActiveWorkSession()
 }
 
-// ResolveOrExit resolves the work-session UUID and exits on error.
 func ResolveOrExit(flagValue string) string {
 	uuid, err := Resolve(flagValue)
 	if err != nil {

--- a/cmd/worksession/worksession_recording_test.go
+++ b/cmd/worksession/worksession_recording_test.go
@@ -12,8 +12,6 @@ func makeRecording(id, sessionID string) wsapi.TimelineItem {
 	return wsapi.TimelineItem{Type: "websh_record", ID: id, SessionID: sessionID}
 }
 
-// findRecording
-
 func TestFindRecording_DefaultFirst(t *testing.T) {
 	recs := []wsapi.TimelineItem{makeRecording("r1", "s1"), makeRecording("r2", "s1")}
 	target, idx := findRecording(recs, 1)
@@ -49,8 +47,6 @@ func TestFindRecording_NegativeIndex(t *testing.T) {
 	assert.Equal(t, -1, idx)
 }
 
-// buildRecordingIndex
-
 func TestBuildRecordingIndex_GroupsBySessionID(t *testing.T) {
 	items := []wsapi.TimelineItem{
 		{Type: "websh_session", ID: "s1"},
@@ -83,8 +79,6 @@ func TestBuildRecordingIndex_Empty(t *testing.T) {
 	assert.Empty(t, flat)
 }
 
-// recordingBadge
-
 func TestRecordingBadge_Single(t *testing.T) {
 	assert.Equal(t, "• 1 recording", recordingBadge(1))
 }
@@ -92,8 +86,6 @@ func TestRecordingBadge_Single(t *testing.T) {
 func TestRecordingBadge_Multiple(t *testing.T) {
 	assert.Equal(t, "• 3 recordings", recordingBadge(3))
 }
-
-// recordingPreview
 
 func TestRecordingPreview_StripsANSI(t *testing.T) {
 	raw := "\x1b]0;user@host:~\x07\x1b[?2004h[user@host:~]$ ls -la"

--- a/cmd/workspace/workspace_switch.go
+++ b/cmd/workspace/workspace_switch.go
@@ -47,10 +47,8 @@ var workspaceSwitchCmd = &cobra.Command{
 			utils.CliErrorWithExit("Failed to update config: %s", err)
 		}
 
-		// Verify connectivity to the new workspace
 		_, err = client.NewAlpaconAPIClient()
 		if err != nil {
-			// Revert to the original workspace
 			if revertErr := config.SwitchWorkspace(origURL, origName); revertErr != nil {
 				utils.CliErrorWithExit("Failed to connect to %q and could not revert config: %s (original error: %s)", newName, revertErr, err)
 			}

--- a/config/config.go
+++ b/config/config.go
@@ -42,7 +42,6 @@ func CreateConfig(workspaceURL, workspaceName, token, expiresAt, accessToken, re
 	return saveConfig(&config)
 }
 
-// SwitchWorkspace updates the workspace URL and name in the existing config.
 func SwitchWorkspace(newURL, newName string) error {
 	cfg, err := LoadConfig()
 	if err != nil {
@@ -227,7 +226,6 @@ func ResolveAuthMethod() string {
 	return GetAuthMethod(cfg)
 }
 
-// GetSmuxConfig returns a ready-to-use smux configuration.
 func GetSmuxConfig() *smux.Config {
 	config := smux.DefaultConfig()
 	config.KeepAliveInterval = 10 * time.Second // connection health check

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -138,7 +138,6 @@ func TestCreateConfig_BaseDomainOmittedFromJSON(t *testing.T) {
 func TestSwitchWorkspace(t *testing.T) {
 	setupTestConfig(t)
 
-	// Create initial config
 	err := CreateConfig(
 		"https://ws1.us1.alpacon.io", "ws1",
 		"", "", "access-token", "refresh-token",
@@ -146,7 +145,6 @@ func TestSwitchWorkspace(t *testing.T) {
 	)
 	assert.NoError(t, err)
 
-	// Switch workspace
 	err = SwitchWorkspace("https://ws2.us1.alpacon.io", "ws2")
 	assert.NoError(t, err)
 

--- a/config/types.go
+++ b/config/types.go
@@ -1,6 +1,5 @@
 package config
 
-// Config describes the configuration for Alpacon CLI
 type Config struct {
 	WorkspaceURL         string `json:"workspace_url"`
 	WorkspaceName        string `json:"workspace_name"`

--- a/pkg/cert/cert.go
+++ b/pkg/cert/cert.go
@@ -17,7 +17,6 @@ import (
 )
 
 func generateKey(keyPath string) (*rsa.PrivateKey, error) {
-	// 1. First, check if a key already exists at the provided path.
 	if _, err := os.Stat(keyPath); err == nil {
 		key, err := readPrivateKey(keyPath)
 		if err != nil {
@@ -27,13 +26,11 @@ func generateKey(keyPath string) (*rsa.PrivateKey, error) {
 		return key, nil
 	}
 
-	// 2. If no key exists at the path, generate a new one.
 	key, err := rsa.GenerateKey(rand.Reader, 2048)
 	if err != nil {
 		return nil, err
 	}
 
-	// 3. After generation, save the key at the specified path.
 	err = savePrivateKey(keyPath, key)
 	if err != nil {
 		return nil, err

--- a/pkg/tunnel/runtime/runtime.go
+++ b/pkg/tunnel/runtime/runtime.go
@@ -19,7 +19,6 @@ import (
 	"github.com/xtaci/smux"
 )
 
-// StartOptions contains user-provided inputs for starting a tunnel runtime.
 type StartOptions struct {
 	ServerName    string
 	LocalPort     string // Use "0" to auto-assign the local port.
@@ -185,7 +184,6 @@ func (r *Runtime) Cause() error {
 	return r.cause
 }
 
-// Close initiates runtime shutdown.
 func (r *Runtime) Close(cause error) {
 	r.shutdown(cause)
 }

--- a/utils/browser.go
+++ b/utils/browser.go
@@ -54,19 +54,15 @@ func OpenBrowser(url string) {
 	}
 }
 
-// shouldOpenBrowser checks whether it makes sense to attempt opening a browser.
 func shouldOpenBrowser(url string) bool {
-	// Only open http/https URLs
 	if !strings.HasPrefix(url, "https://") && !strings.HasPrefix(url, "http://") {
 		return false
 	}
 
-	// Respect explicit opt-out via environment variable
 	if v, ok := os.LookupEnv("ALPACON_NO_BROWSER"); ok && !strings.EqualFold(v, "0") && !strings.EqualFold(v, "false") {
 		return false
 	}
 
-	// Skip on SSH sessions
 	if _, ok := os.LookupEnv("SSH_CONNECTION"); ok {
 		return false
 	}
@@ -101,11 +97,9 @@ func acquireBrowserLock() bool {
 
 	info, err := os.Stat(lockPath)
 	if err == nil && time.Since(info.ModTime()) < browserDebounce {
-		// Another process opened the browser recently
 		return false
 	}
 
-	// Touch the lock file
 	if err := os.MkdirAll(filepath.Dir(lockPath), 0700); err != nil {
 		return true
 	}
@@ -125,7 +119,6 @@ func releaseBrowserLock() {
 	}
 }
 
-// browserLockPath returns the path to the browser debounce lock file.
 func browserLockPath() string {
 	home, err := os.UserHomeDir()
 	if err != nil {

--- a/utils/browser_test.go
+++ b/utils/browser_test.go
@@ -120,15 +120,12 @@ func TestAcquireBrowserLock(t *testing.T) {
 	alpaconDir := filepath.Join(tmpDir, ".alpacon")
 	lockFile := filepath.Join(alpaconDir, ".browser_lock")
 
-	// Patch browserLockPath for this test
 	origFunc := browserLockPathFunc
 	browserLockPathFunc = func() string { return lockFile }
 	t.Cleanup(func() { browserLockPathFunc = origFunc })
 
-	// First call should succeed
 	assert.True(t, acquireBrowserLock(), "first acquire should succeed")
 
-	// Lock file should exist
 	_, err := os.Stat(lockFile)
 	assert.NoError(t, err, "lock file should exist after acquire")
 
@@ -139,6 +136,5 @@ func TestAcquireBrowserLock(t *testing.T) {
 	expired := time.Now().Add(-browserDebounce - time.Second)
 	assert.NoError(t, os.Chtimes(lockFile, expired, expired))
 
-	// Now acquire should succeed again
 	assert.True(t, acquireBrowserLock(), "acquire after debounce expiry should succeed")
 }

--- a/utils/color.go
+++ b/utils/color.go
@@ -21,7 +21,6 @@ const (
 // stderr avoids ANSI artifacts when logs are piped or redirected.
 var colorEnabled = term.IsTerminal(int(os.Stderr.Fd()))
 
-// Green returns a bold green string for terminal output.
 func Green(value string) string {
 	if !colorEnabled {
 		return value
@@ -29,7 +28,6 @@ func Green(value string) string {
 	return fmt.Sprintf("%s%s%s%s", ansiBold, ansiGreen, value, ansiReset)
 }
 
-// Yellow returns a bold yellow string for terminal output.
 func Yellow(value string) string {
 	if !colorEnabled {
 		return value
@@ -37,7 +35,6 @@ func Yellow(value string) string {
 	return fmt.Sprintf("%s%s%s%s", ansiBold, ansiYellow, value, ansiReset)
 }
 
-// Blue returns a bold blue string for terminal output.
 func Blue(value string) string {
 	if !colorEnabled {
 		return value
@@ -45,7 +42,6 @@ func Blue(value string) string {
 	return fmt.Sprintf("%s%s%s%s", ansiBold, ansiBlue, value, ansiReset)
 }
 
-// Red returns a bold red string for terminal output.
 func Red(value string) string {
 	if !colorEnabled {
 		return value
@@ -53,7 +49,6 @@ func Red(value string) string {
 	return fmt.Sprintf("%s%s%s%s", ansiBold, ansiRed, value, ansiReset)
 }
 
-// Bold returns a bold string for terminal output.
 func Bold(value string) string {
 	if !colorEnabled {
 		return value

--- a/utils/error.go
+++ b/utils/error.go
@@ -98,7 +98,8 @@ func HTTPStatusCode(err error) int {
 	return 0
 }
 
-// RetryAfter returns the delay the server asked for on err, or 0 if it sent none.
+// RetryAfter returns the delay the server asked for on err, or 0 when it sent none
+// the client could use (absent, malformed, or out of a Duration's range).
 func RetryAfter(err error) time.Duration {
 	for e := err; e != nil; e = errors.Unwrap(e) {
 		if ra, ok := e.(retryAfterCarrier); ok {

--- a/utils/error_handler.go
+++ b/utils/error_handler.go
@@ -9,13 +9,9 @@ var maxRetryDuration = 3 * time.Minute
 
 var retryInterval = 1 * time.Second
 
-// ErrorHandlerCallbacks defines callback functions for handling different error types
 type ErrorHandlerCallbacks struct {
-	// OnMFARequired is called when MFA authentication is required
-	// serverName: the name of the server requiring MFA
 	OnMFARequired func(serverName string) error
 
-	// OnUsernameRequired is called when username is required
 	OnUsernameRequired func() error
 
 	// CheckMFACompleted is called to poll for MFA completion via a lightweight endpoint.
@@ -42,7 +38,6 @@ func HandleCommonErrors(err error, serverName string, callbacks ErrorHandlerCall
 			return err
 		}
 
-		// Handle MFA error
 		if err := callbacks.OnMFARequired(serverName); err != nil {
 			CliErrorWithExit("MFA authentication failed: %s", err)
 		}
@@ -125,19 +120,16 @@ func HandleCommonErrors(err error, serverName string, callbacks ErrorHandlerCall
 			return err
 		}
 
-		// Handle username required error
 		if err := callbacks.OnUsernameRequired(); err != nil {
 			return err
 		}
 
-		// Retry the operation if callback is provided
 		if callbacks.RetryOperation != nil {
 			return callbacks.RetryOperation()
 		}
 		return nil
 
 	default:
-		// Unknown error code, return original error
 		return err
 	}
 

--- a/utils/jwt_test.go
+++ b/utils/jwt_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// buildTestJWT creates a minimal JWT string with the given payload claims.
 func buildTestJWT(t *testing.T, claims map[string]any) string {
 	t.Helper()
 	header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"RS256","typ":"JWT"}`))

--- a/utils/log.go
+++ b/utils/log.go
@@ -13,14 +13,12 @@ func reportCLIError() {
 	fmt.Fprintln(os.Stderr, "For issues, check the latest version or report on", gitIssueURL)
 }
 
-// CliError handles all error messages in the CLI.
 func CliError(msg string, args ...any) {
 	errorMessage := fmt.Sprintf(msg, args...)
 	fmt.Fprintf(os.Stderr, "%s: %s\n", Red("Error"), errorMessage)
 	reportCLIError()
 }
 
-// CliErrorWithExit handles all error messages in the CLI.
 func CliErrorWithExit(msg string, args ...any) {
 	errorMessage := fmt.Sprintf(msg, args...)
 	fmt.Fprintf(os.Stderr, "%s: %s\n", Red("Error"), errorMessage)
@@ -37,27 +35,23 @@ func CliErrorWithExitCode(code int, msg string, args ...any) {
 	os.Exit(code)
 }
 
-// CliInfo handles all informational messages in the CLI.
 func CliInfo(msg string, args ...any) {
 	infoMessage := fmt.Sprintf(msg, args...)
 	fmt.Fprintf(os.Stderr, "%s: %s\n", Blue("Info"), infoMessage)
 }
 
-// CliWarning handles all warning messages in the CLI.
 func CliWarning(msg string, args ...any) {
 	warningMessage := fmt.Sprintf(msg, args...)
 	fmt.Fprintf(os.Stderr, "%s: %s\n", Yellow("Warning"), warningMessage)
 }
 
-// CliSuccess handles all success messages in the CLI.
 func CliSuccess(msg string, args ...any) {
 	successMessage := fmt.Sprintf(msg, args...)
 	fmt.Fprintf(os.Stderr, "%s: %s\n", Green("Success"), successMessage)
 }
 
-// CliInfoWithExit prints an informational message to stderr and exits the program with a status code of 0
 func CliInfoWithExit(msg string, args ...any) {
 	infoMessage := fmt.Sprintf(msg, args...)
 	fmt.Fprintf(os.Stderr, "%s: %s\n", Blue("Info"), infoMessage)
-	os.Exit(0) // Use exit code 0 to indicate successful completion.
+	os.Exit(0)
 }

--- a/utils/output.go
+++ b/utils/output.go
@@ -209,7 +209,6 @@ func camelToWords(s string) string {
 
 	for i := 1; i < len(runes); i++ {
 		if unicode.IsUpper(runes[i]) {
-			// Check if this is start of a new word
 			if unicode.IsLower(runes[i-1]) {
 				// "requestedAt" → split before "A"
 				words = append(words, string(runes[start:i]))

--- a/utils/prompt.go
+++ b/utils/prompt.go
@@ -77,7 +77,6 @@ func PromptForRequiredInput(promptText string) string {
 	}
 }
 
-// PromptForInputWithDefault prompts for input and returns the default if empty.
 func PromptForInputWithDefault(promptText, defaultValue string) string {
 	input := PromptForInput(promptText)
 	if input == "" {

--- a/utils/spinner.go
+++ b/utils/spinner.go
@@ -40,7 +40,6 @@ func NewSpinner(message string) *Spinner {
 	}
 }
 
-// Start begins the spinner animation
 func (s *Spinner) Start() {
 	s.mu.Lock()
 	if s.running {
@@ -64,7 +63,6 @@ func (s *Spinner) Start() {
 		for {
 			select {
 			case <-s.stopCh:
-				// Clear the spinner line
 				fmt.Fprint(os.Stderr, "\r\033[K")
 				return
 			default:
@@ -74,7 +72,6 @@ func (s *Spinner) Start() {
 
 				frame := s.frames[frameIdx%len(s.frames)]
 
-				// Animate dots if message ends with "..."
 				displayMsg := msg
 				if strings.HasSuffix(msg, "...") {
 					baseMsg := strings.TrimSuffix(msg, "...")
@@ -97,7 +94,6 @@ func (s *Spinner) Start() {
 	}()
 }
 
-// Stop stops the spinner animation
 func (s *Spinner) Stop() {
 	s.mu.Lock()
 	if !s.running {

--- a/utils/ssh_parser.go
+++ b/utils/ssh_parser.go
@@ -2,7 +2,6 @@ package utils
 
 import "strings"
 
-// SSHTarget represents a parsed SSH-like target with user, host, and path components
 type SSHTarget struct {
 	User string // Username (empty if not specified)
 	Host string // Hostname/server name
@@ -22,7 +21,6 @@ func ParseSSHTarget(target string) SSHTarget {
 
 	result.User, target = splitUserPrefix(target)
 
-	// Now check if there's a :path suffix
 	if strings.Contains(target, ":") {
 		parts := strings.SplitN(target, ":", 2)
 		result.Host = parts[0]
@@ -34,8 +32,7 @@ func ParseSSHTarget(target string) SSHTarget {
 	return result
 }
 
-// IsRemoteTarget checks if a target string represents a remote location
-// A target is considered remote if it contains a colon (:)
+// IsRemoteTarget reports whether target contains a colon, which marks it remote.
 func IsRemoteTarget(target string) bool {
 	_, target = splitUserPrefix(target)
 	return strings.Contains(target, ":")
@@ -51,7 +48,6 @@ func splitUserPrefix(target string) (string, string) {
 	return "", target
 }
 
-// IsLocalTarget checks if a target string represents a local location
 func IsLocalTarget(target string) bool {
 	return !IsRemoteTarget(target)
 }

--- a/utils/unzip_test.go
+++ b/utils/unzip_test.go
@@ -8,12 +8,10 @@ import (
 )
 
 func TestUnzip_ValidFiles(t *testing.T) {
-	// Create a temporary zip file with valid content
 	tmpDir := t.TempDir()
 	zipPath := filepath.Join(tmpDir, "test.zip")
 	extractDir := filepath.Join(tmpDir, "extract")
 
-	// Create test zip file
 	zf, err := os.Create(zipPath)
 	if err != nil {
 		t.Fatal(err)
@@ -23,7 +21,6 @@ func TestUnzip_ValidFiles(t *testing.T) {
 	zw := zip.NewWriter(zf)
 	defer func() { _ = zw.Close() }()
 
-	// Add a valid file
 	fw, err := zw.Create("test.txt")
 	if err != nil {
 		t.Fatal(err)
@@ -33,7 +30,6 @@ func TestUnzip_ValidFiles(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Add a file in subdirectory
 	fw, err = zw.Create("subdir/nested.txt")
 	if err != nil {
 		t.Fatal(err)
@@ -46,13 +42,11 @@ func TestUnzip_ValidFiles(t *testing.T) {
 	_ = zw.Close()
 	_ = zf.Close()
 
-	// Test extraction
 	err = Unzip(zipPath, extractDir)
 	if err != nil {
 		t.Errorf("Unzip failed for valid archive: %v", err)
 	}
 
-	// Verify files were extracted
 	if _, err := os.Stat(filepath.Join(extractDir, "test.txt")); os.IsNotExist(err) {
 		t.Error("Expected file test.txt was not extracted")
 	}
@@ -110,7 +104,6 @@ func TestUnzip_PathTraversalAttack(t *testing.T) {
 			zipPath := filepath.Join(tmpDir, "test.zip")
 			extractDir := filepath.Join(tmpDir, "extract")
 
-			// Create malicious zip file
 			zf, err := os.Create(zipPath)
 			if err != nil {
 				t.Fatal(err)
@@ -136,7 +129,6 @@ func TestUnzip_PathTraversalAttack(t *testing.T) {
 			_ = zw.Close()
 			_ = zf.Close()
 
-			// Test extraction
 			err = Unzip(zipPath, extractDir)
 			if tt.wantErr && err == nil {
 				t.Errorf("Expected error for malicious path %q, but got none", tt.filename)
@@ -145,9 +137,7 @@ func TestUnzip_PathTraversalAttack(t *testing.T) {
 				t.Errorf("Unexpected error for valid path %q: %v", tt.filename, err)
 			}
 
-			// Verify malicious file was not created outside extract directory
 			if tt.wantErr {
-				// Check that no files were created outside extractDir
 				parentDir := filepath.Dir(extractDir)
 				entries, _ := os.ReadDir(parentDir)
 				for _, entry := range entries {
@@ -165,7 +155,6 @@ func TestUnzip_DirectoryTraversal(t *testing.T) {
 	zipPath := filepath.Join(tmpDir, "test.zip")
 	extractDir := filepath.Join(tmpDir, "extract")
 
-	// Create zip with directory traversal
 	zf, err := os.Create(zipPath)
 	if err != nil {
 		t.Fatal(err)
@@ -174,7 +163,6 @@ func TestUnzip_DirectoryTraversal(t *testing.T) {
 
 	zw := zip.NewWriter(zf)
 
-	// Add a directory with parent path
 	header := &zip.FileHeader{
 		Name:   "../evil-dir/",
 		Method: zip.Deflate,
@@ -188,7 +176,6 @@ func TestUnzip_DirectoryTraversal(t *testing.T) {
 	_ = zw.Close()
 	_ = zf.Close()
 
-	// Test extraction should fail
 	err = Unzip(zipPath, extractDir)
 	if err == nil {
 		t.Error("Expected error for directory with path traversal, but got none")

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -152,7 +152,6 @@ func ExtractBaseDomain(workspaceURL string) string {
 	return strings.Join(parts[len(parts)-2:], ".")
 }
 
-// ExtractWorkspaceName extracts workspace name from workspace URL
 func ExtractWorkspaceName(workspaceURL string) string {
 	parsedURL, err := url.Parse(workspaceURL)
 	if err != nil {
@@ -583,7 +582,6 @@ func SplitPath(path string) (string, string) {
 	return parts[0], parts[1]
 }
 
-// IsInteractiveShell checks if the current program is running in an interactive terminal.
 func IsInteractiveShell() bool {
 	return term.IsTerminal(int(os.Stdin.Fd()))
 }


### PR DESCRIPTION
## Background

Comments and instruction files carry no compiler, so nothing tells you when they stop matching the code. Three of them had already stopped: `CLAUDE.md` named `event.RunCommand()` and `parseExecArgs`, neither of which exists; its project-structure block was missing nine command packages; `.github/copilot-instructions.md` listed `"all"` as a list alias no command registers.

The rest is volume. Comments that restate the declaration below them (`// Green returns a bold green string` above `func Green`) cost a reader's attention on every pass and say nothing the signature does not, and `CLAUDE.md` spent 66 of its 197 lines on material `ls`, errcheck, and staticcheck already provide.

## Changes

No executable line moves in this branch. `git diff main -- '*.go'` touches comments only.

| Commit | What changes |
|---|---|
| `docs: correct the repo docs the code had outgrown` | The two symbols that do not exist become `event.RunCommandStreaming()` and `ParseRemoteExecArgs`; the structure block gains the nine missing packages and `pkg/testutil`; the phantom `"all"` alias goes |
| `docs(utils): name the Retry-After values RetryAfter also drops` | `utils.RetryAfter`'s doc read 0 as "the server sent none", but `withRetryAfter` in `client/client.go` also drops a header that will not parse, one asking for zero or less, and one too large for a `time.Duration`. A caller taking 0 for "absent" would read those as a server that never asked to be retried |
| `docs: cut the comments that only restate the code` | 56 files, -168 lines. Signature echoes, section narration, and test-step labels. `CliError` and `CliErrorWithExit` carried the same sentence verbatim; `ValidateAndBuildWorkspaceURL` carried `ResolveWorkspaceURL`'s word for word. Survivors are compressed to what the code cannot say—`PollTransferStatus` keeps the two `transferType` values and what its bool reports, `IsRemoteTarget` keeps the colon rule |
| `docs(cmd): drop the per-command labels from root's init` | Every `AddCommand` had a comment naming the package it registers (`// tunnel` above `tunnel.TunnelCmd`) and a blank line to hold it apart. The registrations now read as one block |
| `docs: cut the parts of CLAUDE.md the tooling already carries` | The `cmd/` file-by-file inventory (answerable by `ls`, and stale until the first commit here), the two bullets restating the `cmd/` to `api/` call direction, the notes placing `cp` and the IAM commands, the good/bad pair demonstrating errcheck's own diagnostic, and the restatement of staticcheck ST1005. The discard shape this repo settled on is what the linter cannot tell you, so it stays as one line. 197 lines to 131 |
| `docs: keep one copy of the repo's agent instructions` | `.github/copilot-instructions.md` reproduced `CLAUDE.md`'s conventions and had drifted from both the code and its twin—besides the `"all"` alias, its tunnel example spelled a `Use` string `cmd/tunnel/tunnel.go:40` does not have. Every line in it was already in `CLAUDE.md`, so it becomes a pointer, and `AGENTS.md` is symlinked to `CLAUDE.md` rather than becoming a third copy |
| `docs: title CLAUDE.md for every agent that reads it` | Once `AGENTS.md` and the Copilot file both point at `CLAUDE.md`, its own heading and opening line still said Claude Code only, and the heading named a different file than the one a reader following the symlink has open. Both now say what the file is |

## What was kept

Deletion was the default, so the bar to survive is worth stating: a comment lives only where deleting it loses something the code cannot say. What that left is why-comments, non-obvious constraints, and contracts—the pacing rationale in `api/event/event.go`, the `command_fin` filter's per-server note, the magic-value decoders. Nothing in the streaming and throttling comments from #313 was cut; its numeric claims were checked against the constants instead and hold.

## Left for a human

`sample_test_cli.sh:206,210,221` carry Korean text inside comments, against `CLAUDE.md`'s "Always write comments in English". Rewriting a comment's language is not a mechanical fix, so it is reported rather than done here.

`ALPACON_EXEC_TIMEOUT` (default 30m, `api/event/event.go`) appears in neither `README.md` nor `CLAUDE.md`. It predates this branch, and documenting a flag is writing docs rather than tidying them.

## Testing

```
gofmt -l .                      no output
go build ./...                  ok
go test ./...                   ok, every package
```

Comments only, so the suite proves the absence of an accidental code edit rather than new behaviour.

