### PR TITLE
build(go): raise the go directive to 1.25.13

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -26,7 +26,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25.x'
+          go-version-file: go.mod
 
       - name: Allow Go toolchain auto-download
         run: echo "GOTOOLCHAIN=auto" >> "$GITHUB_ENV"

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -52,8 +52,13 @@ jobs:
       - name: Allow Go toolchain auto-download
         run: echo "GOTOOLCHAIN=auto" >> "$GITHUB_ENV"
 
+      # Blank GOOS/GOARCH so the tool is always built for the runner, even if
+      # this job ever gains a cross-compilation matrix.
       - name: Install govulncheck
         run: go install golang.org/x/vuln/cmd/govulncheck@latest
+        env:
+          GOOS: ""
+          GOARCH: ""
 
       - name: Run govulncheck
         run: govulncheck ./...

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -24,7 +24,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25.x'
+          go-version-file: go.mod
 
       - name: Allow Go toolchain auto-download
         run: echo "GOTOOLCHAIN=auto" >> "$GITHUB_ENV"
@@ -39,10 +39,23 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Check out code
+        uses: actions/checkout@v6
+
+      # golang/govulncheck-action pins its own setup-go with GOTOOLCHAIN=local
+      # and a `go-version-input` that overrides `go-version-file`, so a runner
+      # whose tool cache lags behind go.mod fails before the scan starts. Run
+      # the same steps directly and let go.mod pick the toolchain.
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+
       - name: Allow Go toolchain auto-download
         run: echo "GOTOOLCHAIN=auto" >> "$GITHUB_ENV"
 
+      - name: Install govulncheck
+        run: go install golang.org/x/vuln/cmd/govulncheck@latest
+
       - name: Run govulncheck
-        uses: golang/govulncheck-action@v1
-        with:
-          go-version-input: '1.25.x'
+        run: govulncheck ./...

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -42,10 +42,8 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v6
 
-      # golang/govulncheck-action pins its own setup-go with GOTOOLCHAIN=local
-      # and a `go-version-input` that overrides `go-version-file`, so a runner
-      # whose tool cache lags behind go.mod fails before the scan starts. Run
-      # the same steps directly and let go.mod pick the toolchain.
+      # Inlined instead of golang/govulncheck-action: it forces its own Go
+      # version with GOTOOLCHAIN=local, so a tool cache behind go.mod fails.
       - name: Set up Go
         uses: actions/setup-go@v6
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -57,7 +57,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: 1.25.x
+          go-version-file: go.mod
 
       - name: Allow Go toolchain auto-download
         run: echo "GOTOOLCHAIN=auto" >> "$GITHUB_ENV"

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,10 +1,5 @@
 project_name: alpacon
 
-before:
-  hooks:
-    - go mod tidy
-    - go generate ./...
-
 builds:
   - env:
       - CGO_ENABLED=0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -186,7 +186,7 @@ _ = json.NewEncoder(w).Encode(resp)
 
 ## Important notes
 
-- **Go version**: 1.25.13 (specified in go.mod)
+- **Go version**: see the `go` directive in `go.mod`
 - **Linter**: golangci-lint v2 with errcheck, govet, ineffassign, staticcheck, unused (see `.golangci.yml`)
 - **Config file**: `~/.alpacon/config.json` (dir `0700`, file `0600`)
 - **Alias**: `alpacon` can also be invoked as `ac`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -186,7 +186,7 @@ _ = json.NewEncoder(w).Encode(resp)
 
 ## Important notes
 
-- **Go version**: 1.25.12 (specified in go.mod)
+- **Go version**: 1.25.13 (specified in go.mod)
 - **Linter**: golangci-lint v2 with errcheck, govet, ineffassign, staticcheck, unused (see `.golangci.yml`)
 - **Config file**: `~/.alpacon/config.json` (dir `0700`, file `0600`)
 - **Alias**: `alpacon` can also be invoked as `ac`

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/alpacax/alpacon-cli
 
