### PR TITLE
fix: honor the --tail contract in websh ls and exec ls

### DIFF
--- a/api/event/event.go
+++ b/api/event/event.go
@@ -217,7 +217,7 @@ func GetEventList(ac *client.AlpaconClient, tail int, serverName string, userNam
 		return nil, err
 	}
 
-	var eventList []EventAttributes
+	eventList := make([]EventAttributes, 0, len(events))
 	for _, event := range events {
 		eventList = append(eventList, EventAttributes{
 			Server:      event.Server.Name,

--- a/api/event/event.go
+++ b/api/event/event.go
@@ -193,7 +193,9 @@ func gapFillInterval(noProgress int) time.Duration {
 	return d
 }
 
-func GetEventList(ac *client.AlpaconClient, pageSize int, serverName string, userName string) ([]EventAttributes, error) {
+// GetEventList returns the newest tail commands. The endpoint sorts -scheduled_at,
+// so the newest ones arrive first and the walk stops as soon as tail is reached.
+func GetEventList(ac *client.AlpaconClient, tail int, serverName string, userName string) ([]EventAttributes, error) {
 	var serverID, userID string
 	var err error
 	if serverName != "" {
@@ -209,23 +211,14 @@ func GetEventList(ac *client.AlpaconClient, pageSize int, serverName string, use
 		}
 	}
 
-	relativePath := path.Join(serverID, userID)
-	params := map[string]string{}
-	if pageSize > 0 {
-		params["page_size"] = fmt.Sprintf("%d", pageSize)
-	}
-	responseBody, err := ac.SendGetRequest(utils.BuildURL(getEventURL, relativePath, params))
+	endpoint := path.Join(getEventURL, serverID, userID)
+	events, err := api.FetchPagesUpTo[EventDetails](ac, endpoint, nil, tail)
 	if err != nil {
 		return nil, err
 	}
 
-	var response api.ListResponse[EventDetails]
-	if err = json.Unmarshal(responseBody, &response); err != nil {
-		return nil, err
-	}
-
 	var eventList []EventAttributes
-	for _, event := range response.Results {
+	for _, event := range events {
 		eventList = append(eventList, EventAttributes{
 			Server:      event.Server.Name,
 			Shell:       event.Shell,

--- a/api/event/event_test.go
+++ b/api/event/event_test.go
@@ -18,66 +18,81 @@ import (
 	"time"
 
 	"github.com/alpacax/alpacon-cli/api"
-	"github.com/alpacax/alpacon-cli/api/types"
 	"github.com/alpacax/alpacon-cli/client"
 	"github.com/gorilla/websocket"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func TestGetEventList_NoExtraPagination(t *testing.T) {
-	var eventRequestCount atomic.Int32
+// The page walk itself is pinned in api.TestFetchPagesUpTo_*; what is specific to
+// GetEventList is that tail reaches the helper as its limit, so a tail larger than the
+// server's 100-item page cap still yields exactly tail commands.
+func TestGetEventList_PassesTailAsTheLimit(t *testing.T) {
+	// Twice the pages the tail needs, so a walk that ignored the limit comes back with 500
+	// and fails the length assertion instead of running until the test timeout.
+	const lastPage = 5
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 
-		count := eventRequestCount.Add(1)
-		if count > 1 {
-			t.Errorf("extra request detected: request #%d to %s (should be single request)", count, r.URL.String())
+		size, sizeErr := strconv.Atoi(r.URL.Query().Get("page_size"))
+		page, pageErr := strconv.Atoi(r.URL.Query().Get("page"))
+		if sizeErr != nil || pageErr != nil {
+			t.Errorf("page and page_size must be integers, got page=%q page_size=%q",
+				r.URL.Query().Get("page"), r.URL.Query().Get("page_size"))
+			http.Error(w, "bad pagination query", http.StatusBadRequest)
 			return
 		}
 
-		pageSize := r.URL.Query().Get("page_size")
-		if pageSize != "25" {
-			t.Errorf("expected page_size=25, got %s", pageSize)
+		next := page + 1
+		if page >= lastPage {
+			next = 0
 		}
-
-		var results []EventDetails
-		for i := range 25 {
-			results = append(results, EventDetails{
-				ID:          fmt.Sprintf("evt-%d", i),
-				Server:      types.ServerSummary{Name: "test-server"},
-				Shell:       "bash",
-				Line:        fmt.Sprintf("cmd-%d", i),
-				RequestedBy: types.UserSummary{Name: "admin"},
-			})
-		}
-
-		resp := api.ListResponse[EventDetails]{
-			Count:   200, // more items exist on server
-			Results: results,
-		}
-		_ = json.NewEncoder(w).Encode(resp)
+		results := make([]EventDetails, size)
+		_ = json.NewEncoder(w).Encode(api.ListResponse[EventDetails]{Next: next, Results: results})
 	}))
 	defer ts.Close()
 
-	ac := &client.AlpaconClient{
-		HTTPClient: ts.Client(),
-		BaseURL:    ts.URL,
-	}
+	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
 
-	events, err := GetEventList(ac, 25, "", "")
-	if err != nil {
-		t.Fatalf("GetEventList error: %v", err)
-	}
+	events, err := GetEventList(ac, 250, "", "")
 
-	totalRequests := int(eventRequestCount.Load())
-	if totalRequests != 1 {
-		t.Errorf("expected 1 request, got %d", totalRequests)
-	}
-	if len(events) != 25 {
-		t.Errorf("expected 25 events, got %d", len(events))
-	}
+	require.NoError(t, err)
+	assert.Len(t, events, 250)
+}
+
+// The --server and --user filters are path segments, not query params, so a broken join
+// does not fail the request—it returns every command as if no filter had been given.
+func TestGetEventList_PutsTheResolvedFilterIDsInThePath(t *testing.T) {
+	// Mirrors the lookup endpoints of api/server and api/iam, whose consts are unexported.
+	const (
+		serverLookupURL = "/api/servers/servers/"
+		userLookupURL   = "/api/iam/users/"
+	)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		switch {
+		case strings.HasPrefix(r.URL.Path, serverLookupURL):
+			_, _ = w.Write([]byte(`{"count":1,"results":[{"id":"srv-uuid"}]}`))
+		case strings.HasPrefix(r.URL.Path, userLookupURL):
+			_, _ = w.Write([]byte(`{"count":1,"results":[{"id":"usr-uuid"}]}`))
+		case strings.HasPrefix(r.URL.Path, getEventURL):
+			assert.Equal(t, getEventURL+"srv-uuid/usr-uuid/", r.URL.Path)
+			_, _ = w.Write([]byte(`{"count":0,"results":[]}`))
+		default:
+			t.Errorf("unexpected request path %q", r.URL.Path)
+			http.Error(w, "unexpected path", http.StatusNotFound)
+		}
+	}))
+	defer ts.Close()
+
+	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
+
+	_, err := GetEventList(ac, 25, "my-server", "admin")
+
+	require.NoError(t, err)
 }
 
 func TestPollCommandExecution(t *testing.T) {

--- a/api/event/event_test.go
+++ b/api/event/event_test.go
@@ -70,29 +70,60 @@ func TestGetEventList_PutsTheResolvedFilterIDsInThePath(t *testing.T) {
 		userLookupURL   = "/api/iam/users/"
 	)
 
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
+	tests := []struct {
+		name         string
+		serverName   string
+		userName     string
+		expectedPath string
+	}{
+		{
+			name:         "both filters",
+			serverName:   "my-server",
+			userName:     "admin",
+			expectedPath: getEventURL + "srv-uuid/usr-uuid/",
+		},
+		{
+			name:         "server only",
+			serverName:   "my-server",
+			expectedPath: getEventURL + "srv-uuid/",
+		},
+		{
+			// path.Join drops the empty server segment, so a lone user ID lands on the address
+			// the command detail route also answers on. Recorded as current behavior, not as
+			// the desired one—confirming it needs the server-side route (alpacax/alpacon-cli#363).
+			name:         "user only",
+			userName:     "admin",
+			expectedPath: getEventURL + "usr-uuid/",
+		},
+	}
 
-		switch {
-		case strings.HasPrefix(r.URL.Path, serverLookupURL):
-			_, _ = w.Write([]byte(`{"count":1,"results":[{"id":"srv-uuid"}]}`))
-		case strings.HasPrefix(r.URL.Path, userLookupURL):
-			_, _ = w.Write([]byte(`{"count":1,"results":[{"id":"usr-uuid"}]}`))
-		case strings.HasPrefix(r.URL.Path, getEventURL):
-			assert.Equal(t, getEventURL+"srv-uuid/usr-uuid/", r.URL.Path)
-			_, _ = w.Write([]byte(`{"count":0,"results":[]}`))
-		default:
-			t.Errorf("unexpected request path %q", r.URL.Path)
-			http.Error(w, "unexpected path", http.StatusNotFound)
-		}
-	}))
-	defer ts.Close()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
 
-	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
+				switch {
+				case strings.HasPrefix(r.URL.Path, serverLookupURL):
+					_, _ = w.Write([]byte(`{"count":1,"results":[{"id":"srv-uuid"}]}`))
+				case strings.HasPrefix(r.URL.Path, userLookupURL):
+					_, _ = w.Write([]byte(`{"count":1,"results":[{"id":"usr-uuid"}]}`))
+				case strings.HasPrefix(r.URL.Path, getEventURL):
+					assert.Equal(t, tt.expectedPath, r.URL.Path)
+					_, _ = w.Write([]byte(`{"count":0,"results":[]}`))
+				default:
+					t.Errorf("unexpected request path %q", r.URL.Path)
+					http.Error(w, "unexpected path", http.StatusNotFound)
+				}
+			}))
+			defer ts.Close()
 
-	_, err := GetEventList(ac, 25, "my-server", "admin")
+			ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
 
-	require.NoError(t, err)
+			_, err := GetEventList(ac, 25, tt.serverName, tt.userName)
+
+			require.NoError(t, err)
+		})
+	}
 }
 
 func TestPollCommandExecution(t *testing.T) {

--- a/api/websh/websh.go
+++ b/api/websh/websh.go
@@ -48,7 +48,7 @@ func GetSessionList(ac *client.AlpaconClient, tail int) ([]SessionListItem, erro
 		return nil, err
 	}
 
-	var list []SessionListItem
+	list := make([]SessionListItem, 0, len(sessions))
 	for _, s := range sessions {
 		closedAt := "-"
 		if s.ClosedAt != nil {

--- a/api/websh/websh.go
+++ b/api/websh/websh.go
@@ -36,12 +36,14 @@ const (
 	sessionEndCloseCode = 4000
 )
 
-func GetSessionList(ac *client.AlpaconClient) ([]SessionListItem, error) {
+// GetSessionList returns the newest tail connectable sessions. The endpoint sorts
+// -added_at, so the newest ones arrive first and the walk stops as soon as tail is reached.
+func GetSessionList(ac *client.AlpaconClient, tail int) ([]SessionListItem, error) {
 	params := map[string]string{
 		"is_connectable": "true",
 	}
 
-	sessions, err := api.FetchAllPages[SessionDetailResponse](ac, sessionsBaseURL, params)
+	sessions, err := api.FetchPagesUpTo[SessionDetailResponse](ac, sessionsBaseURL, params, tail)
 	if err != nil {
 		return nil, err
 	}

--- a/api/websh/websh_test.go
+++ b/api/websh/websh_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/signal"
 	"runtime"
+	"strconv"
 	"strings"
 	"syscall"
 	"testing"
@@ -28,6 +29,43 @@ const (
 
 	receivedBufferSize = 8
 )
+
+// The page walk itself is pinned in api.TestFetchPagesUpTo_*; what is specific to
+// GetSessionList is that tail reaches the helper as its limit, so a tail larger than the
+// server's 100-item page cap still yields exactly tail sessions.
+func TestGetSessionList_PassesTailAsTheLimit(t *testing.T) {
+	// Twice the pages the tail needs, so a walk that ignored the limit comes back with 500
+	// and fails the length assertion instead of running until the test timeout.
+	const lastPage = 5
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		size, sizeErr := strconv.Atoi(r.URL.Query().Get("page_size"))
+		page, pageErr := strconv.Atoi(r.URL.Query().Get("page"))
+		if sizeErr != nil || pageErr != nil {
+			t.Errorf("page and page_size must be integers, got page=%q page_size=%q",
+				r.URL.Query().Get("page"), r.URL.Query().Get("page_size"))
+			http.Error(w, "bad pagination query", http.StatusBadRequest)
+			return
+		}
+
+		next := page + 1
+		if page >= lastPage {
+			next = 0
+		}
+		results := make([]SessionDetailResponse, size)
+		_ = json.NewEncoder(w).Encode(api.ListResponse[SessionDetailResponse]{Next: next, Results: results})
+	}))
+	defer ts.Close()
+
+	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
+
+	list, err := GetSessionList(ac, 250)
+
+	require.NoError(t, err)
+	assert.Len(t, list, 250)
+}
 
 func TestGetSessionList(t *testing.T) {
 	closedTime := "2026-03-01T00:00:00Z"
@@ -67,7 +105,7 @@ func TestGetSessionList(t *testing.T) {
 	defer ts.Close()
 
 	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
-	list, err := GetSessionList(ac)
+	list, err := GetSessionList(ac, 25)
 	require.NoError(t, err)
 
 	assert.Len(t, list, 2)

--- a/cmd/audit/audit.go
+++ b/cmd/audit/audit.go
@@ -13,7 +13,7 @@ var AuditCmd = &cobra.Command{
 	Short:   "Retrieve and display audit activity logs",
 	Long: `
 	Retrieve and display audit activity logs from the Alpacon, with options to filter by user,
-	application, and model. Use the '--tail' flag to limit the output to the last N entries.
+	application, and model. Use the '--tail' flag to show the newest N entries.
 	`,
 	Example: `
 	alpacon audit
@@ -30,7 +30,7 @@ func init() {
 	var app string
 	var model string
 
-	AuditCmd.Flags().IntVarP(&tail, "tail", "t", 25, "Number of audit log entries to show from the end")
+	AuditCmd.Flags().IntVarP(&tail, "tail", "t", 25, "Number of audit log entries to show, newest first")
 	AuditCmd.Flags().StringVarP(&userName, "user", "u", "", "Filter by username")
 	AuditCmd.Flags().StringVarP(&app, "app", "a", "", "Filter by application")
 	AuditCmd.Flags().StringVarP(&model, "model", "m", "", "Filter by model")

--- a/cmd/event/event.go
+++ b/cmd/event/event.go
@@ -15,7 +15,7 @@ var EventCmd = &cobra.Command{
 	Use:     "event",
 	Aliases: []string{"events"},
 	Short:   "List recent remote command executions (deprecated)",
-	Long: `List recent remote command executions, most recent last.
+	Long: `List recent remote command executions, most recent first.
 
 This command has moved to 'alpacon exec ls' and will be removed in a future
 release. It still works today and takes the same flags.

--- a/cmd/exec/list.go
+++ b/cmd/exec/list.go
@@ -11,7 +11,7 @@ var listCmd = &cobra.Command{
 	Use:     "ls",
 	Aliases: []string{"list"},
 	Short:   "List recent remote command executions",
-	Long: `List recent remote command executions, most recent last.
+	Long: `List recent remote command executions, most recent first.
 
 Use --tail to limit the number of entries, --server to scope to one server,
 and --user to filter by the requesting user.`,
@@ -32,29 +32,29 @@ func init() {
 // AddListFlags and RunListFromFlags are exported for the deprecated 'alpacon event', which
 // delegates here. Both live in this file so the flag names exist in exactly one place.
 func AddListFlags(cmd *cobra.Command) {
-	cmd.Flags().IntP("tail", "t", 25, "Number of command entries to show from the end")
+	cmd.Flags().IntP("tail", "t", 25, "Number of command entries to show, newest first")
 	cmd.Flags().StringP("server", "s", "", "Filter by server name")
 	cmd.Flags().StringP("user", "u", "", "Filter by requesting user")
 }
 
 // RunListFromFlags requires the flag set registered by AddListFlags.
 func RunListFromFlags(cmd *cobra.Command) {
-	pageSize, _ := cmd.Flags().GetInt("tail")
+	tail, _ := cmd.Flags().GetInt("tail")
 	serverName, _ := cmd.Flags().GetString("server")
 	userName, _ := cmd.Flags().GetString("user")
 
-	runList(pageSize, serverName, userName)
+	runList(tail, serverName, userName)
 }
 
-func runList(pageSize int, serverName, userName string) {
-	utils.RequirePositiveInt("tail", pageSize)
+func runList(tail int, serverName, userName string) {
+	utils.RequirePositiveInt("tail", tail)
 
 	alpaconClient, err := client.NewAlpaconAPIClient()
 	if err != nil {
 		utils.CliErrorWithExit("Connection to Alpacon API failed: %s. Consider re-logging.", err)
 	}
 
-	eventList, err := event.GetEventList(alpaconClient, pageSize, serverName, userName)
+	eventList, err := event.GetEventList(alpaconClient, tail, serverName, userName)
 	if err != nil {
 		utils.CliErrorWithExit("Failed to retrieve the commands: %s.", err)
 	}

--- a/cmd/log/log.go
+++ b/cmd/log/log.go
@@ -13,7 +13,7 @@ var LogCmd = &cobra.Command{
 	Short:   "Retrieve and display server logs",
 	Long: `Retrieve and display logs for a specified server. This command allows you 
 	to view logs of different levels and types associated with a server. Use the '--tail' flag 
-	to limit the output to the last N log entries. Suitable for debugging and monitoring 
+	to show the newest N log entries. Suitable for debugging and monitoring 
 	server activities.`,
 	Example: `
 	alpacon log my-server
@@ -44,5 +44,5 @@ var LogCmd = &cobra.Command{
 func init() {
 	var tail int
 
-	LogCmd.Flags().IntVarP(&tail, "tail", "t", 25, "Number of log entries to show from the end")
+	LogCmd.Flags().IntVarP(&tail, "tail", "t", 25, "Number of log entries to show, newest first")
 }

--- a/cmd/webftp/webftp.go
+++ b/cmd/webftp/webftp.go
@@ -13,7 +13,7 @@ var WebFTPCmd = &cobra.Command{
 	Short:   "Retrieve and display WebFTP transfer logs",
 	Long: `
 	Retrieve and display WebFTP file transfer logs from the Alpacon, with options to filter by
-	server, user, and action. Use the '--tail' flag to limit the output to the last N entries.
+	server, user, and action. Use the '--tail' flag to show the newest N entries.
 	`,
 	Example: `
 	alpacon webftp-log
@@ -30,7 +30,7 @@ func init() {
 	var userName string
 	var action string
 
-	WebFTPCmd.Flags().IntVarP(&tail, "tail", "t", 25, "Number of log entries to show from the end")
+	WebFTPCmd.Flags().IntVarP(&tail, "tail", "t", 25, "Number of log entries to show, newest first")
 	WebFTPCmd.Flags().StringVarP(&serverName, "server", "s", "", "Filter by server name")
 	WebFTPCmd.Flags().StringVarP(&userName, "user", "u", "", "Filter by username")
 	WebFTPCmd.Flags().StringVarP(&action, "action", "a", "", "Filter by action (e.g., upload, download)")

--- a/cmd/websh/websh_list.go
+++ b/cmd/websh/websh_list.go
@@ -15,19 +15,16 @@ var webshListCmd = &cobra.Command{
   alpacon websh ls --tail 50`,
 	Run: func(cmd *cobra.Command, args []string) {
 		tail, _ := cmd.Flags().GetInt("tail")
+		utils.RequirePositiveInt("tail", tail)
 
 		alpaconClient, err := client.NewAlpaconAPIClient()
 		if err != nil {
 			utils.CliErrorWithExit("Connection to Alpacon API failed: %s. Consider re-logging.", err)
 		}
 
-		sessionList, err := websh.GetSessionList(alpaconClient)
+		sessionList, err := websh.GetSessionList(alpaconClient, tail)
 		if err != nil {
 			utils.CliErrorWithExit("Failed to retrieve websh sessions: %s.", err)
-		}
-
-		if tail > 0 && tail < len(sessionList) {
-			sessionList = sessionList[len(sessionList)-tail:]
 		}
 
 		utils.PrintTable(sessionList)
@@ -35,5 +32,5 @@ var webshListCmd = &cobra.Command{
 }
 
 func init() {
-	webshListCmd.Flags().Int("tail", 25, "Number of sessions to show")
+	webshListCmd.Flags().Int("tail", 25, "Number of sessions to show, newest first")
 }

--- a/cmd/websh/websh_list.go
+++ b/cmd/websh/websh_list.go
@@ -15,22 +15,27 @@ var webshListCmd = &cobra.Command{
   alpacon websh ls --tail 50`,
 	Run: func(cmd *cobra.Command, args []string) {
 		tail, _ := cmd.Flags().GetInt("tail")
-		utils.RequirePositiveInt("tail", tail)
 
-		alpaconClient, err := client.NewAlpaconAPIClient()
-		if err != nil {
-			utils.CliErrorWithExit("Connection to Alpacon API failed: %s. Consider re-logging.", err)
-		}
-
-		sessionList, err := websh.GetSessionList(alpaconClient, tail)
-		if err != nil {
-			utils.CliErrorWithExit("Failed to retrieve websh sessions: %s.", err)
-		}
-
-		utils.PrintTable(sessionList)
+		runWebshList(tail)
 	},
 }
 
 func init() {
-	webshListCmd.Flags().Int("tail", 25, "Number of sessions to show, newest first")
+	webshListCmd.Flags().IntP("tail", "t", 25, "Number of sessions to show, newest first")
+}
+
+func runWebshList(tail int) {
+	utils.RequirePositiveInt("tail", tail)
+
+	alpaconClient, err := client.NewAlpaconAPIClient()
+	if err != nil {
+		utils.CliErrorWithExit("Connection to Alpacon API failed: %s. Consider re-logging.", err)
+	}
+
+	sessionList, err := websh.GetSessionList(alpaconClient, tail)
+	if err != nil {
+		utils.CliErrorWithExit("Failed to retrieve websh sessions: %s.", err)
+	}
+
+	utils.PrintTable(sessionList)
 }

--- a/cmd/websh/websh_list_test.go
+++ b/cmd/websh/websh_list_test.go
@@ -1,0 +1,77 @@
+package websh
+
+import (
+	"os"
+	osexec "os/exec"
+	"testing"
+
+	"github.com/alpacax/alpacon-cli/utils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// DisableFlagParsing only covers the parent; this pins that a child still routes and parses flags normally.
+func TestWebshLsRoutesAndParsesFlags(t *testing.T) {
+	tests := []struct {
+		name         string
+		args         []string
+		expectedTail int
+	}{
+		{
+			name:         "defaults",
+			args:         []string{"ls"},
+			expectedTail: 25,
+		},
+		{
+			name:         "long flag",
+			args:         []string{"ls", "--tail", "50"},
+			expectedTail: 50,
+		},
+		{
+			// The parent's hand-rolled -s and -u never reach here, since routing to the subcommand happens first.
+			name:         "short flag",
+			args:         []string{"ls", "-t", "5"},
+			expectedTail: 5,
+		},
+		{
+			name:         "list alias",
+			args:         []string{"list", "--tail", "7"},
+			expectedTail: 7,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd, flags, err := WebshCmd.Find(tt.args)
+			require.NoError(t, err)
+			require.Equal(t, "ls", cmd.Name())
+
+			// Reset from the flag's own default so a prior case cannot leak in and the defaults case still checks what is registered.
+			require.NoError(t, cmd.Flags().Set("tail", cmd.Flags().Lookup("tail").DefValue))
+
+			require.NoError(t, cmd.ParseFlags(flags))
+
+			tail, err := cmd.Flags().GetInt("tail")
+			require.NoError(t, err)
+			assert.Equal(t, tt.expectedTail, tail)
+		})
+	}
+}
+
+func TestWebshLsTailZeroExitsWithUsageErrorCode(t *testing.T) {
+	helper := osexec.Command(os.Args[0], "-test.run=^TestWebshLsTailZeroHelperProcess$")
+	helper.Env = append(os.Environ(), "GO_WANT_WEBSH_LS_TAIL_HELPER=1")
+
+	err := helper.Run()
+
+	var exitErr *osexec.ExitError
+	require.ErrorAs(t, err, &exitErr)
+	assert.Equal(t, utils.ExitCodeUsageError, exitErr.ExitCode())
+}
+
+func TestWebshLsTailZeroHelperProcess(t *testing.T) {
+	if os.Getenv("GO_WANT_WEBSH_LS_TAIL_HELPER") != "1" {
+		return
+	}
+	runWebshList(0)
+}


### PR DESCRIPTION
## Background

Issue #330 settled `--tail N` as the newest N entries, not the physical end of a descending list. `websh ls` and `exec ls` both broke that contract, each in its own way.

`websh ls` pulled every page with `FetchAllPages` and then sliced `sessionList[len-tail:]`. The endpoint sorts newest first (`SessionViewSet.ordering = ['-added_at']`), so that slice handed back the oldest N sessions.

`exec ls` read the right end of the list (`CommandViewSet.ordering = ['-scheduled_at']`) but could not reach past one page: it sent `page_size=tail` in a single request and the server caps `page_size` at 100, so `--tail 250` quietly returned 100 entries.

## Changes

Both commands now go through `api.FetchPagesUpTo`, the helper #330 added: it takes tail as its limit and stops once it holds that many items. `note ls` already reads its tail this way.

| Command | Before | After |
|---|---|---|
| `websh ls` | fetch every page, slice from the end | stop once tail items are held |
| `exec ls` | single `page_size=tail` request | walk pages up to tail |

`FetchPagesUpTo` returns nothing for a limit of 0, where the old `websh ls` code read 0 as "no limit". `utils.RequirePositiveInt` keeps that from turning into a silently empty table, matching every other `--tail` command.

Help text is aligned in the same pass. `exec ls` said "most recent last" in its `Long` and "from the end" in its `--tail` help, describing neither the endpoint's order nor the flag's contract. The deprecated `alpacon event` shares that code path, and `log`, `audit` and `webftp-log` already returned newest-first while their help said otherwise. `websh ls` said only "Number of sessions to show", which named no end at all. All of them now use the wording `note ls` already had: "Number of X to show, newest first".

`websh ls` also picks up the `-t` shorthand that `note`, `audit`, `log`, `webftp` and `exec` all register, and the two list projections in `api/event` and `api/websh` are preallocated now that the final length is known before the loop.

## Testing

`TestGetEventList_NoExtraPagination` pinned the old single-request behavior and is replaced by `TestGetEventList_PassesTailAsTheLimit`, which runs `--tail 250` against a fake server serving five full pages and asserts exactly 250 commands come back—unreachable unless tail arrives as the helper's limit. The fake server stops at five pages rather than paginating forever, so a regression to an unbounded walk fails on the length immediately instead of hanging until the test timeout. `api/websh` gets the same test for `GetSessionList`. The page walk itself stays pinned in `api.TestFetchPagesUpTo_*`.

`TestGetEventList_PutsTheResolvedFilterIDsInThePath` covers the other half of the `exec ls` rewrite. `--server` and `--user` are resolved to IDs and joined into the request path, not passed as query params, so a broken join does not fail the request—it returns every command as if no filter had been given. It is table-driven over all three cases: both filters, server only, and user only. The last one is recorded as current behavior rather than as the desired contract—see the Residual section.

`cmd/websh` gains what `cmd/exec` already had. `TestWebshLsRoutesAndParsesFlags` pins that `ls` still routes and parses flags under the parent's `DisableFlagParsing`, and `TestWebshLsTailZeroExitsWithUsageErrorCode` pins the exit code 2 rejection of `--tail 0` through a helper process, since `RequirePositiveInt` exits the process.

`go build ./...`, `go vet ./...` and `go test -race ./...` all pass.

## Residual

Server-side ordering has no tiebreaker: `CommandViewSet` and `SessionViewSet` both sort on a single key, so equal sort values can repeat one row and skip another at a page boundary under offset pagination. Not fixable from the CLI—filed as alpacax/alpacon-server#3044.

`exec ls --user NAME` with no `--server` builds a URL that collides with the command detail route, because `path.Join` drops the empty server segment. Pre-existing, not introduced here—the old code produced the same URL. Which URL the server expects for a user-only filter cannot be settled from the CLI, so it is filed as #363 and the current behavior is pinned by a test in the meantime.

Closes #338


