### PR TITLE
test: modernize assertion syntax and remove mixed testify usage

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,8 +6,15 @@ linters:
     - govet
     - ineffassign
     - staticcheck
+    - testifylint
     - unused
   settings:
+    testifylint:
+      disable:
+        # Pending cleanups tracked in issue #320; enable as each lands.
+        - require-error # 159 sites
+        - empty         # 29 sites, conversion still undecided
+        - go-require    # 11 sites: require inside handlers/goroutines
     errcheck:
       exclude-functions:
         - fmt.Fprintf

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,7 +12,7 @@ linters:
     testifylint:
       disable:
         # Pending cleanups tracked in issue #320; enable as each lands.
-        - require-error # 159 sites
+        - require-error # 149 sites
         - empty         # 29 sites, conversion still undecided
         - go-require    # 11 sites: require inside handlers/goroutines
     errcheck:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -159,7 +159,7 @@ _ = json.NewEncoder(w).Encode(resp)
 
 - Dedicated helper over a predicate wrapped in `True/False`: `Contains`/`NotContains`, `ErrorAs`/`NotErrorAs`, `Len`, `NoError`, `Empty`. The wrapper collapses both operands to one bool and failure output loses them. `testifylint` enforces all of these but `Empty`—its `empty` checker is still disabled in `.golangci.yml` (#320), so apply that one by hand. Suffix/prefix checks have no helper, so `assert.True(t, strings.HasSuffix(...))` stays
 - `require` when later lines depend on the assertion, `assert` when checks are independent. Never `require` inside an httptest handler or goroutine—`FailNow` off the test goroutine is undefined
-- No message that restates the assertion (helpers print operands and error chains themselves); keep only a reason the code cannot say
+- No message that restates the assertion (helpers print operands and error chains themselves); keep only a reason the code cannot say. `True`/`False` are the exception—they print `Should be true` and nothing else, so their message carries the operand: `"stderr line must end with a newline: %q", line`
 - JSON passthrough tests: one `JSONEq` over the whole body, not per-field asserts—field lists drift and silently drop fields
 
 ### Comments

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -157,7 +157,7 @@ _ = json.NewEncoder(w).Encode(resp)
 
 ### Assertion conventions (testify)
 
-- Dedicated helper over a predicate wrapped in `True/False`: `Contains`/`NotContains`, `ErrorAs`, `Len`, `NoError`, `Empty`. The wrapper collapses both operands to one bool and failure output loses them. Enforced by `testifylint`; suffix/prefix checks have no helper, so `assert.True(t, strings.HasSuffix(...))` stays
+- Dedicated helper over a predicate wrapped in `True/False`: `Contains`/`NotContains`, `ErrorAs`/`NotErrorAs`, `Len`, `NoError`, `Empty`. The wrapper collapses both operands to one bool and failure output loses them. `testifylint` enforces all of these but `Empty`—its `empty` checker is still disabled in `.golangci.yml` (#320), so apply that one by hand. Suffix/prefix checks have no helper, so `assert.True(t, strings.HasSuffix(...))` stays
 - `require` when later lines depend on the assertion, `assert` when checks are independent. Never `require` inside an httptest handler or goroutine—`FailNow` off the test goroutine is undefined
 - No message that restates the assertion (helpers print operands and error chains themselves); keep only a reason the code cannot say
 - JSON passthrough tests: one `JSONEq` over the whole body, not per-field asserts—field lists drift and silently drop fields

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -155,6 +155,13 @@ _ = json.NewEncoder(w).Encode(resp)
 - API tests use `httptest.NewServer` with a minimal `*client.AlpaconClient` pointing at `ts.URL`
 - Command logic is extracted to unexported helpers (e.g., `parseExecArgs`) for direct unit testing
 
+### Assertion conventions (testify)
+
+- Dedicated helper over a predicate wrapped in `True/False`: `Contains`/`NotContains`, `ErrorAs`, `Len`, `NoError`, `Empty`. The wrapper collapses both operands to one bool and failure output loses them. Enforced by `testifylint`; suffix/prefix checks have no helper, so `assert.True(t, strings.HasSuffix(...))` stays
+- `require` when later lines depend on the assertion, `assert` when checks are independent. Never `require` inside an httptest handler or goroutine—`FailNow` off the test goroutine is undefined
+- No message that restates the assertion (helpers print operands and error chains themselves); keep only a reason the code cannot say
+- JSON passthrough tests: one `JSONEq` over the whole body, not per-field asserts—field lists drift and silently drop fields
+
 ### Comments
 
 - Always write comments in English

--- a/api/event/event_test.go
+++ b/api/event/event_test.go
@@ -1920,7 +1920,7 @@ func TestGiveUpGap_BoundsCumulativeSkipped(t *testing.T) {
 		}
 	})
 
-	assert.Equal(t, maxGapWidth, len(g.skipped), "cumulative skipped capped at maxGapWidth")
+	assert.Len(t, g.skipped, maxGapWidth, "cumulative skipped capped at maxGapWidth")
 	// Gap 1 is fully recorded (retryable), gap 2 fills the cap mid-gap (partial
 	// retry), and later gaps must not claim a retry they won't get.
 	assert.Contains(t, stderr, "will retry at command end")