-go 1.25.12
+go 1.25.13
 
 require (
 	github.com/gorilla/websocket v1.5.3


### PR DESCRIPTION
## Summary

The `govulncheck` job on `main` fails ([run #727](https://github.com/alpacax/alpacon-cli/actions/workflows/lint.yaml)) with four standard-library vulnerabilities. All four are fixed in go1.25.13, so this raises the `go` directive in `go.mod` from `1.25.12` to `1.25.13`—and then fixes the workflows, which turned out to be pinning the toolchain in a way that could not follow that bump.

| Advisory | Package | Reachable from |
| --- | --- | --- |
| [GO-2026-6218](https://pkg.go.dev/vuln/GO-2026-6218) | `net/url` — quadratic complexity in `resolvePath` | `client/client.go:366` |
| [GO-2026-6090](https://pkg.go.dev/vuln/GO-2026-6090) | `crypto/tls` — unbounded post-handshake messages | `pkg/tunnel/runtime/runtime.go:98`, `pkg/tunnel/pool.go:38`, `cmd/exec/run.go:379`, `client/client.go:366` |
| [GO-2026-5972](https://pkg.go.dev/vuln/GO-2026-5972) | `encoding/asn1` — unbounded recursion depth | `pkg/cert/cert.go:63` |
| [GO-2026-5026](https://pkg.go.dev/vuln/GO-2026-5026) | `net/http` (vendored `x/net/idna`) — ASCII-only Punycode labels accepted | `client/client.go:366`, `api/ftp/ftp.go:569` |

## Why the workflows had to change too

Raising the directive alone made the `govulncheck` job fail earlier and louder:

```
go: go.mod requires go >= 1.25.13 (running go 1.25.12; GOTOOLCHAIN=local)
```

Three things stack up to produce that:

1. `golang/govulncheck-action@v1` runs **its own `setup-go`** inside the composite action. `setup-go` sets `GOTOOLCHAIN=local` when it is handed an explicit version, which switches off toolchain auto-download.
2. The `GOTOOLCHAIN=auto` step we exported *before* the action is therefore overwritten by the action's own `setup-go`. It never had any effect on that job.
3. `go-version-input: '1.25.x'` resolved to **1.25.12**, the 1.25 build already sitting in the runner's tool cache. Against a go.mod that requires 1.25.13, the scan dies before it starts.

Pointing the action at go.mod is not straightforward: its `go-version-input` defaults to `'stable'` rather than an empty string, and `setup-go` resolves `go-version` ahead of `go-version-file`. Passing `go-version-input: ''` plausibly suppresses the composite default and lets the file input win, but that behavior is undocumented and would silently break on an upstream change. So this PR drops the action and inlines the same four steps it wraps—checkout, `setup-go`, `go install golang.org/x/vuln/cmd/govulncheck@latest`, `govulncheck ./...`—where our `GOTOOLCHAIN=auto` step actually applies.

While in there, every `setup-go` step across the three workflows now reads `go-version-file: go.mod`. Each one previously carried its own `1.25.x` wildcard, so the toolchain was whatever 1.25 build the runner cache happened to hold and drifted job by job. go.mod is now the single source, and the next patch bump needs one line changed instead of four.

## Release notes review

[go1.25.13](https://go.dev/doc/devel/release#go1.25.13) (2026-08-13) is a patch release:

> includes security fixes to the `go` command, and the `crypto/tls`, `encoding/asn1`, `encoding/xml`, `html/template`, `net/http`, and `net/url` packages, as well as bug fixes to the compiler, the runtime, and the `crypto/tls` and `os` packages.

I walked the [Go1.25.13 milestone](https://github.com/golang/go/issues?q=milestone%3AGo1.25.13+label%3ACherryPickApproved) (24 backports) and **found no functional change that this CLI has to adapt to**. Nothing in the release alters an API, a signature, or a documented behavior we depend on. The backports fall into three buckets:

- **Security hardening** — the four advisories above, plus `encoding/xml` recursion depth, `html/template` XSS, and three CVE fixes in the `go` command. All tighten limits on malformed input; none change the shape of a valid result.
- **Compiler and runtime miscompilation fixes** — `cmd/compile` prove/regalloc bugs and arch-specific miscompiles (riscv64, mips64le, arm64), runtime pointer bugs. These correct wrong codegen; they do not change language or library semantics.
- **Platform-specific `os` and `net/http` fixes** — `os.Root.MkdirAll` with trailing slashes, a `Server.UnencryptedHTTP2` header-timeout regression, and Plan 9 / NetBSD test fixes. None of these paths are reachable from this codebase.

So the Go side of this PR is a toolchain floor bump only. No source change accompanies it, and none is required.

## Review follow-ups

Three commits added after the first review round:

| Commit | Change | Review item |
| --- | --- | --- |
| `2f954d4` | `ci: blank GOOS/GOARCH when installing govulncheck` | Warning 2 — restores the one guard `golang/govulncheck-action` carried that did not survive the inlining |
| `aee9c66` | `docs(claude): point the Go version at the go directive` | Suggestion 3 — `CLAUDE.md:189` was the last version literal left in the repo |
| `f4e81b6` | `build(goreleaser): drop the redundant before hooks` | carried over from the same review on [alpamon#416](https://github.com/alpacax/alpamon/pull/416) |

On `.goreleaser.yaml`: `before.hooks` ran `go mod tidy` on every release build, but `build-and-test.yaml` already runs it followed by `git diff --exit-code go.mod go.sum`, and `release.yaml` gates the `goreleaser` job on that workflow. The second hook, `go generate ./...`, was a no-op—the repo carries no `go:generate` directive.

Deliberately not changed: `go install golang.org/x/vuln/cmd/govulncheck@latest` stays unpinned (Warning 1). govulncheck fetches its vulnerability database from `https://vuln.go.dev` at run time, so a pin would still catch every new advisory; what `@latest` buys is the scanner engine itself—new reachability analysis and symbol matching—which is the one thing a pin cannot get. The drift risk that argues for pinning is already closed here by the `GOTOOLCHAIN=auto` step above the install.

## Test plan

Ran locally against go1.25.13 (`GOTOOLCHAIN=auto`):

- `go build ./...` — clean
- `go test -race ./...` — every package `ok`, no failures
- `govulncheck ./...` — `No vulnerabilities found.`

CI on this branch: `govulncheck` and `golangci-lint` both pass on the rewritten workflow.

One vulnerability remains in the "imported but not called" bucket: [GO-2026-5942](https://pkg.go.dev/vuln/GO-2026-5942) (`x/net/dns/dnsmessage` panic on an invalid SVCB/HTTPS RR), fixed only in go1.26.6 with no 1.25 backport yet. Our code never calls it, so `govulncheck` still exits `0` and CI passes.

