### PR TITLE
fix(utils): sanitize server-controlled text in the Cli* helpers

### DIFF
--- a/cmd/login.go
+++ b/cmd/login.go
@@ -177,7 +177,7 @@ with the saved target as the default. Non-interactive login requires a HOST or
 		switch classifyWhoamiVerification(whoErr) {
 		case whoamiVerified:
 			if who.PrincipalType == auth.PrincipalTypeApplication && who.Application != nil {
-				utils.CliInfo("Authenticated as application '%s'.", utils.SanitizeTerminalText(who.Application.Name))
+				utils.CliInfo("Authenticated as application '%s'.", who.Application.Name)
 			}
 		case whoamiFallback:
 			// Old server without whoami: fall back to legacy prefix-based verification.

--- a/cmd/server/server_create.go
+++ b/cmd/server/server_create.go
@@ -266,8 +266,7 @@ func createTokenAndWarn(ac *client.AlpaconClient, name string) string {
 	if err != nil {
 		utils.CliErrorWithExit("Failed to create the registration token: %s.", err)
 	}
-	fmt.Fprintf(os.Stderr, "%s: New token created. Save the key now—it will not be shown again: %s\n",
-		utils.Yellow("Warning"), utils.Green(utils.SanitizeTerminalText(response.Key)))
+	warnTokenKey("New token created. Save the key now—it will not be shown again", response.Key)
 	return response.ID
 }
 

--- a/cmd/server/server_create.go
+++ b/cmd/server/server_create.go
@@ -266,7 +266,8 @@ func createTokenAndWarn(ac *client.AlpaconClient, name string) string {
 	if err != nil {
 		utils.CliErrorWithExit("Failed to create the registration token: %s.", err)
 	}
-	utils.CliWarning("New token created. Save the key now—it will not be shown again: %s", utils.Green(response.Key))
+	fmt.Fprintf(os.Stderr, "%s: New token created. Save the key now—it will not be shown again: %s\n",
+		utils.Yellow("Warning"), utils.Green(utils.SanitizeTerminalText(response.Key)))
 	return response.ID
 }
 

--- a/cmd/server/token_create.go
+++ b/cmd/server/token_create.go
@@ -72,8 +72,7 @@ The token key is displayed once at creation time and cannot be retrieved again.`
 		}
 
 		utils.CliSuccess("Registration token created: %s", resp.Name)
-		fmt.Fprintf(os.Stderr, "%s: Save this key now—it will not be shown again: %s\n",
-			utils.Yellow("Warning"), utils.Green(utils.SanitizeTerminalText(resp.Key)))
+		warnTokenKey("Save this key now—it will not be shown again", resp.Key)
 		if resp.ExpiresAt != nil {
 			utils.CliInfo("Token expires at: %s", *resp.ExpiresAt)
 		}
@@ -107,4 +106,11 @@ func resolveGroupIDs(ac *client.AlpaconClient, entries []string) ([]string, erro
 		}
 	}
 	return ids, nil
+}
+
+// warnTokenKey prints the one-time key like CliWarning, except it colors the
+// key after sanitizing—CliWarning would strip the highlight with the escapes.
+func warnTokenKey(prefix, key string) {
+	fmt.Fprintf(os.Stderr, "%s: %s: %s\n",
+		utils.Yellow("Warning"), prefix, utils.Green(utils.SanitizeTerminalText(key)))
 }

--- a/cmd/server/token_create.go
+++ b/cmd/server/token_create.go
@@ -3,6 +3,7 @@ package server
 import (
 	"encoding/json"
 	"fmt"
+	"os"
 	"strings"
 
 	iamAPI "github.com/alpacax/alpacon-cli/api/iam"
@@ -71,7 +72,8 @@ The token key is displayed once at creation time and cannot be retrieved again.`
 		}
 
 		utils.CliSuccess("Registration token created: %s", resp.Name)