--- a/api/event/event_test.go
+++ b/api/event/event_test.go
@@ -3,7 +3,6 @@ package event
 import (
 	"bytes"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"math"
@@ -309,7 +308,7 @@ func TestErrorFromDetails_PropagatesExitCode(t *testing.T) {
 			require.Error(t, err)
 
 			var remoteErr *RemoteCommandError
-			require.True(t, errors.As(err, &remoteErr), "err must be *RemoteCommandError")
+			require.ErrorAs(t, err, &remoteErr)
 			assert.Equal(t, tt.wantOutput, remoteErr.Output)
 			assert.Equal(t, tt.wantExitCode, remoteErr.ExitCode)
 			assert.Equal(t, tt.wantErrorPhase, remoteErr.ErrorPhase)
@@ -320,7 +319,7 @@ func TestErrorFromDetails_PropagatesExitCode(t *testing.T) {
 func TestErrorFromDetails_AwaitingApprovalReturnsPendingApprovalError(t *testing.T) {
 	err := errorFromDetails(EventDetails{ID: "cmd-9", Status: "awaiting_approval"})
 	var pending *PendingApprovalError
-	require.True(t, errors.As(err, &pending), "err must be *PendingApprovalError")
+	require.ErrorAs(t, err, &pending)
 	assert.Equal(t, "cmd-9", pending.CommandID)
 }
 
@@ -430,8 +429,7 @@ func TestPollCommandExecution_ClientTimeout(t *testing.T) {
 	require.Error(t, err)
 
 	var clientTimeout *ClientTimeoutError
-	require.True(t, errors.As(err, &clientTimeout),
-		"deadline expiry must surface a *ClientTimeoutError, got %T: %v", err, err)
+	require.ErrorAs(t, err, &clientTimeout, "deadline expiry must surface a client timeout")
 }
 
 func TestNextPollTick(t *testing.T) {
@@ -587,8 +585,7 @@ func TestPollCommandExecution_ThrottleExtensionIsBoundedByDuration(t *testing.T)
 	_, err := pollCommandExecution(ac, "cmd-1", 100*time.Millisecond, 5*time.Millisecond, false, seams)
 
 	var clientTimeout *ClientTimeoutError
-	require.True(t, errors.As(err, &clientTimeout),
-		"a permanently throttled poll must surface a *ClientTimeoutError, got %T: %v", err, err)
+	require.ErrorAs(t, err, &clientTimeout, "a permanently throttled poll must surface a client timeout")
 	// One 300ms extension spends the 100ms budget whole—the ceiling is the timeout plus
 	// one backoff wait, not the timeout. The second wait gets no extension and is cut
 	// to the 95ms left, so the timeout is reported at the deadline, not 300ms past it.
@@ -613,8 +610,7 @@ func TestPollCommandExecution_ThrottleExtensionIsBoundedByCount(t *testing.T) {
 	_, err := pollCommandExecution(ac, "cmd-1", timeout, tick, false, seams)
 
 	var clientTimeout *ClientTimeoutError
-	require.True(t, errors.As(err, &clientTimeout),
-		"a permanently throttled poll must surface a *ClientTimeoutError, got %T: %v", err, err)
+	require.ErrorAs(t, err, &clientTimeout, "a permanently throttled poll must surface a client timeout")
 	var elapsed time.Duration
 	for _, d := range delays() {
 		elapsed += d
@@ -683,8 +679,7 @@ func TestPollCommandExecution_ProgressRestoresThrottleExtensions(t *testing.T) {
 	_, err := pollCommandExecution(ac, "cmd-1", timeout, tick, false, seams)
 
 	var clientTimeout *ClientTimeoutError
-	require.True(t, errors.As(err, &clientTimeout),
-		"a permanently throttled poll must surface a *ClientTimeoutError, got %T: %v", err, err)
+	require.ErrorAs(t, err, &clientTimeout, "a permanently throttled poll must surface a client timeout")
 	var elapsed time.Duration
 	for _, d := range delays() {
 		elapsed += d
@@ -1127,7 +1122,7 @@ func TestRunCommandStreaming_FailedStatusPropagatesExitCode(t *testing.T) {
 	err := runCommandStreamingWithWriter(ac, "srv", "exit 23", "", "", nil, "", stdoutBuf)
 	require.Error(t, err)
 	var remoteErr *RemoteCommandError
-	require.True(t, errors.As(err, &remoteErr), "failed status must yield *RemoteCommandError")
+	require.ErrorAs(t, err, &remoteErr, "failed status must yield a remote command error")
 	assert.Equal(t, 23, remoteErr.ExitCode)
 	assert.Equal(t, "before-exit\n", stdoutBuf.String())
 }

--- a/api/event/event_test.go
+++ b/api/event/event_test.go
@@ -1122,7 +1122,7 @@ func TestRunCommandStreaming_FailedStatusPropagatesExitCode(t *testing.T) {
 	err := runCommandStreamingWithWriter(ac, "srv", "exit 23", "", "", nil, "", stdoutBuf)
 	require.Error(t, err)
 	var remoteErr *RemoteCommandError
-	require.ErrorAs(t, err, &remoteErr, "failed status must yield a remote command error")
+	require.ErrorAs(t, err, &remoteErr)
 	assert.Equal(t, 23, remoteErr.ExitCode)
 	assert.Equal(t, "before-exit\n", stdoutBuf.String())
 }
@@ -1920,7 +1920,7 @@ func TestGiveUpGap_BoundsCumulativeSkipped(t *testing.T) {
 		}
 	})
 
-	assert.Len(t, g.skipped, maxGapWidth, "cumulative skipped capped at maxGapWidth")
+	assert.Len(t, g.skipped, maxGapWidth)
 	// Gap 1 is fully recorded (retryable), gap 2 fills the cap mid-gap (partial
 	// retry), and later gaps must not claim a retry they won't get.
 	assert.Contains(t, stderr, "will retry at command end")

--- a/api/websh/websh_test.go
+++ b/api/websh/websh_test.go
@@ -92,7 +92,7 @@ func TestGetSessionDetail(t *testing.T) {
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodGet, r.Method)
-		assert.True(t, strings.Contains(r.URL.Path, "sess-abc"))
+		assert.Contains(t, r.URL.Path, "sess-abc")
 
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(detail)
@@ -168,7 +168,7 @@ func TestConnectToSession(t *testing.T) {
 func TestInviteToSession(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodPost, r.Method)
-		assert.True(t, strings.Contains(r.URL.Path, "sess-abc/invite"))
+		assert.Contains(t, r.URL.Path, "sess-abc/invite")
 
 		var req InviteRequest
 		require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
@@ -187,7 +187,7 @@ func TestInviteToSession(t *testing.T) {
 func TestJoinWebshSession(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodPost, r.Method)
-		assert.True(t, strings.Contains(r.URL.Path, "chan-id-123/join"))
+		assert.Contains(t, r.URL.Path, "chan-id-123/join")
 
 		var req JoinRequest
 		require.NoError(t, json.NewDecoder(r.Body).Decode(&req))

--- a/api/workspace/authentication_test.go
+++ b/api/workspace/authentication_test.go
@@ -31,7 +31,7 @@ func TestGetAuthentication(t *testing.T) {
 
 	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
 	body, err := GetAuthentication(ac)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	expectedJSON, err := json.Marshal(expected)
 	require.NoError(t, err)
@@ -59,7 +59,7 @@ func TestGetAuthentication_EmptyResponse(t *testing.T) {
 
 	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
 	body, err := GetAuthentication(ac)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	var got map[string]any
 	err = json.Unmarshal(body, &got)

--- a/api/workspace/authentication_test.go
+++ b/api/workspace/authentication_test.go
@@ -8,12 +8,13 @@ import (
 
 	"github.com/alpacax/alpacon-cli/client"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestGetAuthentication(t *testing.T) {
 	expected := map[string]any{
 		"mfa_required":         true,
-		"mfa_timeout":          float64(300),
+		"mfa_timeout":          300,
 		"allowed_mfa_methods":  []any{"email", "otp"},
 		"mfa_required_actions": []any{"server", "websh"},
 		"passkey_as_mfa":       false,
@@ -32,14 +33,9 @@ func TestGetAuthentication(t *testing.T) {
 	body, err := GetAuthentication(ac)
 	assert.NoError(t, err)
 
-	var got map[string]any
-	err = json.Unmarshal(body, &got)
-	assert.NoError(t, err)
-	assert.Equal(t, true, got["mfa_required"])
-	assert.Equal(t, float64(300), got["mfa_timeout"])
-	assert.Equal(t, []any{"email", "otp"}, got["allowed_mfa_methods"])
-	assert.Equal(t, []any{"server", "websh"}, got["mfa_required_actions"])
-	assert.Equal(t, false, got["passkey_as_mfa"])
+	expectedJSON, err := json.Marshal(expected)
+	require.NoError(t, err)
+	assert.JSONEq(t, string(expectedJSON), string(body))
 }
 
 func TestGetAuthentication_ServerError(t *testing.T) {

--- a/api/workspace/preferences_test.go
+++ b/api/workspace/preferences_test.go
@@ -34,7 +34,7 @@ func TestGetPreferences(t *testing.T) {
 
 	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
 	body, err := GetPreferences(ac)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	expectedJSON, err := json.Marshal(expected)
 	require.NoError(t, err)
@@ -62,7 +62,7 @@ func TestGetPreferences_EmptyResponse(t *testing.T) {
 
 	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
 	body, err := GetPreferences(ac)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	var got map[string]any
 	err = json.Unmarshal(body, &got)

--- a/api/workspace/preferences_test.go
+++ b/api/workspace/preferences_test.go
@@ -8,14 +8,15 @@ import (
 
 	"github.com/alpacax/alpacon-cli/client"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestGetPreferences(t *testing.T) {
 	expected := map[string]any{
 		"language":              "ko",
 		"timezone":              "Asia/Seoul",
-		"invite_ttl":            float64(172800),
-		"websh_session_timeout": float64(3600),
+		"invite_ttl":            172800,
+		"websh_session_timeout": 3600,
 		"auto_agent_upgrade":    true,
 		"package_proxy":         nil,
 		"front_url":             "https://example.alpacon.io",
@@ -35,15 +36,9 @@ func TestGetPreferences(t *testing.T) {
 	body, err := GetPreferences(ac)
 	assert.NoError(t, err)
 
-	var got map[string]any
-	err = json.Unmarshal(body, &got)
-	assert.NoError(t, err)
-	assert.Equal(t, "ko", got["language"])
-	assert.Equal(t, "Asia/Seoul", got["timezone"])
-	assert.Equal(t, float64(172800), got["invite_ttl"])
-	assert.Equal(t, float64(3600), got["websh_session_timeout"])
-	assert.Equal(t, true, got["auto_agent_upgrade"])
-	assert.Equal(t, "KR", got["country"])
+	expectedJSON, err := json.Marshal(expected)
+	require.NoError(t, err)
+	assert.JSONEq(t, string(expectedJSON), string(body))
 }
 
 func TestGetPreferences_ServerError(t *testing.T) {

--- a/cmd/csr/csr_test.go
+++ b/cmd/csr/csr_test.go
@@ -76,7 +76,7 @@ func TestCsrSubcommands(t *testing.T) {
 		})
 	}
 
-	assert.Equal(t, 8, len(subCmds), "should have 8 subcommands")
+	assert.Len(t, subCmds, 8)
 }
 
 func TestSubcommandAliases(t *testing.T) {

--- a/cmd/exec/credential_hint_test.go
+++ b/cmd/exec/credential_hint_test.go
@@ -116,7 +116,7 @@ func TestExecInlineCredentialDenialExits1WithJSONErrorCode(t *testing.T) {
 	err := helper.Run()
 	require.Error(t, err)
 	var exitErr *osexec.ExitError
-	require.True(t, errors.As(err, &exitErr), "expected child process exit error, got %T", err)
+	require.ErrorAs(t, err, &exitErr)
 	assert.Equal(t, 1, exitErr.ExitCode(), "inline-credential refusal uses the general failure exit code, not a dedicated one")
 	assert.Empty(t, stdout.String())
 
@@ -165,7 +165,7 @@ func TestExecInlineCredentialDenialTablePrintsHint(t *testing.T) {
 	err := helper.Run()
 	require.Error(t, err)
 	var exitErr *osexec.ExitError
-	require.True(t, errors.As(err, &exitErr), "expected child process exit error, got %T", err)
+	require.ErrorAs(t, err, &exitErr)
 	assert.Equal(t, 1, exitErr.ExitCode())
 	assert.Empty(t, stdout.String())
 
@@ -218,7 +218,7 @@ func TestExecNonInlineCredentialErrorFallsThroughUnchanged(t *testing.T) {
 	err := helper.Run()
 	require.Error(t, err)
 	var exitErr *osexec.ExitError
-	require.True(t, errors.As(err, &exitErr), "expected child process exit error, got %T", err)
+	require.ErrorAs(t, err, &exitErr)
 	assert.Equal(t, 1, exitErr.ExitCode())
 
 	out := stderr.String()

--- a/cmd/exec/logs_test.go
+++ b/cmd/exec/logs_test.go
@@ -182,7 +182,7 @@ func TestLogsCommandOutcome(t *testing.T) {
 					assert.Contains(t, stderrLine, sub, "stderr should contain %q", sub)
 				}
 				assert.True(t, strings.HasSuffix(stderrLine, "\n"),
-					"stderr line should end with a newline")
+					"stderr line must end with a newline: %q", stderrLine)
 			}
 		})
 	}

--- a/cmd/exec/logs_test.go
+++ b/cmd/exec/logs_test.go
@@ -1,6 +1,7 @@
 package exec
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/alpacax/alpacon-cli/api/event"
@@ -180,9 +181,8 @@ func TestLogsCommandOutcome(t *testing.T) {
 				for _, sub := range tt.wantStderrContains {
 					assert.Contains(t, stderrLine, sub, "stderr should contain %q", sub)
 				}
-				if len(stderrLine) > 0 {
-					assert.Equal(t, '\n', rune(stderrLine[len(stderrLine)-1]), "stderr should end with newline")
-				}
+				assert.True(t, strings.HasSuffix(stderrLine, "\n"),
+					"stderr line should end with a newline")
 			}
 		})
 	}

--- a/cmd/exec/pending_approval_test.go
+++ b/cmd/exec/pending_approval_test.go
@@ -3,7 +3,6 @@ package exec
 import (
 	"bytes"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -104,7 +103,7 @@ func TestExecStatusAwaitingApprovalExits4WithJSONSignal(t *testing.T) {
 	err := helper.Run()
 	require.Error(t, err)
 	var exitErr *osexec.ExitError
-	require.True(t, errors.As(err, &exitErr), "expected child process exit error, got %T", err)
+	require.ErrorAs(t, err, &exitErr)
 	assert.Equal(t, utils.ExitCodePendingApproval, exitErr.ExitCode(), "pending approval must exit 4")
 
 	var got struct {
@@ -152,7 +151,7 @@ func TestExecPendingApprovalExits4WithJSONSignal(t *testing.T) {
 	err := helper.Run()
 	require.Error(t, err)
 	var exitErr *osexec.ExitError
-	require.True(t, errors.As(err, &exitErr), "expected child process exit error, got %T", err)
+	require.ErrorAs(t, err, &exitErr)
 	assert.Equal(t, utils.ExitCodePendingApproval, exitErr.ExitCode(), "pending approval must exit 4")
 
 	var got struct {

--- a/cmd/exec/run_test.go
+++ b/cmd/exec/run_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"strings"
 	"testing"
 	"time"
 
@@ -17,7 +18,7 @@ func TestClientTimeoutLine(t *testing.T) {
 	assert.Contains(t, line, "[client_timeout]", "stderr should carry the phase id in brackets")
 	assert.Contains(t, line, event.DescribePhase("client_timeout"),
 		"stderr should include the human-readable description")
-	assert.True(t, len(line) > 0 && line[len(line)-1] == '\n', "line should end with newline")
+	assert.True(t, strings.HasSuffix(line, "\n"), "line should end with newline")
 }
 
 func TestAsPhasedError(t *testing.T) {
@@ -108,7 +109,7 @@ func TestRemoteCommandOutcome(t *testing.T) {
 				"stderr should carry the phase identifier in brackets for CI/grep")
 			assert.Contains(t, stderrLine, event.DescribePhase(tt.wantStderrPhrase),
 				"stderr should include the human-readable phase description")
-			assert.True(t, len(stderrLine) > 0 && stderrLine[len(stderrLine)-1] == '\n',
+			assert.True(t, strings.HasSuffix(stderrLine, "\n"),
 				"stderr line should end with a newline")
 		})
 	}

--- a/cmd/exec/run_test.go
+++ b/cmd/exec/run_test.go
@@ -41,7 +41,7 @@ func TestAsPhasedError(t *testing.T) {
 			got, ok := asPhasedError(tt.err)
 			assert.Equal(t, tt.wantOk, ok)
 			if tt.wantNil {
-				assert.Nil(t, got)
+				assert.NoError(t, got)
 			}
 		})
 	}

--- a/cmd/exec/run_test.go
+++ b/cmd/exec/run_test.go
@@ -18,7 +18,7 @@ func TestClientTimeoutLine(t *testing.T) {
 	assert.Contains(t, line, "[client_timeout]", "stderr should carry the phase id in brackets")
 	assert.Contains(t, line, event.DescribePhase("client_timeout"),
 		"stderr should include the human-readable description")
-	assert.True(t, strings.HasSuffix(line, "\n"), "line should end with newline")
+	assert.True(t, strings.HasSuffix(line, "\n"), "line must end with a newline: %q", line)
 }
 
 func TestAsPhasedError(t *testing.T) {
@@ -110,7 +110,7 @@ func TestRemoteCommandOutcome(t *testing.T) {
 			assert.Contains(t, stderrLine, event.DescribePhase(tt.wantStderrPhrase),
 				"stderr should include the human-readable phase description")
 			assert.True(t, strings.HasSuffix(stderrLine, "\n"),
-				"stderr line should end with a newline")
+				"stderr line must end with a newline: %q", stderrLine)
 		})
 	}
 }

--- a/cmd/exec/sudo_hint_test.go
+++ b/cmd/exec/sudo_hint_test.go
@@ -3,7 +3,6 @@ package exec
 import (
 	"errors"
 	"fmt"
-	"strings"
 	"testing"
 
 	"github.com/alpacax/alpacon-cli/api/event"
@@ -15,31 +14,27 @@ func TestSudoDenialHint(t *testing.T) {
 		out := "Alpacon denied this sudo command (SUDO_NO_WORKSESSION_POLICY).\n"
 		hint := sudoDenialHint(out)
 		assert.NotEmpty(t, hint)
-		assert.True(t, strings.Contains(hint, "work-session update"),
-			"hint should point to the work-session update command")
+		assert.Contains(t, hint, "work-session update")
 	})
 
 	t.Run("presence-required points to a step-up", func(t *testing.T) {
 		hint := sudoDenialHint("Alpacon denied this sudo command (SUDO_PRESENCE_REQUIRED).\n")
 		assert.NotEmpty(t, hint)
-		assert.True(t, strings.Contains(hint, "step-up"),
-			"hint should tell the user to step up MFA")
+		assert.Contains(t, hint, "step-up")
 	})
 
 	t.Run("approval-required points to re-running after approval", func(t *testing.T) {
 		hint := sudoDenialHint("Alpacon denied this sudo command (SUDO_APPROVAL_REQUIRED).\n")
 		assert.NotEmpty(t, hint)
-		assert.True(t, strings.Contains(hint, "approv"),
-			"hint should mention the approval request")
+		assert.Contains(t, hint, "approv")
 	})
 
 	t.Run("risk-denied is a terminal denial", func(t *testing.T) {
 		hint := sudoDenialHint("Alpacon denied this sudo command (SUDO_RISK_DENIED).\n")
 		assert.NotEmpty(t, hint)
-		assert.True(t, strings.Contains(hint, "risk"),
-			"hint should name the risk assessment")
+		assert.Contains(t, hint, "risk")
 		// Disclosure: never echo a score/reasoning, only the category.
-		assert.False(t, strings.Contains(hint, "score"))
+		assert.NotContains(t, hint, "score")
 	})
 
 	t.Run("empty when no denial code", func(t *testing.T) {

--- a/cmd/exec/sudo_hint_test.go
+++ b/cmd/exec/sudo_hint_test.go
@@ -13,25 +13,21 @@ func TestSudoDenialHint(t *testing.T) {
 	t.Run("returns guidance when denial code present", func(t *testing.T) {
 		out := "Alpacon denied this sudo command (SUDO_NO_WORKSESSION_POLICY).\n"
 		hint := sudoDenialHint(out)
-		assert.NotEmpty(t, hint)
 		assert.Contains(t, hint, "work-session update")
 	})
 
 	t.Run("presence-required points to a step-up", func(t *testing.T) {
 		hint := sudoDenialHint("Alpacon denied this sudo command (SUDO_PRESENCE_REQUIRED).\n")
-		assert.NotEmpty(t, hint)
 		assert.Contains(t, hint, "step-up")
 	})
 
 	t.Run("approval-required points to re-running after approval", func(t *testing.T) {
 		hint := sudoDenialHint("Alpacon denied this sudo command (SUDO_APPROVAL_REQUIRED).\n")
-		assert.NotEmpty(t, hint)
 		assert.Contains(t, hint, "approv")
 	})
 
 	t.Run("risk-denied is a terminal denial", func(t *testing.T) {
 		hint := sudoDenialHint("Alpacon denied this sudo command (SUDO_RISK_DENIED).\n")
-		assert.NotEmpty(t, hint)
 		assert.Contains(t, hint, "risk")
 		// Disclosure: never echo a score/reasoning, only the category.
 		assert.NotContains(t, hint, "score")

--- a/cmd/exec/worksession_command_test.go
+++ b/cmd/exec/worksession_command_test.go
@@ -3,7 +3,6 @@ package exec
 import (
 	"bytes"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -66,7 +65,7 @@ func TestExecCommandWorkSessionGateExits3WithJSONDiagnostic(t *testing.T) {
 	err := helper.Run()
 	require.Error(t, err)
 	var exitErr *osexec.ExitError
-	require.True(t, errors.As(err, &exitErr), "expected child process exit error, got %T", err)
+	require.ErrorAs(t, err, &exitErr)
 	assert.Equal(t, utils.ExitCodeWorkSessionDenied, exitErr.ExitCode())
 	assert.Empty(t, stdout.String())
 	assert.True(t, sawCommandPost.Load(), "expected exec command to submit the remote command request")

--- a/cmd/login_test.go
+++ b/cmd/login_test.go
@@ -796,7 +796,7 @@ func runLoginCommandHelper(t *testing.T, args []string) (stdout, stderr string, 
 	exitCode = 0
 	if err != nil {
 		var exitErr *osexec.ExitError
-		require.True(t, errors.As(err, &exitErr), "expected exit error, got %T: %v", err, err)
+		require.ErrorAs(t, err, &exitErr)
 		exitCode = exitErr.ExitCode()
 	}
 	return stdoutBuf.String(), stderrBuf.String(), exitCode

--- a/cmd/server/server_action_test.go
+++ b/cmd/server/server_action_test.go
@@ -1,7 +1,6 @@
 package server
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -32,7 +31,7 @@ func TestBusyGuardMessage(t *testing.T) {
 			msg := busyGuardMessage("my-server", tt.force)
 			assert.Contains(t, msg, "my-server")
 			assert.Contains(t, msg, tt.wantContain)
-			assert.False(t, strings.Contains(msg, tt.wantAbsent), "message should not contain %q", tt.wantAbsent)
+			assert.NotContains(t, msg, tt.wantAbsent)
 		})
 	}
 }

--- a/cmd/worksession/worksession_create_test.go
+++ b/cmd/worksession/worksession_create_test.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"strings"
 	"testing"
 	"time"
 
@@ -128,13 +127,13 @@ func TestParseExpiryFlag_ExpiresAt(t *testing.T) {
 func TestParseExpiryFlag_BothProvided(t *testing.T) {
 	_, err := parseExpiryFlag("2h", "2026-12-31T23:59:59Z")
 	assert.Error(t, err)
-	assert.True(t, strings.Contains(err.Error(), "mutually exclusive"))
+	assert.Contains(t, err.Error(), "mutually exclusive")
 }
 
 func TestParseExpiryFlag_NeitherProvided(t *testing.T) {
 	_, err := parseExpiryFlag("", "")
 	assert.Error(t, err)
-	assert.True(t, strings.Contains(err.Error(), "required"))
+	assert.Contains(t, err.Error(), "required")
 }
 
 func TestParseExpiryFlag_InvalidDuration(t *testing.T) {
@@ -145,13 +144,13 @@ func TestParseExpiryFlag_InvalidDuration(t *testing.T) {
 func TestParseExpiryFlag_ZeroDuration(t *testing.T) {
 	_, err := parseExpiryFlag("0s", "")
 	assert.Error(t, err)
-	assert.True(t, strings.Contains(err.Error(), "positive duration"))
+	assert.Contains(t, err.Error(), "positive duration")
 }
 
 func TestParseExpiryFlag_NegativeDuration(t *testing.T) {
 	_, err := parseExpiryFlag("-1h", "")
 	assert.Error(t, err)
-	assert.True(t, strings.Contains(err.Error(), "positive duration"))
+	assert.Contains(t, err.Error(), "positive duration")
 }
 
 func TestResolveWaitTimeout(t *testing.T) {
@@ -192,7 +191,7 @@ func TestResolveWaitTimeout(t *testing.T) {
 func TestValidateAgentScopes_AgentWithWebsh(t *testing.T) {
 	err := validateAgentScopes("agent", []string{"command", "websh"})
 	assert.Error(t, err)
-	assert.True(t, strings.Contains(err.Error(), "\"websh\" is not allowed"))
+	assert.Contains(t, err.Error(), "\"websh\" is not allowed")
 }
 
 func TestValidateAgentScopes_AgentWithoutWebsh(t *testing.T) {

--- a/cmd/worksession/worksession_create_test.go
+++ b/cmd/worksession/worksession_create_test.go
@@ -125,13 +125,13 @@ func TestParseExpiryFlag_ExpiresAt(t *testing.T) {
 
 func TestParseExpiryFlag_BothProvided(t *testing.T) {
 	_, err := parseExpiryFlag("2h", "2026-12-31T23:59:59Z")
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Contains(t, err.Error(), "mutually exclusive")
 }
 
 func TestParseExpiryFlag_NeitherProvided(t *testing.T) {
 	_, err := parseExpiryFlag("", "")
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Contains(t, err.Error(), "required")
 }
 
@@ -142,13 +142,13 @@ func TestParseExpiryFlag_InvalidDuration(t *testing.T) {
 
 func TestParseExpiryFlag_ZeroDuration(t *testing.T) {
 	_, err := parseExpiryFlag("0s", "")
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Contains(t, err.Error(), "positive duration")
 }
 
 func TestParseExpiryFlag_NegativeDuration(t *testing.T) {
 	_, err := parseExpiryFlag("-1h", "")
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Contains(t, err.Error(), "positive duration")
 }
 
@@ -189,7 +189,7 @@ func TestResolveWaitTimeout(t *testing.T) {
 
 func TestValidateAgentScopes_AgentWithWebsh(t *testing.T) {
 	err := validateAgentScopes("agent", []string{"command", "websh"})
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Contains(t, err.Error(), "\"websh\" is not allowed")
 }
 
@@ -248,7 +248,7 @@ func TestValidateScopeEnum(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			err := validateScopeEnum(tt.scopes)
 			if tt.wantErr {
-				assert.Error(t, err)
+				require.Error(t, err)
 				for _, s := range tt.wantSubstrs {
 					assert.Contains(t, err.Error(), s)
 				}

--- a/cmd/worksession/worksession_create_test.go
+++ b/cmd/worksession/worksession_create_test.go
@@ -2,7 +2,6 @@ package worksession
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -45,7 +44,7 @@ func TestPollForApproval_TerminalStatusesAreDistinguishable(t *testing.T) {
 			assert.Contains(t, err.Error(), tt.wantMsg)
 
 			var terminal *terminalWaitError
-			assert.True(t, errors.As(err, &terminal), "a settled status must be typed so the caller can exit 6")
+			assert.ErrorAs(t, err, &terminal, "a settled status must be typed so the caller can exit 6")
 		})
 	}
 }
@@ -63,7 +62,7 @@ func TestPollForApproval_APIFailureIsNotTerminal(t *testing.T) {
 	require.Error(t, err)
 	var terminal *terminalWaitError
 	// A 500 is a transient failure, not a settled outcome—exit 1, not 6.
-	assert.False(t, errors.As(err, &terminal))
+	assert.NotErrorAs(t, err, &terminal)
 }
 
 func TestPollForApproval_TimeoutIsNotTerminal(t *testing.T) {
@@ -80,9 +79,9 @@ func TestPollForApproval_TimeoutIsNotTerminal(t *testing.T) {
 	require.Error(t, err)
 	// Still pending is exit 4's territory, not the settled-negative code.
 	var terminal *terminalWaitError
-	assert.False(t, errors.As(err, &terminal))
+	assert.NotErrorAs(t, err, &terminal)
 	var pending *pendingWaitError
-	assert.True(t, errors.As(err, &pending))
+	assert.ErrorAs(t, err, &pending)
 }
 
 // Guards the attempt-count regression: at interval=10ms the old logic returned

--- a/cmd/worksession/worksession_error_json_test.go
+++ b/cmd/worksession/worksession_error_json_test.go
@@ -3,7 +3,6 @@ package worksession
 import (
 	"bytes"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -123,7 +122,7 @@ func runWorkSessionHelper(t *testing.T, serverURL string, args ...string) (strin
 	exitCode := 0
 	if err != nil {
 		var exitErr *osexec.ExitError
-		require.True(t, errors.As(err, &exitErr), "expected exit error, got %T: %v", err, err)
+		require.ErrorAs(t, err, &exitErr)
 		exitCode = exitErr.ExitCode()
 	}
 	return stdout.String(), stderr.String(), exitCode

--- a/cmd/worksession/worksession_update_test.go
+++ b/cmd/worksession/worksession_update_test.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
-	"strings"
 	"testing"
 
 	wsapi "github.com/alpacax/alpacon-cli/api/worksession"
@@ -37,7 +36,7 @@ func TestValidateSessionForSudoUpdate(t *testing.T) {
 		assert.Contains(t, err.Error(), "ses-no-sudo")
 		assert.Contains(t, err.Error(), "'sudo' scope")
 		// Guidance must point at the create flag, not at a separate scope flag.
-		assert.True(t, strings.Contains(err.Error(), "--sudo"),
+		assert.Contains(t, err.Error(), "--sudo",
 			"guidance should reference --sudo so the user creates the right session next time")
 	})
 


### PR DESCRIPTION
## Background

Review of #278 flagged `assert.False(t, strings.Contains(...))` in `cmd/server/server_action_test.go:35`. That form collapses both operands into one bool, so a failure prints only "Should be false", while `assert.NotContains` prints the actual string together with the substring. This PR sweeps the whole suite for the same roundabout patterns, normalizes them to the dedicated helpers, and enables testifylint so they stay out.

## Changes

- Convert the 15 `assert.True/False`-wrapping-`strings.Contains` sites to `Contains`/`NotContains` and drop the 4 `strings` imports left unused (49ea7c7)
- Rewrite the newline checks in `cmd/exec/run_test.go` from `len(line) > 0 && line[len(line)-1] == '\n'` to `strings.HasSuffix`; testify has no suffix helper, so `assert.True` stays (e668afc)
- Convert the 19 assertions wrapping `errors.As`—the same anti-pattern—to `ErrorAs`/`NotErrorAs`. require/assert strength is preserved at every site, and messages that merely restated the type are dropped since the failure output already prints the expected type and the error chain (2cb8ba4)
- Replace the 2 `Equal`-on-`len` sites with `Len` and the 1 `Nil` on an error value with `NoError`, which compares `err != nil` exactly as callers do and therefore also catches typed-nil regressions (66d262e)
- Restructure the two workspace passthrough tests from per-field asserts to a single `JSONEq` over the whole payload. The per-field form had drifted to checking 6 of expected's 8 fields, and the `float64()` casts that existed only to match Unmarshal's number decoding go away with it (3315dbc)
- Enable testifylint in `.golangci.yml`. The three checkers with remaining findings—`require-error` (149), `empty` (29), `go-require` (11)—stay disabled and are tracked in #320 (2702cd1)
- Record the resulting assertion conventions in CLAUDE.md: dedicated helpers over wrapped predicates, the require/assert selection rule and the ban on `require` off the test goroutine, no assertion-restating messages, JSONEq for passthrough tests (57cf678)

## Review follow-ups

- Upgrade to `require` at every site whose next line consumes the result: the four workspace tests that feed `body` into `JSONEq`/`Unmarshal`, where an API error otherwise surfaced as "needs to be valid json" instead of the actual error (386904d), and the six `worksession_create_test.go` sites followed by `err.Error()`, where a nil error panicked and took the package's remaining test results with it (05d1b9d)
- Drop the two remaining messages that restated their assertion (3ca47cf) and the four `NotEmpty` checks that `Contains` already covers (1ab7744)
- Convert the last guarded newline check in `cmd/exec/logs_test.go`; the `if len(...) > 0` guard skipped the assertion on empty output, which is what a dropped newline produces (decc56b)
- Carry the operand in the three `HasSuffix` messages—`assert.True` prints only "Should be true", so this is the one place a message is not redundant with the helper (6c8ec24)
- Correct the CLAUDE.md helper list: `Empty` was documented as enforced while its checker is disabled, and `NotErrorAs` was missing (0f7cdae); refresh the `require-error` count the conversions above changed (e734405)

## Testing

- `go test -race ./...` — all packages ok
- `golangci-lint run ./...` — 0 issues with testifylint active
- Full-suite testifylint count 226 → 189; the checkers this PR addresses (contains, error-is-as, len, error-nil, float-compare) are all at 0
- Mutation check that `JSONEq` guards the previously unchecked fields: mutating only `front_url` in the handler fails the test; reverted with no trace
- Enforcement check: temporarily reintroducing the original pattern is caught immediately as `contains: use assert.NotContains`

Closes #279

