### PR TITLE
fix: strip the Cf runes the control-char passes miss on audit-review output

### DIFF
--- a/cmd/websh/websh_records.go
+++ b/cmd/websh/websh_records.go
@@ -55,7 +55,9 @@ Use --query to search records by command text (fuzzy match).`,
 }
 
 func sanitizeRecord(record string, width int) string {
-	record = utils.StripANSIEscapes(record)
+	// Format chars are deleted rather than spaced: they are zero-width, so a space
+	// in their place would widen the row beyond what was recorded.
+	record = utils.StripFormatAndANSI(record)
 	// Map control chars to spaces so they separate tokens instead of merging them.
 	record = strings.Map(func(r rune) rune {
 		if utils.IsControlRune(r) {

--- a/cmd/websh/websh_records.go
+++ b/cmd/websh/websh_records.go
@@ -55,8 +55,10 @@ Use --query to search records by command text (fuzzy match).`,
 }
 
 func sanitizeRecord(record string, width int) string {
-	// Format chars are deleted rather than spaced: they are zero-width, so a space
-	// in their place would widen the row beyond what was recorded.
+	// Format chars are deleted rather than spaced: a space would be
+	// indistinguishable from whitespace that was actually recorded, and no Cf rune
+	// carries anything a reviewer needs. The tradeoff is that legitimate text
+	// changes shape — a ZWJ emoji splits into its parts, Arabic joining breaks.
 	record = utils.StripFormatAndANSI(record)
 	// Map control chars to spaces so they separate tokens instead of merging them.
 	record = strings.Map(func(r rune) rune {

--- a/cmd/websh/websh_test.go
+++ b/cmd/websh/websh_test.go
@@ -391,6 +391,15 @@ func TestSanitizeRecord(t *testing.T) {
 
 	// C1 control (U+0085) separates tokens rather than leaking to the terminal.
 	assert.Equal(t, "foo bar", sanitizeRecord("foo"+string(rune(0x85))+"bar", 100))
+
+	// A bidi override (U+202E) carries no control byte, so IsControlRune alone
+	// leaves it free to reorder the record the reviewer reads. It is zero-width,
+	// so it goes without leaving a space behind.
+	assert.Equal(t, "foobar", sanitizeRecord("foo\u202ebar", 100))
+
+	// A format char buried in a sequence would break the escape match, leaving
+	// the sequence's tail on screen as text.
+	assert.Equal(t, "ls", sanitizeRecord("\x1b[2\u200dKls", 100))
 }
 
 func TestPrintWatchHeader_StripsControlSequences(t *testing.T) {

--- a/cmd/worksession/worksession_recording.go
+++ b/cmd/worksession/worksession_recording.go
@@ -81,11 +81,14 @@ func printRecordingHeader(w io.Writer, target *wsapi.TimelineItem, idx, total in
 
 func printRecordingContent(w io.Writer, raw string) {
 	// No full control pass: this path shows the recording as it was, so \r and the
-	// line endings have to survive. DEL and the C1 block are the exception — U+009B
-	// is an 8-bit CSI, so it opens a control sequence on a terminal that decodes
-	// them, and no C1 code point is content a recording can carry.
+	// line endings have to survive. DEL, the C1 block, and a bare ESC are the
+	// exception. ansiEscapeRE matches ESC-led forms ending in \x40-\x7e alone, so
+	// "ESC ( 0" and "ESC 7" get past it and still reach the reviewer's terminal,
+	// where they switch the charset and move the cursor off the line. Every matched
+	// sequence is already gone by here, so a leftover ESC is an introducer that
+	// failed to match and its tail belongs on screen as text.
 	content := strings.Map(func(r rune) rune {
-		if r == 0x7f || (r >= 0x80 && r <= 0x9f) {
+		if r == 0x1b || utils.IsC1OrDEL(r) {
 			return -1
 		}
 		return r

--- a/cmd/worksession/worksession_recording.go
+++ b/cmd/worksession/worksession_recording.go
@@ -81,14 +81,15 @@ func printRecordingHeader(w io.Writer, target *wsapi.TimelineItem, idx, total in
 
 func printRecordingContent(w io.Writer, raw string) {
 	// No full control pass: this path shows the recording as it was, so \r and the
-	// line endings have to survive. DEL, the C1 block, and a bare ESC are the
-	// exception. ansiEscapeRE matches ESC-led forms ending in \x40-\x7e alone, so
-	// "ESC ( 0" and "ESC 7" get past it and still reach the reviewer's terminal,
-	// where they switch the charset and move the cursor off the line. Every matched
-	// sequence is already gone by here, so a leftover ESC is an introducer that
-	// failed to match and its tail belongs on screen as text.
+	// line endings have to survive. ansiEscapeRE matches ESC-led forms ending in
+	// \x40-\x7e alone, so "ESC ( 0" and "ESC 7" get past it and switch the charset
+	// or move the cursor off the line. By here every matched sequence is gone, so a
+	// leftover ESC is an introducer that failed to match and its tail belongs on
+	// screen as text. SO and SI reach that same charset switch without an ESC and
+	// hold it until a reset; xterm in UTF-8 mode ignores them, the Linux console
+	// and VTE do not.
 	content := strings.Map(func(r rune) rune {
-		if r == 0x1b || utils.IsC1OrDEL(r) {
+		if r == 0x1b || r == 0x0e || r == 0x0f || utils.IsC1OrDEL(r) {
 			return -1
 		}
 		return r

--- a/cmd/worksession/worksession_recording.go
+++ b/cmd/worksession/worksession_recording.go
@@ -77,7 +77,9 @@ func printRecordingHeader(w io.Writer, target *wsapi.TimelineItem, idx, total in
 }
 
 func printRecordingContent(w io.Writer, raw string) {
-	content := utils.StripANSIEscapes(raw)
+	// No control pass: this path shows the recording as it was, so \r and the
+	// line endings have to survive.
+	content := utils.StripFormatAndANSI(raw)
 	_, _ = fmt.Fprint(w, content)
 	if len(content) > 0 && content[len(content)-1] != '\n' {
 		_, _ = fmt.Fprintln(w)

--- a/cmd/worksession/worksession_recording.go
+++ b/cmd/worksession/worksession_recording.go
@@ -71,7 +71,7 @@ func findRecording(recordings []wsapi.TimelineItem, index int) (*wsapi.TimelineI
 func printRecordingHeader(w io.Writer, target *wsapi.TimelineItem, idx, total int) {
 	header := fmt.Sprintf("Recording %d/%d", idx, total)
 	// formatTimestamp hands back the server's string whenever it fails to parse, so
-	// this line is a sink for whatever was stored, same as every other timeline cell.
+	// this line is a sink for whatever was stored.
 	if ts := utils.SanitizeTerminalText(resolveTimestamp(target.Timestamp)); ts != "" {
 		header += " — " + ts
 	}

--- a/cmd/worksession/worksession_recording.go
+++ b/cmd/worksession/worksession_recording.go
@@ -69,7 +69,9 @@ func findRecording(recordings []wsapi.TimelineItem, index int) (*wsapi.TimelineI
 
 func printRecordingHeader(w io.Writer, target *wsapi.TimelineItem, idx, total int) {
 	header := fmt.Sprintf("Recording %d/%d", idx, total)
-	if ts := resolveTimestamp(target.Timestamp); ts != "" {
+	// formatTimestamp hands back the server's string whenever it fails to parse, so
+	// this line is a sink for whatever was stored, same as every other timeline cell.
+	if ts := utils.SanitizeTerminalText(resolveTimestamp(target.Timestamp)); ts != "" {
 		header += " — " + ts
 	}
 	_, _ = fmt.Fprintln(w, header)

--- a/cmd/worksession/worksession_recording.go
+++ b/cmd/worksession/worksession_recording.go
@@ -2,6 +2,8 @@ package worksession
 
 import (
 	"fmt"
+	"io"
+	"os"
 
 	wsapi "github.com/alpacax/alpacon-cli/api/worksession"
 	"github.com/alpacax/alpacon-cli/client"
@@ -49,8 +51,8 @@ var workSessionRecordingCmd = &cobra.Command{
 			utils.CliUsageErrorEnvelopeWithExit(opRecording, "Recording index %d out of range (session has %d recording(s)).", recordingIndex, len(recordings))
 		}
 
-		printRecordingHeader(target, idx, len(recordings))
-		printRecordingContent(target.MaskedRecord)
+		printRecordingHeader(os.Stdout, target, idx, len(recordings))
+		printRecordingContent(os.Stdout, target.MaskedRecord)
 	},
 }
 
@@ -65,19 +67,19 @@ func findRecording(recordings []wsapi.TimelineItem, index int) (*wsapi.TimelineI
 	return &recordings[index-1], index
 }
 
-func printRecordingHeader(target *wsapi.TimelineItem, idx int, total int) {
+func printRecordingHeader(w io.Writer, target *wsapi.TimelineItem, idx, total int) {
 	header := fmt.Sprintf("Recording %d/%d", idx, total)
 	if ts := resolveTimestamp(target.Timestamp); ts != "" {
 		header += " — " + ts
 	}
-	fmt.Println(header)
-	fmt.Println()
+	_, _ = fmt.Fprintln(w, header)
+	_, _ = fmt.Fprintln(w)
 }
 
-func printRecordingContent(raw string) {
+func printRecordingContent(w io.Writer, raw string) {
 	content := utils.StripANSIEscapes(raw)
-	fmt.Print(content)
+	_, _ = fmt.Fprint(w, content)
 	if len(content) > 0 && content[len(content)-1] != '\n' {
-		fmt.Println()
+		_, _ = fmt.Fprintln(w)
 	}
 }

--- a/cmd/worksession/worksession_recording.go
+++ b/cmd/worksession/worksession_recording.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 
 	wsapi "github.com/alpacax/alpacon-cli/api/worksession"
 	"github.com/alpacax/alpacon-cli/client"
@@ -79,9 +80,16 @@ func printRecordingHeader(w io.Writer, target *wsapi.TimelineItem, idx, total in
 }
 
 func printRecordingContent(w io.Writer, raw string) {
-	// No control pass: this path shows the recording as it was, so \r and the
-	// line endings have to survive.
-	content := utils.StripFormatAndANSI(raw)
+	// No full control pass: this path shows the recording as it was, so \r and the
+	// line endings have to survive. DEL and the C1 block are the exception — U+009B
+	// is an 8-bit CSI, so it opens a control sequence on a terminal that decodes
+	// them, and no C1 code point is content a recording can carry.
+	content := strings.Map(func(r rune) rune {
+		if r == 0x7f || (r >= 0x80 && r <= 0x9f) {
+			return -1
+		}
+		return r
+	}, utils.StripFormatAndANSI(raw))
 	_, _ = fmt.Fprint(w, content)
 	if len(content) > 0 && content[len(content)-1] != '\n' {
 		_, _ = fmt.Fprintln(w)

--- a/cmd/worksession/worksession_recording_test.go
+++ b/cmd/worksession/worksession_recording_test.go
@@ -136,6 +136,17 @@ func TestRecordingPreview_StripsFormatCharBuriedInSequence(t *testing.T) {
 	assert.Equal(t, "ls", recordingPreview("\x1b[2\u200dKls"))
 }
 
+// printRecordingHeader
+
+func TestPrintRecordingHeader_SanitizesTimestamp(t *testing.T) {
+	// formatTimestamp returns the server's string as-is when it does not parse, so
+	// the header is a sink for an escape sequence that clears the reviewer's screen.
+	ts := "\x1b[2J\x1b[H\u202eSPOOFED"
+	var buf bytes.Buffer
+	printRecordingHeader(&buf, &wsapi.TimelineItem{Timestamp: &ts}, 1, 1)
+	assert.Equal(t, "Recording 1/1 — SPOOFED\n\n", buf.String())
+}
+
 // printRecordingContent
 
 func TestPrintRecordingContent_StripsFormatChars(t *testing.T) {

--- a/cmd/worksession/worksession_recording_test.go
+++ b/cmd/worksession/worksession_recording_test.go
@@ -121,3 +121,16 @@ func TestRecordingPreview_EmptyRaw(t *testing.T) {
 func TestRecordingPreview_OnlyANSI(t *testing.T) {
 	assert.Equal(t, "", recordingPreview("\x1b[?2004h\x1b[2J\x1b[H"))
 }
+
+func TestRecordingPreview_StripsBidiOverride(t *testing.T) {
+	// A bidi override carries no control byte, so the control pass alone leaves
+	// it free to reorder the preview a reviewer reads back.
+	raw := "[user@host:~]$ echo ‮safe"
+	assert.Equal(t, "[user@host:~]$ echo safe", recordingPreview(raw))
+}
+
+func TestRecordingPreview_StripsFormatCharBuriedInSequence(t *testing.T) {
+	// Format chars go before the escape strip, or the match breaks and the
+	// sequence's tail lands on screen as text.
+	assert.Equal(t, "ls", recordingPreview("\x1b[2‍Kls"))
+}

--- a/cmd/worksession/worksession_recording_test.go
+++ b/cmd/worksession/worksession_recording_test.go
@@ -163,6 +163,14 @@ func TestPrintRecordingContent_StripsC1Controls(t *testing.T) {
 	assert.Equal(t, "reboot2Krm -rf /\n", buf.String())
 }
 
+func TestPrintRecordingContent_StripsShiftFunctions(t *testing.T) {
+	// SO invokes G1 into GL and holds until SI or a reset: the same charset switch
+	// as "ESC ( 0", reached without an ESC.
+	var buf bytes.Buffer
+	printRecordingContent(&buf, "a\x0eb\x0fc\n")
+	assert.Equal(t, "abc\n", buf.String())
+}
+
 func TestPrintRecordingContent_StripsUnmatchedEscapeIntroducers(t *testing.T) {
 	// ansiEscapeRE ends an ESC-led form at \x40-\x7e, so these three get past it.
 	// Left in, "ESC ( 0" turns the rest of the reviewer's screen into line-drawing

--- a/cmd/worksession/worksession_recording_test.go
+++ b/cmd/worksession/worksession_recording_test.go
@@ -1,6 +1,7 @@
 package worksession
 
 import (
+	"bytes"
 	"strings"
 	"testing"
 
@@ -125,12 +126,28 @@ func TestRecordingPreview_OnlyANSI(t *testing.T) {
 func TestRecordingPreview_StripsBidiOverride(t *testing.T) {
 	// A bidi override carries no control byte, so the control pass alone leaves
 	// it free to reorder the preview a reviewer reads back.
-	raw := "[user@host:~]$ echo ‮safe"
+	raw := "[user@host:~]$ echo \u202esafe"
 	assert.Equal(t, "[user@host:~]$ echo safe", recordingPreview(raw))
 }
 
 func TestRecordingPreview_StripsFormatCharBuriedInSequence(t *testing.T) {
 	// Format chars go before the escape strip, or the match breaks and the
 	// sequence's tail lands on screen as text.
-	assert.Equal(t, "ls", recordingPreview("\x1b[2‍Kls"))
+	assert.Equal(t, "ls", recordingPreview("\x1b[2\u200dKls"))
+}
+
+// printRecordingContent
+
+func TestPrintRecordingContent_StripsFormatChars(t *testing.T) {
+	var buf bytes.Buffer
+	printRecordingContent(&buf, "echo \u202esafe\n")
+	assert.Equal(t, "echo safe\n", buf.String())
+}
+
+func TestPrintRecordingContent_KeepsControlBytes(t *testing.T) {
+	// The control pass is deliberately absent here: a recording shown as it was
+	// keeps \r and its line endings.
+	var buf bytes.Buffer
+	printRecordingContent(&buf, "a\rb")
+	assert.Equal(t, "a\rb\n", buf.String())
 }

--- a/cmd/worksession/worksession_recording_test.go
+++ b/cmd/worksession/worksession_recording_test.go
@@ -163,6 +163,15 @@ func TestPrintRecordingContent_StripsC1Controls(t *testing.T) {
 	assert.Equal(t, "reboot2Krm -rf /\n", buf.String())
 }
 
+func TestPrintRecordingContent_StripsRawC1Byte(t *testing.T) {
+	// A recording of an 8-bit program carries CSI as the raw byte 0x9b, which is
+	// invalid UTF-8, so IsC1OrDEL never sees it. What keeps it off the terminal is
+	// strings.Map substituting U+FFFD, so a rewrite into a byte loop reopens this.
+	var buf bytes.Buffer
+	printRecordingContent(&buf, "reboot\x9b2Krm -rf /\n")
+	assert.Equal(t, "reboot�2Krm -rf /\n", buf.String())
+}
+
 func TestPrintRecordingContent_StripsShiftFunctions(t *testing.T) {
 	// SO invokes G1 into GL and holds until SI or a reset: the same charset switch
 	// as "ESC ( 0", reached without an ESC.

--- a/cmd/worksession/worksession_recording_test.go
+++ b/cmd/worksession/worksession_recording_test.go
@@ -155,9 +155,17 @@ func TestPrintRecordingContent_StripsFormatChars(t *testing.T) {
 	assert.Equal(t, "echo safe\n", buf.String())
 }
 
+func TestPrintRecordingContent_StripsC1Controls(t *testing.T) {
+	// U+009B is an 8-bit CSI: left in, it erases the recorded line and the reviewer
+	// reads what follows instead.
+	var buf bytes.Buffer
+	printRecordingContent(&buf, "reboot\u009b2Krm -rf /\n")
+	assert.Equal(t, "reboot2Krm -rf /\n", buf.String())
+}
+
 func TestPrintRecordingContent_KeepsControlBytes(t *testing.T) {
-	// The control pass is deliberately absent here: a recording shown as it was
-	// keeps \r and its line endings.
+	// The C0 pass is deliberately absent here: a recording shown as it was keeps
+	// \r and its line endings.
 	var buf bytes.Buffer
 	printRecordingContent(&buf, "a\rb")
 	assert.Equal(t, "a\rb\n", buf.String())

--- a/cmd/worksession/worksession_recording_test.go
+++ b/cmd/worksession/worksession_recording_test.go
@@ -182,9 +182,8 @@ func TestPrintRecordingContent_StripsShiftFunctions(t *testing.T) {
 
 func TestPrintRecordingContent_StripsUnmatchedEscapeIntroducers(t *testing.T) {
 	// ansiEscapeRE ends an ESC-led form at \x40-\x7e, so these three get past it.
-	// Left in, "ESC ( 0" turns the rest of the reviewer's screen into line-drawing
-	// glyphs and "ESC 7"/"ESC 8" restore the cursor onto an earlier line, which lets
-	// the recording overwrite what was already read.
+	// "ESC 7"/"ESC 8" restore the cursor onto an earlier line, which lets the
+	// recording overwrite what the reviewer already read.
 	for _, raw := range []string{"ab\x1b(0", "ab\x1b7\x1b8", "ab\x1b#3"} {
 		var buf bytes.Buffer
 		printRecordingContent(&buf, raw)

--- a/cmd/worksession/worksession_recording_test.go
+++ b/cmd/worksession/worksession_recording_test.go
@@ -163,6 +163,18 @@ func TestPrintRecordingContent_StripsC1Controls(t *testing.T) {
 	assert.Equal(t, "reboot2Krm -rf /\n", buf.String())
 }
 
+func TestPrintRecordingContent_StripsUnmatchedEscapeIntroducers(t *testing.T) {
+	// ansiEscapeRE ends an ESC-led form at \x40-\x7e, so these three get past it.
+	// Left in, "ESC ( 0" turns the rest of the reviewer's screen into line-drawing
+	// glyphs and "ESC 7"/"ESC 8" restore the cursor onto an earlier line, which lets
+	// the recording overwrite what was already read.
+	for _, raw := range []string{"ab\x1b(0", "ab\x1b7\x1b8", "ab\x1b#3"} {
+		var buf bytes.Buffer
+		printRecordingContent(&buf, raw)
+		assert.NotContains(t, buf.String(), "\x1b", "raw %q", raw)
+	}
+}
+
 func TestPrintRecordingContent_KeepsControlBytes(t *testing.T) {
 	// The C0 pass is deliberately absent here: a recording shown as it was keeps
 	// \r and its line endings.

--- a/cmd/worksession/worksession_timeline.go
+++ b/cmd/worksession/worksession_timeline.go
@@ -313,7 +313,10 @@ func formatDetails(item *wsapi.TimelineItem) string {
 		return detail
 
 	case "websh_record":
-		return utils.TruncateString(item.MaskedRecord, 60)
+		// Sanitize before truncating, as every case above does: otherwise the 60-char
+		// budget goes on escape bytes and the cell shows less of the command than the
+		// rows beside it.
+		return utils.TruncateString(utils.SanitizeTerminalText(item.MaskedRecord), 60)
 
 	default:
 		return ""

--- a/cmd/worksession/worksession_timeline.go
+++ b/cmd/worksession/worksession_timeline.go
@@ -134,7 +134,9 @@ func recordingPreview(raw string) string {
 	scanner := bufio.NewScanner(strings.NewReader(raw))
 	scanner.Buffer(make([]byte, 64*1024), 1024*1024)
 	for i := 0; i < 50 && scanner.Scan(); i++ {
-		line := utils.StripANSIEscapes(scanner.Text())
+		// Not SanitizeTerminalText: its control pass would take \r before the
+		// overwrite handling below gets to use it.
+		line := utils.StripFormatAndANSI(scanner.Text())
 		// Strip trailing CR from CRLF line endings before overwrite handling.
 		line = strings.TrimRight(line, "\r")
 		// \r moves cursor to line start; take only the last overwritten segment

--- a/cmd/worksession/worksession_timeline.go
+++ b/cmd/worksession/worksession_timeline.go
@@ -2,9 +2,9 @@ package worksession
 
 import (
 	"bufio"
-	"encoding/json"
 	"fmt"
 	"io"
+	"os"
 	"strings"
 	"sync"
 	"text/tabwriter"
@@ -214,11 +214,11 @@ func outputTimelineJSON(rows []wsapi.TimelineAttributes, recordings []wsapi.Time
 		"timeline":   rows,
 		"recordings": recEntries,
 	}
-	b, err := json.MarshalIndent(out, "", "  ")
-	if err != nil {
+	// Not a plain Marshal: the shared writer escapes the format and C1 runes that
+	// encoding/json leaves alone, and this output is read in a terminal too.
+	if err := utils.PrintJSONValue(os.Stdout, out); err != nil {
 		utils.CliErrorEnvelopeWithExit(opTimeline, err, "Failed to serialize timeline: %s.", err)
 	}
-	fmt.Println(string(b))
 }
 
 func projectTimelineAttributes(item *wsapi.TimelineItem, serverMap map[string]string) wsapi.TimelineAttributes {

--- a/cmd/worksession/worksession_timeline_test.go
+++ b/cmd/worksession/worksession_timeline_test.go
@@ -213,6 +213,13 @@ func TestFormatDetails_WebshRecord(t *testing.T) {
 	assert.Equal(t, "ls -la /home/user", formatDetails(&item))
 }
 
+func TestFormatDetails_WebshRecord_SanitizesBeforeTruncating(t *testing.T) {
+	// The escape has to go before the 60-char cut, or it eats the budget the command
+	// text needs and the cell shows less than the rows beside it.
+	item := wsapi.TimelineItem{Type: "websh_record", MaskedRecord: "\x1b[2K\u202els -la"}
+	assert.Equal(t, "ls -la", formatDetails(&item))
+}
+
 func TestFormatDetails_Unknown(t *testing.T) {
 	item := wsapi.TimelineItem{Type: "unknown_event"}
 	assert.Equal(t, "", formatDetails(&item))

--- a/cmd/worksession/worksession_timeline_test.go
+++ b/cmd/worksession/worksession_timeline_test.go
@@ -252,6 +252,17 @@ func TestPrintRecordingsSectionTo_StripsControlSequences(t *testing.T) {
 	assert.Contains(t, got, "web-01db-prod")
 }
 
+// A bidi override in a server name reaches the terminal through --output json
+// too, so the JSON goes out escaped rather than verbatim.
+func TestOutputTimelineJSON_EscapesFormatChars(t *testing.T) {
+	rows := []wsapi.TimelineAttributes{{Server: "prod\u202edb"}}
+	out := testutil.CaptureStdout(t, func() {
+		outputTimelineJSON(rows, nil, nil)
+	})
+	assert.NotContains(t, out, "\u202e")
+	assert.Contains(t, out, `\u202e`)
+}
+
 // outputTimelineJSON must emit recordings as [] not null when no recordings exist,
 // including when --no-records passes nil for recordings.
 func TestOutputTimelineJSON_RecordingsEmptyArrayNotNull(t *testing.T) {

--- a/utils/output.go
+++ b/utils/output.go
@@ -70,9 +70,9 @@ func escapeJSONControls(b []byte) []byte {
 	for i := 0; i < len(b); {
 		r, size := utf8.DecodeRune(b[i:])
 		switch {
-		case r == 0x7f || (r >= 0x80 && r <= 0x9f) || unicode.Is(unicode.Cf, r):
+		case IsC1OrDEL(r) || unicode.Is(unicode.Cf, r):
 			out = appendUnicodeEscape(out, r)
-		case r == utf8.RuneError && size == 1 && b[i] >= 0x80 && b[i] <= 0x9f:
+		case r == utf8.RuneError && size == 1 && IsC1OrDEL(rune(b[i])):
 			out = appendUnicodeEscape(out, rune(b[i]))
 		default:
 			out = append(out, b[i:i+size]...)

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -488,6 +488,13 @@ func IsControlRune(r rune) bool {
 	return r < 0x20 || (r >= 0x7f && r <= 0x9f)
 }
 
+// IsC1OrDEL reports whether r is DEL or a C1 control. A terminal decodes U+009B as
+// an 8-bit CSI, so these open a control sequence that the escape pass never sees:
+// it matches ESC-led forms alone.
+func IsC1OrDEL(r rune) bool {
+	return r == 0x7f || (r >= 0x80 && r <= 0x9f)
+}
+
 func StripControlChars(s string) string {
 	return strings.Map(func(r rune) rune {
 		if IsControlRune(r) {

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -497,9 +497,9 @@ func StripControlChars(s string) string {
 	}, s)
 }
 
-// StripFormatChars removes Unicode format characters. They carry no control byte,
-// so the control passes miss them, while a bidi override reorders what is rendered:
-// "denied" can reach the screen as "approved".
+// StripFormatChars removes the Unicode format (Cf) characters. No Cf rune is a
+// control byte, so IsControlRune misses them all, while the bidi controls among
+// them reorder what a terminal renders: "denied" can display as "approved".
 func StripFormatChars(s string) string {
 	return strings.Map(func(r rune) rune {
 		if unicode.Is(unicode.Cf, r) {
@@ -509,11 +509,16 @@ func StripFormatChars(s string) string {
 	}, s)
 }
 
+// StripFormatAndANSI removes format characters before escape sequences. Reversed,
+// one buried in a sequence would break the match and leave its tail on screen.
+func StripFormatAndANSI(s string) string {
+	return StripANSIEscapes(StripFormatChars(s))
+}
+
 // SanitizeTerminalText strips escape sequences before the standalone control
 // bytes; reversed, ESC alone would go and "[2K" would stay on screen as text.
-// Format characters go first, so one buried in a sequence cannot break the match.
 func SanitizeTerminalText(s string) string {
-	return StripControlChars(StripANSIEscapes(StripFormatChars(s)))
+	return StripControlChars(StripFormatAndANSI(s))
 }
 
 // ProcessEditedData facilitates user modifications to original data,

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -376,10 +376,11 @@ func TestStripFormatChars(t *testing.T) {
 	assert.Equal(t, "abé", StripFormatChars("a\u200dbé"))
 
 	// The bidi controls are the ones that matter: they reorder what a terminal
-	// renders without changing a byte. Every one of them goes.
+	// renders without changing a byte. All twelve members of Bidi_Control go.
 	for _, r := range []rune{
 		0x202a, 0x202b, 0x202c, 0x202d, 0x202e, // embedding and override
 		0x2066, 0x2067, 0x2068, 0x2069, // isolates
+		0x061c, 0x200e, 0x200f, // marks
 	} {
 		assert.Equal(t, "ab", StripFormatChars("a"+string(r)+"b"), "U+%04X", r)
 	}

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -374,6 +374,18 @@ func TestStripFormatChars(t *testing.T) {
 	// Cf carries no control byte, so the control passes leave it behind.
 	assert.Equal(t, "denied approved", StripFormatChars("denied\u202e\u2066 approved"))
 	assert.Equal(t, "abé", StripFormatChars("a\u200dbé"))
+
+	// The bidi controls are the ones that matter: they reorder what a terminal
+	// renders without changing a byte. Every one of them goes.
+	for _, r := range []rune{
+		0x202a, 0x202b, 0x202c, 0x202d, 0x202e, // embedding and override
+		0x2066, 0x2067, 0x2068, 0x2069, // isolates
+	} {
+		assert.Equal(t, "ab", StripFormatChars("a"+string(r)+"b"), "U+%04X", r)
+	}
+
+	// Control bytes are StripControlChars' job; this pass leaves them alone.
+	assert.Equal(t, "a\x1bb", StripFormatChars("a\x1bb"))
 }
 
 func TestSanitizeTerminalText(t *testing.T) {


### PR DESCRIPTION
## Background

No Cf (Unicode format) rune carries a control byte, so `IsControlRune` misses all of them. Among them are the bidi controls U+202A-202E and U+2066-2069, which reorder what a terminal renders without changing a byte: a recorded `denied` can reach the reviewer's screen as `approved`. That makes it a Trojan Source attack aimed at the audit trail rather than at a compiler.

`a04efd2` added `utils.StripFormatChars` and `utils.SanitizeTerminalText` and covered most call sites. Three paths on the audit-review surface were still running the old `StripANSIEscapes` + `StripControlChars` pair, and a fourth bypassed the shared JSON writer entirely.

## Changes

- `utils.StripFormatAndANSI` names the format-then-escape order in one place (fb8396c). The order is load-bearing, not stylistic: a Cf rune buried in an escape sequence breaks the regex match and leaves the sequence's tail on screen as text. `SanitizeTerminalText` now composes it instead of spelling the order out again.
- `websh records`: `sanitizeRecord` let bidi overrides straight into the table (8572ae2). They are deleted rather than mapped to a space like the control bytes are, because a space would be indistinguishable from whitespace that was actually recorded and no Cf rune carries anything a reviewer needs. The trade is that legitimate non-Latin and emoji text comes out altered — a ZWJ emoji splits into its parts, Arabic joining breaks (c6f5766 corrects a comment that claimed width preservation instead).
- `work-session timeline`: `recordingPreview` stripped escapes, handled `\r` overwrites, then stripped control bytes, and a bidi override survived all three (73fb179). The format strip goes ahead of the escape strip rather than into the control pass at the end, because the `\r` overwrite handling in between needs `\r` alive.
- `work-session recording`: `printRecordingContent` stripped escape sequences only (2c6a5b1, 40579f5). This path shows the recording as it was recorded, so the C0 pass stays out and `\r` and the line endings survive; a bidi override has no such claim on the output. DEL and the C1 block do go (8499328) — U+009B is an 8-bit CSI, so a recorded `reboot` followed by U+009B `2K` erases itself and `rm -rf /` is what the reviewer reads. That is the same rune set `escapeJSONControls` already singles out. Both print helpers take an `io.Writer` so they can be tested at all.
- `work-session recording`: the header line took no strip of any kind (ff22534). `formatTimestamp` returns the server's string verbatim when it does not parse, so a stored `ESC[2J ESC[H` plus a bidi override cleared the reviewer's screen and reordered the header. Every sibling call site already wrapped this value; this one did not.
- `work-session timeline --output json`: `outputTimelineJSON` called `json.MarshalIndent` directly, bypassing the shared writer's `escapeJSONControls` (963d44e). `encoding/json` emits a bidi override verbatim, so the JSON path handed the terminal the reordering the table path already blocked. `PrintJSONValue` escapes rather than strips, so a decoder still reads the recorded value back unchanged. One side effect on this machine-readable surface: `FormatJSON` sets `SetEscapeHTML(false)` where `json.MarshalIndent` escapes HTML by default, so `&`, `<`, and `>` now come out literal instead of as `\u0026`, `\u003c`, `\u003e`. Decoder-equivalent, but a consumer grepping raw bytes would notice — and it does not make the CLI uniform: `PrintTable`'s JSON branch still marshals through `json.MarshalIndent`, so every list command keeps emitting `&`, `<`, `>`. Converging that one is its own change.

### Follow-ups from review

Findings from two review passes over the branch, each fixed here rather than deferred.

- `work-session recording`: `printRecordingContent` still let a bare ESC through (d970456). `ansiEscapeRE` ends an ESC-led form at `\x40-\x7e`, so a sequence whose final byte falls in `\x30-\x3f` never matches, and this is the one call site that follows `StripFormatAndANSI` with no control pass to sweep up the unmatched introducer. `ESC ( 0` switched the charset for the rest of the screen and `ESC 7` / `ESC 8` saved and restored the cursor, which is worse than the `\r` this path deliberately keeps: `\r` overwrites inside its own line, a restored cursor overwrites a line the reviewer already read. ESC is stripped after the regex rather than by widening the regex, so the change stays local — by that point anything the regex does match is gone, and leaving the tail as text is the trade `StripControlChars` already makes.
- `utils.IsC1OrDEL` names the DEL-and-C1 predicate that `escapeJSONControls` and `printRecordingContent` had each spelled out inline (8643b7c). Same rule, same reason, and widening one copy alone would have left a gap that reads as covered.
- `work-session timeline`: `formatDetails` wrapped every field it renders in `SanitizeTerminalText` except `websh_record`, which passed `MaskedRecord` to `TruncateString` raw (7c58b0b). MaskedRecord is the only verbatim terminal capture in the struct, so it was the wrong one to skip. Nothing leaked — `printTimelineTableTo` sanitizes the cell again and `escapeJSONControls` covers the JSON path — but the truncation order was visible: escape bytes spent the 60-rune budget, so a recording row showed less of the command than the command row beside it.
- `work-session recording`: `printRecordingContent` let SO and SI (`\x0e` / `\x0f`) through as well. SO invokes G1 into GL and the switch holds until SI or a reset — the same charset switch `ESC ( 0` performs, reached without an ESC. Both are C0 bytes, so the deliberate absence of a C0 pass on this path passed them straight to the screen. xterm in UTF-8 mode ignores the shift functions, but the Linux console, VTE, and PuTTY honor them, which is reviewer environment enough to close rather than document. BS, BEL, VT, and FF stay: like the `\r` this path keeps on purpose, they act inside their own line.
- The C1 case pinned only the two-byte UTF-8 form `C2 9B`. A recording of a program emitting 8-bit output carries the raw byte `0x9b`, which is invalid UTF-8, so `IsC1OrDEL` never decodes it — what keeps it off the terminal is `strings.Map` substituting U+FFFD for the invalid byte. That is an implicit stdlib property rather than a visible predicate, and a later rewrite into a byte loop would reopen it silently, so the raw form now has its own case. The same substitution is a fidelity change on the one path whose contract is "as it was recorded": invalid bytes used to reach the screen verbatim.

## Safety

The threat model is the reviewer's terminal, not the stored record. Nothing here rewrites what the server holds; each change is the last step before bytes reach a screen. Whether the server sanitizes these fields before serving them was not verified, so treat the CLI side as defence in depth rather than the only line.

`--output json` escapes instead of stripping, which keeps that path lossless for machine consumers while still safe to `cat`.

## Out of scope

U+2028 and U+2029 (Zl/Zp) are reached by no pass here — they are neither Cc nor Cf. The JSON path is safe either way, since both encoders escape them unconditionally, and xterm-family terminals do not honor them as line breaks, so the table path's practical risk is near zero. Anything downstream that does honor them (a web viewer, a log pipeline) would see a cell spill into a second row, which `utils/output.go:162-164` states as an invariant. Left for its own change rather than widened into this one.

The plain-text error path is the same harm class on a different surface: `CliError*` prints the message raw to stderr, and `parseAPIError` puts the server's `detail` — or the truncated body verbatim when it is not JSON — into that message, so a hostile or compromised server can land a bidi override or an escape sequence on the operator's terminal through any command's error output. The `--output json` error envelope already goes through `escapeJSONControls`; only the default text form is exposed. That is every command's stderr, not the audit-review surface this PR is scoped to, so it goes to its own issue rather than into this diff.

`ansiEscapeRE` itself keeps the narrow `\x40-\x7e` final-byte range; ECMA-48 allows `\x30-\x7e` for the nF forms. Every other caller runs a control pass afterwards, which removes the unmatched ESC and leaves the tail inert, so the gap has no other reachable consequence. Widening the regex would change what every sanitized string in the CLI looks like and belongs in its own change.

## Testing

- `go test -race -count=1 ./...` — 38 packages ok, no failures
- `golangci-lint run ./...` — 0 issues
- Every commit was checked out into a detached worktree and built and tested on its own; all pass
- `TestStripFormatChars` now pins all twelve members of `Bidi_Control` individually — the nine embedding, override, and isolate runes plus U+061C, U+200E, and U+200F, which the first version left out — and that the pass leaves control bytes to `StripControlChars`
- `TestRecordingPreview_StripsFormatCharBuriedInSequence` and the matching `sanitizeRecord` case pin the ordering: with the strips reversed, `\x1b[2<ZWJ>Kls` renders as `2Kls`
- `TestPrintRecordingHeader_SanitizesTimestamp` fails on the old code with `Recording 1/1 — \x1b[2J\x1b[H\u202eSPOOFED`
- `TestPrintRecordingContent_StripsC1Controls` fails on the old code with `reboot\^[2Krm -rf /`, and `TestPrintRecordingContent_KeepsControlBytes` still pins that `\r` survives
- `TestPrintRecordingContent_StripsUnmatchedEscapeIntroducers` covers the three forms `ansiEscapeRE` cannot match: `ESC ( 0`, `ESC 7` / `ESC 8`, `ESC # 3`
- `TestPrintRecordingContent_StripsShiftFunctions` fails on the old code with `a\x0eb\x0fc`
- `TestPrintRecordingContent_StripsRawC1Byte` pins the raw `0x9b` form down to the U+FFFD it becomes, so a rewrite away from `strings.Map` breaks the test rather than the protection
- `TestFormatDetails_WebshRecord_SanitizesBeforeTruncating` pins that the escape goes before the 60-rune cut

Closes #294