-		utils.CliWarning("Save this key now—it will not be shown again: %s", utils.Green(resp.Key))
+		fmt.Fprintf(os.Stderr, "%s: Save this key now—it will not be shown again: %s\n",
+			utils.Yellow("Warning"), utils.Green(utils.SanitizeTerminalText(resp.Key)))
 		if resp.ExpiresAt != nil {
 			utils.CliInfo("Token expires at: %s", *resp.ExpiresAt)
 		}

--- a/utils/log.go
+++ b/utils/log.go
@@ -19,17 +19,33 @@ func reportCLIError() {
 	fmt.Fprintln(os.Stderr, "For issues, check the latest version or report on", gitIssueURL)
 }
 
+// cliMessage sanitizes a rendered message before it reaches the terminal:
+// client.parseAPIError puts the server's error detail into every one of these
+// helpers through %s, and the --output json envelope is the only path escaping
+// it today (escapeJSONControls).
+//
+// Per line, because SanitizeTerminalText drops \n and callers pass multi-line
+// guidance. Splitting after the format is rendered means a \n from the server
+// survives too, so the detail can add a line that looks like our own prefix.
+// Accepted: \r is still dropped, so it can only append below, never overwrite
+// what is already on screen.
+func cliMessage(msg string, args ...any) string {
+	lines := strings.Split(fmt.Sprintf(msg, args...), "\n")
+	for i, line := range lines {
+		lines[i] = SanitizeTerminalText(line)
+	}
+	return strings.Join(lines, "\n")
+}
+
 // CliError handles all error messages in the CLI.
 func CliError(msg string, args ...any) {
-	errorMessage := fmt.Sprintf(msg, args...)
-	fmt.Fprintf(os.Stderr, "%s: %s\n", Red("Error"), errorMessage)
+	fmt.Fprintf(os.Stderr, "%s: %s\n", Red("Error"), cliMessage(msg, args...))
 	reportCLIError()
 }
 
 // CliErrorWithExit handles all error messages in the CLI.
 func CliErrorWithExit(msg string, args ...any) {
-	errorMessage := fmt.Sprintf(msg, args...)
-	fmt.Fprintf(os.Stderr, "%s: %s\n", Red("Error"), errorMessage)
+	fmt.Fprintf(os.Stderr, "%s: %s\n", Red("Error"), cliMessage(msg, args...))
 	reportCLIError()
 	os.Exit(1)
 }
