### PR TITLE
docs(utils): record why the CLI omits the credential override

### DIFF
--- a/utils/error.go
+++ b/utils/error.go
@@ -23,6 +23,12 @@ const (
 	// The rejected-forms list above is repeated in the exec and websh help text
 	// and the README's "When a command is denied" section—when the server-side
 	// gate changes, update all of them together.
+	//
+	// The server also accepts a per-command credential_exposure_acknowledged
+	// override, which the CLI deliberately does not expose: it records the
+	// exposure rather than preventing it (hygiene, not authorization—it carries
+	// no role gate), so exposing it would offer a one-flag way past the gate
+	// where rewriting with --env costs the same. --env stays the only path.
 	CommandInlineCredential = "command_inline_credential"
 
 	// WorkSession gate codes (returned by alpacon-server work_sessions/services.py)


### PR DESCRIPTION
## Background

alpacon-server accepts a per-command `credential_exposure_acknowledged`. Sending it passes the inline-credential gate (`execution_gate/stages.py:274-276`). The CLI has the field nowhere, and no note saying why, so the omission read as an oversight. #305 asked whether to expose it; this PR records the answer next to the constant.

The answer is not to expose it, for three reasons.

First, the override records the exposure rather than preventing it. The server frames the gate as hygiene, not authorization, and deliberately gave the override no role gate—the control is the audit trail, not a permission. alpacon-server commit `fd71f7e8f` states this explicitly: "Deliberately still no role gate on the override: ADR 0037 makes this gate hygiene, not authorization, so the control is the audit trail." The same commit put the override on the detail and list serializers and made it filterable, precisely so auditors can enumerate overrides. Its current role is an audited exception at the API level, not a routine path a CLI flag should pave.

Second, the stored rendering is masked either way (`mask_command_line`, ADR 0042, keyed on the same predicate as the gate). Acknowledging buys nothing but the command running—the secret still lands in `Command.line` verbatim, which is exactly what the gate exists to prevent.

Third, the override's original justification is gone. It entered the server as a false-positive escape hatch for the monitor-to-enforce rollout (alpacax/alpacon-server#2745, `COMMAND_CREDENTIAL_MODE`). That flag no longer exists: commit `fd71f7e8f` removed it after an adversarial review executed the patterns, produced the full false-positive and false-negative set, and both were closed (upstream alpacax/alpacon-ai-server#293, then the re-vendoring commit). The known false positives were fixed in the detector itself—`_is_indirect` in `utils/credentials.py` exempts shell variable references and command substitutions (`--password="$DB_PASSWORD"`), pinned by `RejectSemanticsTest`, and the key-boundary and prompt-mode `--password` cases moved upstream (ai-server#300, #302). The gaps still documented in that module are all false negatives (bare high-entropy secrets, uncommon key names, secrets in prose). A false positive today is a detector bug to report and fix, not an expected condition that needs a bypass flag.

Given all three, exposing the override would add a one-flag way past the rewrite the gate exists to force, while rewriting with `--env="KEY"` costs the caller the same keystroke count. There is no reason to build the bypass.

This is a judgment call recorded, not a door closed: if you read the trade-off differently—for example, a workflow where `--env` genuinely cannot carry the secret—please raise it here. The comment (and the decision) can be revised in this PR.

## Changes

Six comment lines on `CommandInlineCredential` in `utils/error.go`, recording the decision and its rationale. No executable line changed.

## Testing

`gofmt -l .` clean, `go build ./...` succeeds, `go vet ./utils/` clean. Comments only, so there is no behavior to verify.

Closes #305
