### PR TITLE
refactor(ftp): drop the unreachable colon checks in validatePaths

### DIFF
--- a/cmd/ftp/cp.go
+++ b/cmd/ftp/cp.go
@@ -240,16 +240,8 @@ func validatePaths(sources []string, dest string) error {
 	allPaths = append(allPaths, dest)
 	for _, path := range allPaths {
 		if isRemotePath(path) {
-			if !strings.Contains(path, ":") {
-				return fmt.Errorf("invalid remote path format: '%s'\n\n"+
-					"Remote paths must be in format 'servername:/path'\n"+
-					"Examples:\n"+
-					"  • myserver:/home/user/file.txt\n"+
-					"  • web-server:/var/www/index.html", path)
-			}
-
-			parts := strings.SplitN(path, ":", 2)
-			if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+			// SplitPath accepts an empty remote path; cp requires one.
+			if _, remotePath, err := utils.SplitPath(path); err != nil || remotePath == "" {
 				return fmt.Errorf("invalid remote path format: '%s'\n\n"+
 					"Remote paths must include both server name and path:\n"+
 					"  • Correct: myserver:/path/to/file\n"+

--- a/cmd/ftp/cp.go
+++ b/cmd/ftp/cp.go
@@ -240,7 +240,8 @@ func validatePaths(sources []string, dest string) error {
 	allPaths = append(allPaths, dest)
 	for _, path := range allPaths {
 		if isRemotePath(path) {
-			// SplitPath accepts an empty remote path; cp requires one.
+			// SplitPath accepts an empty remote path; cp requires one. Its error
+			// text is replaced by the guidance message below.
 			if _, remotePath, err := utils.SplitPath(path); err != nil || remotePath == "" {
 				return fmt.Errorf("invalid remote path format: '%s'\n\n"+
 					"Remote paths must include both server name and path:\n"+

--- a/cmd/ftp/cp_test.go
+++ b/cmd/ftp/cp_test.go
@@ -202,6 +202,7 @@ func TestValidatePaths(t *testing.T) {
 	}
 }
 
+// Test the SSH parsing logic used in the cp command
 func TestCpCommandSSHParsing(t *testing.T) {
 	tests := []struct {
 		name         string

--- a/cmd/ftp/cp_test.go
+++ b/cmd/ftp/cp_test.go
@@ -164,6 +164,13 @@ func TestValidatePaths(t *testing.T) {
 			dest:    "./",
 		},
 		{
+			// Run strips the user prefix before validatePaths sees it; this pins
+			// that SplitPath itself does not, so the server name keeps "admin@".
+			name:    "Remote source with a user prefix",
+			sources: []string{"admin@myserver:/tmp/file.txt"},
+			dest:    "./",
+		},
+		{
 			name:       "Mixed local and remote sources",
 			sources:    []string{"./test.txt", "myserver:/tmp/file.txt"},
 			dest:       "/tmp/",

--- a/cmd/ftp/cp_test.go
+++ b/cmd/ftp/cp_test.go
@@ -146,7 +146,55 @@ func TestIsLocalPaths(t *testing.T) {
 	}
 }
 
-// Test the SSH parsing logic used in the cp command
+func TestValidatePaths(t *testing.T) {
+	tests := []struct {
+		name       string
+		sources    []string
+		dest       string
+		wantErrSub string
+	}{
+		{
+			name:    "Local sources with remote destination",
+			sources: []string{"./test.txt", "/home/user/file.txt"},
+			dest:    "myserver:/tmp/",
+		},
+		{
+			name:    "Remote source with local destination",
+			sources: []string{"myserver:/tmp/file.txt"},
+			dest:    "./",
+		},
+		{
+			name:       "Mixed local and remote sources",
+			sources:    []string{"./test.txt", "myserver:/tmp/file.txt"},
+			dest:       "/tmp/",
+			wantErrSub: "cannot mix local and remote source paths",
+		},
+		{
+			name:       "Remote source without server name",
+			sources:    []string{":/tmp/file.txt"},
+			dest:       "./",
+			wantErrSub: "invalid remote path format",
+		},
+		{
+			name:       "Remote destination without path",
+			sources:    []string{"./test.txt"},
+			dest:       "myserver:",
+			wantErrSub: "invalid remote path format",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validatePaths(tt.sources, tt.dest)
+			if tt.wantErrSub == "" {
+				assert.NoError(t, err)
+				return
+			}
+			assert.ErrorContains(t, err, tt.wantErrSub)
+		})
+	}
+}
+
 func TestCpCommandSSHParsing(t *testing.T) {
 	tests := []struct {
 		name         string


### PR DESCRIPTION
## Background

`validatePaths` (`cmd/ftp/cp.go:216`) rejected a remote path with no colon from inside a branch that only runs when the path already has one.

`isRemotePath` calls `utils.IsRemoteTarget` (`utils/ssh_parser.go:39`), which passes the target through `splitUserPrefix` and then looks for a colon in what is left. `splitUserPrefix` (`utils/ssh_parser.go:44`) removes a leading `user@` and never inserts characters, so a colon surviving the strip was in the original path. `isRemotePath(path)` being true therefore implies `strings.Contains(path, ":")`.

Two checks were unreachable as a result:

- the `!strings.Contains(path, ":")` guard and the error message it returned
- the `len(parts) != 2` clause after `strings.SplitN(path, ":", 2)` — splitting a string that contains the separator always yields exactly two parts

## Changes

Both are gone. The check that does fire — server name and remote path both non-empty — now splits through `utils.SplitPath` instead of a second hand-rolled `SplitN`:

```go
if _, remotePath, err := utils.SplitPath(path); err != nil || remotePath == "" {
```

`utils.SplitPath` (`utils/utils.go:596`) is the helper `uploadObject` (`cmd/ftp/cp.go:259`) and `downloadObject` (`cmd/ftp/cp.go:302`) already call a few lines below. A missing colon and an empty server name come back as its error; the empty remote path stays a local condition, because `SplitPath` documents an empty path as accepted and left to the caller — a contract those two callers depend on.

No behavior changes. For any path that reaches the branch:

| Input | Before | After |
|---|---|---|
| `myserver:/tmp/f` | accepted | accepted |
| `:/tmp/f` | rejected, missing server name | rejected, `SplitPath` error |
| `myserver:` | rejected, missing path | rejected, `remotePath == ""` |

Removing the guard opens no validation gap for a path with no colon at all: `isRemotePath` classifies it as local, and `utils.SplitPath` rejects it at the `uploadObject`/`downloadObject` call sites (added in #337).

## Testing

`validatePaths` had no test, so `TestValidatePaths` now pins what survives — both accepted directions, the mixed local and remote source rejection, the empty server name, and the empty remote path. It follows `cmd/login_test.go:609` for the `wantErrSub` substring shape.

- `go test -race -count=1 ./...` — 39 packages ok, no failures
- `golangci-lint run ./...` — `0 issues.`
- `gofmt -l .` and `go vet ./...` — no output
- Every commit builds and passes on its own
- Rebased onto `origin/main` (`19afae6`); all of the above re-run after the rebase

## Review follow-up

Three suggestions from review, all applied in the two commits on top:

- `TestValidatePaths` gains a case for `admin@myserver:/tmp/file.txt`. `isRemotePath` strips a leading `user@`, `SplitPath` does not, so a path reaching `validatePaths` with the prefix intact is accepted with `admin@myserver` as the server name. `Run` (`cmd/ftp/cp.go:78`) rewrites the argument first, so the input is unreachable in practice and the behavior is the same before and after this PR — but that asymmetry is what the unreachability argument above rests on, and the case now fails if `IsRemoteTarget` changes.
- The comment above the guard now covers the `err != nil` half as well. `SplitPath`'s error is discarded on purpose: `cp` prints a returned error verbatim through `CliErrorWithExit`, and the guidance message names both failure shapes.
- The narration comment on `TestCpCommandSSHParsing` is restored. It was removed as a redundant restatement of the function name, but it belongs to a test this branch does not otherwise touch.

Closes #340