@@ -38,8 +54,7 @@ func CliErrorWithExit(msg string, args ...any) {
 // Unlike CliErrorWithExit it omits the "report an issue" footer—use it for expected,
 // machine-distinguishable refusals (e.g. a busy server) that scripts branch on by exit code.
 func CliErrorWithExitCode(code int, msg string, args ...any) {
-	errorMessage := fmt.Sprintf(msg, args...)
-	fmt.Fprintf(os.Stderr, "%s: %s\n", Red("Error"), errorMessage)
+	fmt.Fprintf(os.Stderr, "%s: %s\n", Red("Error"), cliMessage(msg, args...))
 	os.Exit(code)
 }
 
@@ -63,31 +78,26 @@ func CliDebug(msg string, args ...any) {
 	if !DebugEnabled() {
 		return
 	}
-	debugMessage := fmt.Sprintf(msg, args...)
-	fmt.Fprintf(os.Stderr, "%s: %s\n", Yellow("Debug"), debugMessage)
+	fmt.Fprintf(os.Stderr, "%s: %s\n", Yellow("Debug"), cliMessage(msg, args...))
 }
 
 // CliInfo handles all informational messages in the CLI.
 func CliInfo(msg string, args ...any) {
-	infoMessage := fmt.Sprintf(msg, args...)
-	fmt.Fprintf(os.Stderr, "%s: %s\n", Blue("Info"), infoMessage)
+	fmt.Fprintf(os.Stderr, "%s: %s\n", Blue("Info"), cliMessage(msg, args...))
 }
 
 // CliWarning handles all warning messages in the CLI.
 func CliWarning(msg string, args ...any) {
-	warningMessage := fmt.Sprintf(msg, args...)
-	fmt.Fprintf(os.Stderr, "%s: %s\n", Yellow("Warning"), warningMessage)
+	fmt.Fprintf(os.Stderr, "%s: %s\n", Yellow("Warning"), cliMessage(msg, args...))
 }
 
 // CliSuccess handles all success messages in the CLI.
 func CliSuccess(msg string, args ...any) {
-	successMessage := fmt.Sprintf(msg, args...)
-	fmt.Fprintf(os.Stderr, "%s: %s\n", Green("Success"), successMessage)
+	fmt.Fprintf(os.Stderr, "%s: %s\n", Green("Success"), cliMessage(msg, args...))
 }
 
 // CliInfoWithExit prints an informational message to stderr and exits the program with a status code of 0
 func CliInfoWithExit(msg string, args ...any) {
-	infoMessage := fmt.Sprintf(msg, args...)
-	fmt.Fprintf(os.Stderr, "%s: %s\n", Blue("Info"), infoMessage)
+	fmt.Fprintf(os.Stderr, "%s: %s\n", Blue("Info"), cliMessage(msg, args...))
 	os.Exit(0) // Use exit code 0 to indicate successful completion.
 }

--- a/utils/log.go
+++ b/utils/log.go
@@ -29,6 +29,10 @@ func reportCLIError() {
 // survives too, so the detail can add a line that looks like our own prefix.
 // Accepted: \r is still dropped, so it can only append below, never overwrite
 // what is already on screen.
+//
+// The arguments go through the same strip, so never hand a Color()-wrapped
+// value to a Cli* helper—it loses its highlight. Colorize after sanitizing,
+// the way cmd/server prints a registration key.
 func cliMessage(msg string, args ...any) string {
 	lines := strings.Split(fmt.Sprintf(msg, args...), "\n")
 	for i, line := range lines {

--- a/utils/log_test.go
+++ b/utils/log_test.go
@@ -29,6 +29,14 @@ func captureStderr(t *testing.T, fn func()) string {
 	return <-captured
 }
 
+// pinColor fixes the color switch for one test, whatever stderr happens to be.
+func pinColor(t *testing.T, enabled bool) {
+	t.Helper()
+	original := colorEnabled
+	colorEnabled = enabled
+	t.Cleanup(func() { colorEnabled = original })
+}
+
 func TestDebugEnabled(t *testing.T) {
 	tests := []struct {
 		name  string
@@ -74,6 +82,9 @@ func TestCliDebug(t *testing.T) {
 // The server's error detail reaches these helpers through %s.
 func TestCliHelpers_SanitizeServerControlledText(t *testing.T) {
 	t.Setenv(DebugEnvVar, "1")
+	// Red("Error") and its siblings carry an escape of their own, so the ANSI
+	// case would fail whenever the test binary's stderr is a terminal.
+	pinColor(t, false)
 	emitters := map[string]func(string, ...any){
 		"CliError":   CliError,
 		"CliWarning": CliWarning,

--- a/utils/log_test.go
+++ b/utils/log_test.go
@@ -70,3 +70,53 @@ func TestCliDebug(t *testing.T) {
 		assert.Empty(t, stderr)
 	})
 }
+
+// The server's error detail reaches these helpers through %s.
+func TestCliHelpers_SanitizeServerControlledText(t *testing.T) {
+	t.Setenv(DebugEnvVar, "1")
+	emitters := map[string]func(string, ...any){
+		"CliError":   CliError,
+		"CliWarning": CliWarning,
+		"CliInfo":    CliInfo,
+		"CliSuccess": CliSuccess,
+		"CliDebug":   CliDebug,
+	}
+	tests := []struct {
+		name    string
+		detail  string
+		notWant string
+	}{
+		{name: "ANSI escape", detail: "denied\x1b[2Kapproved", notWant: "\x1b"},
+		{name: "bidi override", detail: "denied\u202eapproved", notWant: "\u202e"},
+		{name: "carriage return", detail: "denied\rapproved", notWant: "\r"},
+		{name: "8-bit CSI", detail: "denied\u009b2Kapproved", notWant: "\u009b"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for name, emit := range emitters {
+				stderr := captureStderr(t, func() { emit("%s", tt.detail) })
+				assert.NotContains(t, stderr, tt.notWant, name)
+				assert.Contains(t, stderr, "denied", name)
+				assert.Contains(t, stderr, "approved", name)
+			}
+		})
+	}
+}
+
+// Sanitizing the rendered message cannot tell a caller's newline from the
+// server's, so the detail keeps the power to open a line of its own.
+func TestCliHelpers_KeepServerNewlines(t *testing.T) {
+	stderr := captureStderr(t, func() {
+		CliError("%s", "denied\nSuccess: approved")
+	})
+
+	assert.Contains(t, stderr, "denied\nSuccess: approved\n")
+}
+
+func TestCliHelpers_KeepCallerNewlines(t *testing.T) {
+	stderr := captureStderr(t, func() {
+		CliWarning("first line\nsecond line: %s", "value")
+	})
+
+	assert.Contains(t, stderr, "first line\nsecond line: value\n")
+}

--- a/utils/log_test.go
+++ b/utils/log_test.go
@@ -1,10 +1,10 @@
 package utils
 
 import (
-	"io"
 	"os"
 	"testing"
 
+	"github.com/alpacax/alpacon-cli/pkg/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -12,21 +12,8 @@ import (
 // captureStderr returns everything fn writes to stderr.
 func captureStderr(t *testing.T, fn func()) string {
 	t.Helper()
-	reader, writer, err := os.Pipe()
-	require.NoError(t, err)
-	original := os.Stderr
-	os.Stderr = writer
-	defer func() { os.Stderr = original }()
-
-	captured := make(chan string, 1)
-	go func() {
-		data, _ := io.ReadAll(reader)
-		captured <- string(data)
-	}()
-
-	fn()
-	require.NoError(t, writer.Close())
-	return <-captured
+	_, stderr := testutil.CaptureOutput(t, fn)
+	return stderr
 }
 
 // pinColor fixes the color switch for one test, whatever stderr happens to be.

--- a/utils/log_test.go
+++ b/utils/log_test.go
@@ -72,12 +72,15 @@ func TestCliHelpers_SanitizeServerControlledText(t *testing.T) {
 	// Red("Error") and its siblings carry an escape of their own, so the ANSI
 	// case would fail whenever the test binary's stderr is a terminal.
 	pinColor(t, false)
-	emitters := map[string]func(string, ...any){
-		"CliError":   CliError,
-		"CliWarning": CliWarning,
-		"CliInfo":    CliInfo,
-		"CliSuccess": CliSuccess,
-		"CliDebug":   CliDebug,
+	emitters := []struct {
+		name string
+		emit func(string, ...any)
+	}{
+		{name: "CliError", emit: CliError},
+		{name: "CliWarning", emit: CliWarning},
+		{name: "CliInfo", emit: CliInfo},
+		{name: "CliSuccess", emit: CliSuccess},
+		{name: "CliDebug", emit: CliDebug},
 	}
 	tests := []struct {
 		name    string
@@ -91,11 +94,13 @@ func TestCliHelpers_SanitizeServerControlledText(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			for name, emit := range emitters {
-				stderr := captureStderr(t, func() { emit("%s", tt.detail) })
-				assert.NotContains(t, stderr, tt.notWant, name)
-				assert.Contains(t, stderr, "denied", name)
-				assert.Contains(t, stderr, "approved", name)
+			for _, emitter := range emitters {
+				t.Run(emitter.name, func(t *testing.T) {
+					stderr := captureStderr(t, func() { emitter.emit("%s", tt.detail) })
+					assert.NotContains(t, stderr, tt.notWant)
+					assert.Contains(t, stderr, "denied")
+					assert.Contains(t, stderr, "approved")
+				})
 			}
 		})
 	}

--- a/utils/log_test.go
+++ b/utils/log_test.go
@@ -131,3 +131,12 @@ func TestCliHelpers_KeepCallerNewlines(t *testing.T) {
 
 	assert.Contains(t, stderr, "first line\nsecond line: value\n")
 }
+
+// The choke point strips its arguments too, so a pre-colored value comes out
+// plain. cmd/server relies on the reverse order—sanitize the key, then color
+// it—to keep the "copy this" highlight on a registration key.
+func TestCliMessage_StripsColorFromArguments(t *testing.T) {
+	pinColor(t, true)
+
+	assert.Equal(t, "Save this key: secret", cliMessage("Save this key: %s", Green("secret")))
+}


### PR DESCRIPTION
## Background

`utils.CliError`, `CliErrorWithExit`, `CliErrorWithExitCode` and `CliWarning` printed their rendered message to stderr with no sanitize pass.

`client.parseAPIError` (`client/client.go:476`) puts the server's `detail` field into that message, or the truncated response body verbatim when the response is not JSON. Nearly every command renders API failures through `%s` on these helpers, so a bidi override or an escape sequence chosen by the server lands raw on the operator's terminal. Same class as the Trojan Source issue #294 closed on the audit-review surface, this time reachable through any command's error output.

A self-hosted workspace talks to a server the operator does not necessarily control end to end, and reflected input reaches the same path whenever an error message echoes an attacker-chosen name or path back. The `--output json` error envelope already goes through `escapeJSONControls` and is safe, so only the default text form was exposed.

Whether the server sanitizes `detail` before serving it is not verified. As with #294, the CLI side is treated as defence in depth.

## Changes

`cliMessage` in `utils/log.go` is the single choke point every `Cli*` helper now passes through, rather than the roughly 200 call sites.

It sanitizes per line. `SanitizeTerminalText` drops `\n` and callers pass multi-line guidance, so splitting first is what keeps their formatting alive.

The label colors (`Red("Error")` and friends) sit outside `cliMessage` in the `Fprintf` call and survive unchanged.

The token key highlight in `cmd/server` did not. It was passed as `utils.Green(key)` into a `%s` argument, so the sanitize pass stripped it. `warnTokenKey` (`cmd/server/token_create.go:113`) now prints both one-time keys, colorizing after sanitizing. The key is shown once and never again, so the highlight is what tells the user which part of the line to copy.

That contract—colorize after sanitizing, never hand a `Color()`-wrapped value to a `Cli*` helper—is stated on `cliMessage` and pinned by a test. `cmd/login.go` dropped its own `SanitizeTerminalText` call, which the choke point had made redundant; nothing hands a pre-sanitized or pre-colored value to a `Cli*` helper any more.

The decision the issue left open went to sanitizing the rendered message per line, not the interpolated arguments alone.

## Safety

Splitting after the format is rendered means a `\n` from the server survives too, so a `detail` can open a line that looks like the CLI's own prefix.

That is pinned by a test rather than fixed. `\r` is still dropped, so injected text can only appear below what is already on screen and never overwrites it.

`CliErrorWithExit`, `CliErrorWithExitCode` and `CliInfoWithExit` are absent from the table test because `os.Exit` makes their stderr uncapturable without a subprocess. All three go through the same `cliMessage`.

Registration guide strings take a different path—`cmd/server/server_create.go` prints them raw with `fmt.Fprintln`—and are out of scope here. Filed as #360, since those are the strings the operator is told to paste into a shell.

## Testing

Five emitters (`CliError`, `CliWarning`, `CliInfo`, `CliSuccess`, `CliDebug`) are crossed with four inputs: ANSI escape, bidi override, carriage return, 8-bit CSI. Caller newline preservation and server newline pass-through are each pinned separately, and one more test pins that `cliMessage` strips its arguments too, so a `Color()`-wrapped value comes out plain.

`colorEnabled` is fixed per test rather than left to the environment. It is decided once at package init by `term.IsTerminal`, so the assertion that stderr holds no `\x1b` at all was resting on `go test` happening to pipe the test binary's output—build the binary and run it under a pty and it fails on the label's own escape.

```
$ gofmt -l .                    (no output)
$ go vet ./...                  (no output, exit 0)
$ golangci-lint run ./...       0 issues.
$ go test -race -count=1 ./...  39 packages ok, 0 failures
```

`config.TestGetOrCreateDeviceID_ConcurrentCreation` fails intermittently in this repo (about half of `-count=20` iterations). It predates this branch and is untouched by it—filed as #361.

Closes #324
