### PR TITLE
fix(mfa): reject a malformed or empty MFA link response

### DIFF
--- a/api/event/sudolistener.go
+++ b/api/event/sudolistener.go
@@ -123,7 +123,7 @@ func (sl *SudoListener) handleSudoMFA(event sudoMFAEvent) {
 	// Slow path: open browser for MFA verification.
 	// Use CLI-specific MFA URL (location=cli) so the server persists
 	// MFACompletion to DB for polling.
-	mfaURL, err := mfa.GetMFALinkForSudo(sl.ac, sl.serverName)
+	mfaURL, err := mfa.GetMFALinkByServerName(sl.ac, sl.serverName)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "\r\n\033[31mFailed to get MFA link: %s\033[0m\r\n", err)
 		return

--- a/api/mfa/mfa.go
+++ b/api/mfa/mfa.go
@@ -163,10 +163,23 @@ func StepUpForSudo(ac *client.AlpaconClient, serverName string) error {
 // Uses location "cli" so the mfa-success page notifies the backend,
 // enabling CheckMFACompletion polling to detect when MFA is done.
 func GetWorkspaceSecurityMFALink(ac *client.AlpaconClient, workspaceName string) (string, error) {
-	params := map[string]string{
+	return fetchMFALink(ac, map[string]string{
 		"location":  "cli",
 		"workspace": workspaceName,
-	}
+	})
+}
+
+func GetMFALink(ac *client.AlpaconClient, serverID string, workspaceName string) (string, error) {
+	return fetchMFALink(ac, map[string]string{
+		"location":  "cli",
+		"server":    serverID,
+		"workspace": workspaceName,
+	})
+}
+
+// fetchMFALink rejects an empty URL as an error: every caller prints the link
+// to the user.
+func fetchMFALink(ac *client.AlpaconClient, params map[string]string) (string, error) {
 	responseBody, err := ac.SendGetRequest(utils.BuildURL(mfaURL, "", params))
 	if err != nil {
 		return "", fmt.Errorf("failed to get the MFA URL: %w", err)
@@ -179,23 +192,6 @@ func GetWorkspaceSecurityMFALink(ac *client.AlpaconClient, workspaceName string)
 	if mfaResp.MfaURL == "" {
 		return "", fmt.Errorf("MFA URL is empty in server response")
 	}
-
-	return mfaResp.MfaURL, nil
-}
-
-func GetMFALink(ac *client.AlpaconClient, serverID string, workspaceName string) (string, error) {
-	params := map[string]string{
-		"location":  "cli",
-		"server":    serverID,
-		"workspace": workspaceName,
-	}
-	responseBody, err := ac.SendGetRequest(utils.BuildURL(mfaURL, "", params))
-	if err != nil {
-		return "", fmt.Errorf("failed to get the MFA URL: %w", err)
-	}
-
-	var mfaResp mfaResponse
-	_ = json.Unmarshal(responseBody, &mfaResp)
 
 	return mfaResp.MfaURL, nil
 }

--- a/api/mfa/mfa.go
+++ b/api/mfa/mfa.go
@@ -33,14 +33,7 @@ type mfaCompletionResponse struct {
 }
 
 func HandleMFAError(ac *client.AlpaconClient, serverName string) error {
-
-	cfg, err := config.LoadConfig()
-	if err != nil {
-		utils.CliErrorWithExit("Failed to load configuration: %s.", err)
-	}
-
-	serverID, _ := server.GetServerIDByName(ac, serverName)
-	mfaURL, err := GetMFALink(ac, serverID, cfg.WorkspaceName)
+	mfaURL, err := GetMFALinkByServerName(ac, serverName)
 	if err != nil {
 		return err
 	}

--- a/api/mfa/mfa.go
+++ b/api/mfa/mfa.go
@@ -65,9 +65,9 @@ func CheckMFACompletion(ac *client.AlpaconClient) (bool, error) {
 	return resp.Completed, nil
 }
 
-// GetMFALinkForSudo resolves the server name and returns a CLI MFA URL.
-// Used by the sudo MFA listener where only the server name is available.
-func GetMFALinkForSudo(ac *client.AlpaconClient, serverName string) (string, error) {
+// GetMFALinkByServerName resolves the server name and returns a CLI MFA URL.
+// Used where only the server name is available, not the ID.
+func GetMFALinkByServerName(ac *client.AlpaconClient, serverName string) (string, error) {
 	cfg, err := config.LoadConfig()
 	if err != nil {
 		return "", fmt.Errorf("failed to load configuration: %w", err)
@@ -95,7 +95,7 @@ func GetMFALinkForSudo(ac *client.AlpaconClient, serverName string) (string, err
 func StepUpForSudo(ac *client.AlpaconClient, serverName string) error {
 	// Use the CLI-scoped sudo MFA URL (location=cli) so the mfa-success page
 	// notifies the backend, letting CheckMFACompletion observe completion.
-	stepUpURL, err := GetMFALinkForSudo(ac, serverName)
+	stepUpURL, err := GetMFALinkByServerName(ac, serverName)
 	if err != nil {
 		return fmt.Errorf("failed to get the MFA step-up link: %w", err)
 	}

--- a/api/mfa/mfa.go
+++ b/api/mfa/mfa.go
@@ -99,11 +99,6 @@ func StepUpForSudo(ac *client.AlpaconClient, serverName string) error {
 	if err != nil {
 		return fmt.Errorf("failed to get the MFA step-up link: %w", err)
 	}
-	// GetMFALink can return an empty URL without an error on a malformed
-	// response; fail fast rather than print a blank link and poll until timeout.
-	if stepUpURL == "" {
-		return fmt.Errorf("server returned an empty MFA step-up link")
-	}
 
 	fmt.Fprintf(os.Stderr, "\nsudo needs a recent MFA to proceed. Open this link to verify:\n%s\n", stepUpURL)
 	fmt.Fprintf(os.Stderr, "Press Enter to open it in your browser, or open the link manually.\n")

--- a/api/mfa/mfa_test.go
+++ b/api/mfa/mfa_test.go
@@ -3,6 +3,7 @@ package mfa
 import (
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 
 	"github.com/alpacax/alpacon-cli/client"
@@ -58,4 +59,79 @@ func TestCheckMFACompletion_ServerError(t *testing.T) {
 
 	_, err := CheckMFACompletion(ac)
 	assert.Error(t, err)
+}
+
+func mfaLinkServer(t *testing.T, body string) (*client.AlpaconClient, *url.Values) {
+	t.Helper()
+	var query url.Values
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, mfaURL+"/", r.URL.Path)
+		query = r.URL.Query()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(body))
+	}))
+	t.Cleanup(ts.Close)
+
+	return &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}, &query
+}
+
+func TestGetMFALink_ReturnsTheURLAndScopesItToTheServer(t *testing.T) {
+	ac, query := mfaLinkServer(t, `{"mfa_url": "https://example.com/mfa"}`)
+
+	link, err := GetMFALink(ac, "server-id", "my-workspace")
+
+	assert.NoError(t, err)
+	assert.Equal(t, "https://example.com/mfa", link)
+	assert.Equal(t, "cli", query.Get("location"))
+	assert.Equal(t, "server-id", query.Get("server"))
+	assert.Equal(t, "my-workspace", query.Get("workspace"))
+}
+
+// It used to yield ("", nil), so callers opened a browser on a blank link.
+func TestGetMFALink_MalformedBodyIsAnError(t *testing.T) {
+	ac, _ := mfaLinkServer(t, `not json`)
+
+	link, err := GetMFALink(ac, "server-id", "my-workspace")
+
+	assert.Error(t, err)
+	assert.Empty(t, link)
+}
+
+func TestGetMFALink_EmptyURLIsAnError(t *testing.T) {
+	ac, _ := mfaLinkServer(t, `{"mfa_url": ""}`)
+
+	link, err := GetMFALink(ac, "server-id", "my-workspace")
+
+	assert.Error(t, err)
+	assert.Empty(t, link)
+}
+
+func TestGetWorkspaceSecurityMFALink_SendsNoServerScope(t *testing.T) {
+	ac, query := mfaLinkServer(t, `{"mfa_url": "https://example.com/mfa"}`)
+
+	link, err := GetWorkspaceSecurityMFALink(ac, "my-workspace")
+
+	assert.NoError(t, err)
+	assert.Equal(t, "https://example.com/mfa", link)
+	assert.Equal(t, "cli", query.Get("location"))
+	assert.Equal(t, "my-workspace", query.Get("workspace"))
+	assert.NotContains(t, *query, "server")
+}
+
+func TestGetMFALink_ServerErrorIsAnError(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"detail": "internal server error"}`))
+	}))
+	defer ts.Close()
+
+	ac := &client.AlpaconClient{
+		HTTPClient: ts.Client(),
+		BaseURL:    ts.URL,
+	}
+
+	link, err := GetMFALink(ac, "server-id", "my-workspace")
+
+	assert.Error(t, err)
+	assert.Empty(t, link)
 }

--- a/cmd/exec/run.go
+++ b/cmd/exec/run.go
@@ -349,7 +349,7 @@ func RunExecWithPresenceStepUp(ac *client.AlpaconClient, serverName, command, us
 		// Non-interactive: surface the verification link so a human reading the
 		// logs can complete MFA out of band, then re-run. We cannot prompt or
 		// open a browser here.
-		if url, linkErr := mfa.GetMFALinkByServerName(ac, serverName); linkErr == nil && url != "" {
+		if url, linkErr := mfa.GetMFALinkByServerName(ac, serverName); linkErr == nil {
 			utils.CliInfo("MFA verification link (open in a browser):\n  %s", url)
 		}
 		return err

--- a/cmd/exec/run.go
+++ b/cmd/exec/run.go
@@ -349,7 +349,7 @@ func RunExecWithPresenceStepUp(ac *client.AlpaconClient, serverName, command, us
 		// Non-interactive: surface the verification link so a human reading the
 		// logs can complete MFA out of band, then re-run. We cannot prompt or
 		// open a browser here.
-		if url, linkErr := mfa.GetMFALinkForSudo(ac, serverName); linkErr == nil && url != "" {
+		if url, linkErr := mfa.GetMFALinkByServerName(ac, serverName); linkErr == nil && url != "" {
 			utils.CliInfo("MFA verification link (open in a browser):\n  %s", url)
 		}
 		return err

--- a/cmd/exec/run.go
+++ b/cmd/exec/run.go
@@ -47,6 +47,7 @@ var approvalWaitPollInterval = 5 * time.Second
 var (
 	runPresenceStepUp     = RunExecWithPresenceStepUp
 	streamApprovedCommand = event.StreamApprovedCommand
+	mfaLinkByServerName   = mfa.GetMFALinkByServerName
 )
 
 // sudoDenialHints maps a non-interactive sudo denial code to actionable
@@ -346,12 +347,7 @@ func RunExecWithPresenceStepUp(ac *client.AlpaconClient, serverName, command, us
 	}
 
 	if !utils.IsInteractiveShell() {
-		// Non-interactive: surface the verification link so a human reading the
-		// logs can complete MFA out of band, then re-run. We cannot prompt or
-		// open a browser here.
-		if url, linkErr := mfa.GetMFALinkByServerName(ac, serverName); linkErr == nil {
-			utils.CliInfo("MFA verification link (open in a browser):\n  %s", url)
-		}
+		printPresenceStepUpLink(ac, serverName)
 		return err
 	}
 
@@ -363,6 +359,19 @@ func RunExecWithPresenceStepUp(ac *client.AlpaconClient, serverName, command, us
 	// Presence is fresh—retry once. Any remaining denial falls through to the
 	// static hint in HandleCommandResult.
 	return RunCommandWithRetry(ac, serverName, command, username, groupname, env, workSessionID, out)
+}
+
+// printPresenceStepUpLink surfaces the verification link for a non-interactive
+// presence denial, so a human reading the logs can complete MFA out of band and
+// re-run. We cannot prompt or open a browser here. A link that cannot be
+// fetched is dropped silently: the static denial hint already carries the
+// actionable part, and the link is the extra.
+func printPresenceStepUpLink(ac *client.AlpaconClient, serverName string) {
+	url, err := mfaLinkByServerName(ac, serverName)
+	if err != nil {
+		return
+	}
+	utils.CliInfo("MFA verification link (open in a browser):\n  %s", url)
 }
 
 // approvalDenialOutput returns the captured output of a denial that left an

--- a/cmd/exec/run_test.go
+++ b/cmd/exec/run_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -11,6 +12,7 @@ import (
 	"github.com/alpacax/alpacon-cli/api/event"
 	"github.com/alpacax/alpacon-cli/client"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestClientTimeoutLine(t *testing.T) {
@@ -200,4 +202,52 @@ func TestRunExecWithApprovalWait_TimesOutAfterWindow(t *testing.T) {
 
 	assert.Same(t, denial, err, "timeout returns the last pending denial for the caller's handler")
 	assert.GreaterOrEqual(t, elapsed, waitTimeout, "loop must wait the full anchored window before timing out")
+}
+
+// captureStderr returns everything fn writes to stderr.
+func captureStderr(t *testing.T, fn func()) string {
+	t.Helper()
+	reader, writer, err := os.Pipe()
+	require.NoError(t, err)
+	original := os.Stderr
+	os.Stderr = writer
+	defer func() { os.Stderr = original }()
+
+	captured := make(chan string, 1)
+	go func() {
+		data, _ := io.ReadAll(reader)
+		captured <- string(data)
+	}()
+
+	fn()
+	require.NoError(t, writer.Close())
+	return <-captured
+}
+
+func TestPrintPresenceStepUpLink(t *testing.T) {
+	original := mfaLinkByServerName
+	t.Cleanup(func() { mfaLinkByServerName = original })
+
+	// The link is printed unconditionally: api/mfa never hands back an empty URL
+	// with a nil error, so there is nothing left for this caller to filter.
+	t.Run("prints the link", func(t *testing.T) {
+		mfaLinkByServerName = func(*client.AlpaconClient, string) (string, error) {
+			return "https://example.com/mfa", nil
+		}
+
+		stderr := captureStderr(t, func() { printPresenceStepUpLink(nil, "my-server") })
+
+		assert.Contains(t, stderr, "https://example.com/mfa")
+		assert.Contains(t, stderr, "MFA verification link")
+	})
+
+	t.Run("stays silent when the link cannot be fetched", func(t *testing.T) {
+		mfaLinkByServerName = func(*client.AlpaconClient, string) (string, error) {
+			return "", errors.New("failed to parse MFA URL response")
+		}
+
+		stderr := captureStderr(t, func() { printPresenceStepUpLink(nil, "my-server") })
+
+		assert.Empty(t, stderr)
+	})
 }

--- a/cmd/exec/run_test.go
+++ b/cmd/exec/run_test.go
@@ -4,15 +4,14 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"os"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/alpacax/alpacon-cli/api/event"
 	"github.com/alpacax/alpacon-cli/client"
+	"github.com/alpacax/alpacon-cli/pkg/testutil"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestClientTimeoutLine(t *testing.T) {
@@ -207,21 +206,8 @@ func TestRunExecWithApprovalWait_TimesOutAfterWindow(t *testing.T) {
 // captureStderr returns everything fn writes to stderr.
 func captureStderr(t *testing.T, fn func()) string {
 	t.Helper()
-	reader, writer, err := os.Pipe()
-	require.NoError(t, err)
-	original := os.Stderr
-	os.Stderr = writer
-	defer func() { os.Stderr = original }()
-
-	captured := make(chan string, 1)
-	go func() {
-		data, _ := io.ReadAll(reader)
-		captured <- string(data)
-	}()
-
-	fn()
-	require.NoError(t, writer.Close())
-	return <-captured
+	_, stderr := testutil.CaptureOutput(t, fn)
+	return stderr
 }
 
 func TestPrintPresenceStepUpLink(t *testing.T) {


### PR DESCRIPTION
## Background

`GetMFALink` discarded its unmarshal error:

```go
var mfaResp mfaResponse
_ = json.Unmarshal(responseBody, &mfaResp)

return mfaResp.MfaURL, nil
```

A malformed body therefore yielded `("", nil)` — an empty URL with no error. `client.SendGetRequest` validates only the HTTP layer, so a 2xx response whose body is not JSON, or is JSON without an `mfa_url` field, reached the caller as a success. Callers printed the blank link and called `utils.OpenBrowser` on it, with nothing to indicate a failure.

The sibling `GetWorkspaceSecurityMFALink` issues the same request with a different parameter set and already checked both the unmarshal error and the empty URL. Two other call sites worked around the gap locally: `StepUpForSudo` failed fast on an empty link, and the non-interactive `exec` path checked `url != ""` before printing. The same workaround appearing in two files is what pointed at the callee.

## Changes

Six commits, ordered so review reads top to bottom.

| Commit | What |
|---|---|
| `refactor(mfa)` | rename `GetMFALinkForSudo` to `GetMFALinkByServerName` — it resolves a name and returns a CLI-scoped link, which is not sudo-specific |
| `fix(mfa)` | `GetMFALink` and `GetWorkspaceSecurityMFALink` now share `fetchMFALink`, which returns an error for a malformed body and separately for an empty `mfa_url` |
| `refactor` | drop the two local guards `fetchMFALink` made unreachable |
| `fix(mfa)` | `HandleMFAError` stops discarding the server lookup error |
| `test(exec)` | cover the non-interactive step-up link print |
| `test(exec)` | route the new test's stderr capture through `pkg/testutil` |

### The second fix

`HandleMFAError` carried the same defect class one level up:

```go
serverID, _ := server.GetServerIDByName(ac, serverName)
mfaURL, err := GetMFALink(ac, serverID, cfg.WorkspaceName)
```

A name that failed to resolve produced an empty `serverID`, so the request went out with an empty `server` parameter — a link scoped to the workspace rather than to the server the caller named. `GetMFALinkByServerName` already loads the config and resolves the name with the error checked, so `HandleMFAError` delegates to it and the duplicated sequence goes away.

## Behavior change worth stating

`HandleMFAError` previously called `utils.CliErrorWithExit` itself on a config load failure; it now returns an error. The process still exits. All eight call sites wire it in as `utils.HandleCommonErrors`' `OnMFARequired` callback, and `utils/error_handler.go:46` turns a non-nil return into `CliErrorWithExit`. Only the message text differs.

What does change: a server name that cannot be resolved now aborts the MFA flow instead of continuing with a workspace-scoped link. Every one of the eight call sites takes `serverName` from a required positional argument or from a parser that rejects an empty host, so no path reaches this with an empty name. The two `cmd/workspace` commands that call `HandleCommonErrors(err, "", ...)` wire `OnMFARequired` to their own inline callback around `mfa.GetWorkspaceSecurityMFALink`, not to `HandleMFAError`.

`GetServerIDByName` hits the `list` action, which is not in `ServerViewSet.mfa_rules` on the server side, so resolving the name to build an MFA link is not itself MFA-gated.

## Testing

`api/mfa/mfa_test.go` — five tests over `fetchMFALink` through its two public wrappers: the success path with the query scoped to the server, a malformed body, an empty `mfa_url`, a 500 response, and `GetWorkspaceSecurityMFALink` sending no `server` parameter. The malformed-body test is the regression proof — it is the exact input that used to return `("", nil)`.

`cmd/exec/run_test.go` — `printPresenceStepUpLink` in both branches: the link printed to stderr, and silence when the lookup fails. The mfa lookup joins the package-var seams already in that file for `runPresenceStepUp` and `streamApprovedCommand`. The stderr capture delegates to `testutil.CaptureOutput`, matching what `utils/log_test.go` does — the shared `redirect` makes the stop idempotent through `t.Cleanup`, so a panic in the captured function cannot leave the pipe installed for the rest of the package.

```
$ gofmt -l .                 (no output)
$ go vet ./...               (no output)
$ golangci-lint run ./...    0 issues.
$ go test -race ./...         39 ok, 0 FAIL
```

Coverage: `api/mfa` 8.5% to 28.8%, `cmd/exec` 75.1% to 75.5%, both measured against `origin/main` after the rebase.

`GetMFALinkByServerName` and `HandleMFAError` have no direct test of their own. Both depend on `config.LoadConfig()` reading the real `~/.alpacon/config.json`, and what is left to verify in each is three lines of error propagation. Checked by reading all eight call sites instead.

Rebased onto `origin/main` at `7c0befb`. No conflicts.

Closes #356
