### PR TITLE
fix(ftp): keep the trailing colon on a user-prefixed remote target

### DIFF
--- a/cmd/ftp/cp.go
+++ b/cmd/ftp/cp.go
@@ -74,13 +74,7 @@ Requires an active WorkSession when using Browser login (Auth0); Token auth (API
 			return
 		}
 
-		for i, arg := range args {
-			rewritten, user := stripUserPrefix(arg)
-			if username == "" {
-				username = user
-			}
-			args[i] = rewritten
-		}
+		username = normalizeArgs(args, username)
 
 		sources := args[:len(args)-1]
 		dest := args[len(args)-1]
@@ -203,6 +197,19 @@ func isLocalPaths(paths []string) bool {
 		}
 	}
 	return true
+}
+
+// normalizeArgs strips inline user prefixes in place and resolves the username:
+// the -u flag wins, then the first inline user.
+func normalizeArgs(args []string, username string) string {
+	for i, arg := range args {
+		rewritten, user := stripUserPrefix(arg)
+		if username == "" {
+			username = user
+		}
+		args[i] = rewritten
+	}
+	return username
 }
 
 // stripUserPrefix rewrites user@host:path as host:path, handing back the user.

--- a/cmd/ftp/cp.go
+++ b/cmd/ftp/cp.go
@@ -214,10 +214,7 @@ func stripUserPrefix(arg string) (rewritten, user string) {
 		return arg, ""
 	}
 	sshTarget := utils.ParseSSHTarget(arg)
-	if sshTarget.Path != "" || strings.HasSuffix(arg, ":") {
-		return sshTarget.Host + ":" + sshTarget.Path, sshTarget.User
-	}
-	return sshTarget.Host, sshTarget.User
+	return sshTarget.Host + ":" + sshTarget.Path, sshTarget.User
 }
 
 func validatePaths(sources []string, dest string) error {

--- a/cmd/ftp/cp.go
+++ b/cmd/ftp/cp.go
@@ -75,19 +75,11 @@ Requires an active WorkSession when using Browser login (Auth0); Token auth (API
 		}
 
 		for i, arg := range args {
-			if strings.Contains(arg, "@") && strings.Contains(arg, ":") {
-				// Parse SSH-like target: user@host:path (requires : to distinguish from local files with @)
-				sshTarget := utils.ParseSSHTarget(arg)
-				if username == "" && sshTarget.User != "" {
-					username = sshTarget.User
-				}
-				// Reconstruct the argument without the user part
-				if sshTarget.Path != "" {
-					args[i] = sshTarget.Host + ":" + sshTarget.Path
-				} else {
-					args[i] = sshTarget.Host
-				}
+			rewritten, user := stripUserPrefix(arg)
+			if username == "" {
+				username = user
 			}
+			args[i] = rewritten
 		}
 
 		sources := args[:len(args)-1]
@@ -211,6 +203,21 @@ func isLocalPaths(paths []string) bool {
 		}
 	}
 	return true
+}
+
+// stripUserPrefix rewrites user@host:path as host:path, handing back the user.
+// The : is required to tell the syntax from a local file name holding an @. A
+// trailing colon survives ("alice@myserver:" stays remote), so validatePaths
+// reports the missing remote path rather than a source/destination mismatch.
+func stripUserPrefix(arg string) (rewritten, user string) {
+	if !strings.Contains(arg, "@") || !strings.Contains(arg, ":") {
+		return arg, ""
+	}
+	sshTarget := utils.ParseSSHTarget(arg)
+	if sshTarget.Path != "" || strings.HasSuffix(arg, ":") {
+		return sshTarget.Host + ":" + sshTarget.Path, sshTarget.User
+	}
+	return sshTarget.Host, sshTarget.User
 }
 
 func validatePaths(sources []string, dest string) error {

--- a/cmd/ftp/cp_test.go
+++ b/cmd/ftp/cp_test.go
@@ -1,10 +1,8 @@
 package ftp
 
 import (
-	"strings"
 	"testing"
 
-	"github.com/alpacax/alpacon-cli/utils"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -271,28 +269,13 @@ func TestCpCommandSSHParsing(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Simulate the parsing logic from the cp command
 			args := make([]string, len(tt.args))
 			copy(args, tt.args)
-			username := ""
 
-			// Apply the same parsing logic as in cp.go
-			for i, arg := range args {
-				if strings.Contains(arg, "@") && strings.Contains(arg, ":") {
-					sshTarget := utils.ParseSSHTarget(arg)
-					if username == "" && sshTarget.User != "" {
-						username = sshTarget.User
-					}
-					if sshTarget.Path != "" {
-						args[i] = sshTarget.Host + ":" + sshTarget.Path
-					} else {
-						args[i] = sshTarget.Host
-					}
-				}
-			}
+			username := normalizeArgs(args, "")
 
-			assert.Equal(t, tt.expectedArgs, args, "Arguments should match expected after parsing")
-			assert.Equal(t, tt.expectedUser, username, "Username should match expected")
+			assert.Equal(t, tt.expectedArgs, args)
+			assert.Equal(t, tt.expectedUser, username)
 		})
 	}
 }

--- a/cmd/ftp/cp_test.go
+++ b/cmd/ftp/cp_test.go
@@ -368,3 +368,29 @@ func TestStripUserPrefix(t *testing.T) {
 		})
 	}
 }
+
+func TestNormalizeArgsUsername(t *testing.T) {
+	tests := []struct {
+		name     string
+		args     []string
+		flagUser string
+		wantUser string
+	}{
+		{
+			name:     "the -u flag wins over an inline user",
+			args:     []string{"test.txt", "alice@myserver:/tmp/"},
+			flagUser: "carol",
+			wantUser: "carol",
+		},
+		{
+			name:     "the first inline user wins",
+			args:     []string{"alice@myserver:/tmp/f", "bob@myserver:/tmp/g"},
+			wantUser: "alice",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.wantUser, normalizeArgs(tt.args, tt.flagUser))
+		})
+	}
+}

--- a/cmd/ftp/cp_test.go
+++ b/cmd/ftp/cp_test.go
@@ -357,3 +357,31 @@ func TestRequiredCpPatterns(t *testing.T) {
 		})
 	}
 }
+
+func TestStripUserPrefix(t *testing.T) {
+	tests := []struct {
+		name          string
+		arg           string
+		wantRewritten string
+		wantUser      string
+	}{
+		{name: "user, host and path", arg: "alice@myserver:/tmp/f", wantRewritten: "myserver:/tmp/f", wantUser: "alice"},
+		{
+			name:          "user and host with a trailing colon",
+			arg:           "alice@myserver:",
+			wantRewritten: "myserver:",
+			wantUser:      "alice",
+		},
+		{name: "no user is untouched", arg: "myserver:/tmp/f", wantRewritten: "myserver:/tmp/f"},
+		{name: "trailing colon without a user is untouched", arg: "myserver:", wantRewritten: "myserver:"},
+		{name: "local path with an @ but no colon is untouched", arg: "./mail@example.txt", wantRewritten: "./mail@example.txt"},
+		{name: "path may itself contain an @", arg: "alice@myserver:/tmp/mail@example.txt", wantRewritten: "myserver:/tmp/mail@example.txt", wantUser: "alice"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rewritten, user := stripUserPrefix(tt.arg)
+			assert.Equal(t, tt.wantRewritten, rewritten)
+			assert.Equal(t, tt.wantUser, user)
+		})
+	}
+}

--- a/cmd/ftp/cp_test.go
+++ b/cmd/ftp/cp_test.go
@@ -372,8 +372,8 @@ func TestStripUserPrefix(t *testing.T) {
 			wantRewritten: "myserver:",
 			wantUser:      "alice",
 		},
+		{name: "user and an empty host", arg: "alice@:", wantRewritten: ":", wantUser: "alice"},
 		{name: "no user is untouched", arg: "myserver:/tmp/f", wantRewritten: "myserver:/tmp/f"},
-		{name: "trailing colon without a user is untouched", arg: "myserver:", wantRewritten: "myserver:"},
 		{name: "local path with an @ but no colon is untouched", arg: "./mail@example.txt", wantRewritten: "./mail@example.txt"},
 		{name: "path may itself contain an @", arg: "alice@myserver:/tmp/mail@example.txt", wantRewritten: "myserver:/tmp/mail@example.txt", wantUser: "alice"},
 	}


### PR DESCRIPTION
## Background

`alpacon cp file.txt alice@myserver:` reported an invalid source/destination combination instead of the missing remote path. The same destination without the user prefix — `myserver:` — reported the accurate error.

`cmd/ftp/cp.go` reassembled every argument holding both `@` and `:` after parsing it:

```go
if sshTarget.Path != "" {
    args[i] = sshTarget.Host + ":" + sshTarget.Path
} else {
    args[i] = sshTarget.Host
}
```

For `alice@myserver:`, `utils.ParseSSHTarget` returns `Host: "myserver"`, `Path: ""`, so the else branch dropped the colon along with the user. `validatePaths` then received a bare `myserver`, which `utils.IsRemoteTarget` classifies as local; with both operands local it fell through to the mismatch error. `myserver:` never entered the loop — the condition needs an `@` — so it survived intact and hit the remote-path check.

An empty path is the only case where the reassembly discarded something the user typed. No transfer ran either way and the exit code was already `1`, so this misled the reader rather than losing data.

## Changes

Five commits, ordered so review reads top to bottom.

| Commit | What |
|---|---|
| `fix(ftp)` | the reassembly moves into `stripUserPrefix`, where a trailing colon in the original argument keeps the target remote |
| `refactor(ftp)` | drop the branch that helper's own guard made dead |
| `test(ftp)` | pin the empty-host target, drop the case that proved nothing |
| `refactor(ftp)` | the normalization loop moves into `normalizeArgs` so `TestCpCommandSSHParsing` calls it instead of inlining a copy |
| `test(ftp)` | pin the username precedence that copy left unreachable |

### Why the dead branch went

`stripUserPrefix` returns early unless the argument holds both `@` and `:`, so by the time `ParseSSHTarget` runs the colon is always present. `splitUserPrefix` (`utils/ssh_parser.go:44`) only shifts the colon, never removes it, so `Path` always comes from the `SplitN` and is empty exactly when the argument ends with a colon. That made the first cut of the fix — `if sshTarget.Path != "" || strings.HasSuffix(arg, ":")` — a tautology, with an unreachable return below it:

```go
sshTarget := utils.ParseSSHTarget(arg)
return sshTarget.Host + ":" + sshTarget.Path, sshTarget.User
```

Keeping the branch bought nothing. It dropped the colon and the path, which is the defect being fixed here, so it was never a usable fallback if `ParseSSHTarget` changed. `TestStripUserPrefix` holds the observable behavior instead.

## Testing

`cmd/ftp/cp_test.go` — `TestStripUserPrefix`, six cases over the helper:

| Argument | Rewritten | User |
|---|---|---|
| `alice@myserver:/tmp/f` | `myserver:/tmp/f` | `alice` |
| `alice@myserver:` | `myserver:` | `alice` |
| `alice@:` | `:` | `alice` |
| `myserver:/tmp/f` | unchanged | — |
| `./mail@example.txt` | unchanged | — |
| `alice@myserver:/tmp/mail@example.txt` | `myserver:/tmp/mail@example.txt` | `alice` |

`alice@myserver:` is the regression proof — the exact input from the report. `alice@:` is adjacent: it reached the old code as an empty string, a local argument nobody typed, and now rewrites to `:` so `validatePaths` reports the missing server name.

`TestCpCommandSSHParsing` used to inline the normalization loop rather than call `cp`, and that copy still carried the branch the `fix` commit deletes — it pinned `alice@myserver:` rewriting to `myserver` as correct. The loop now lives in `normalizeArgs` and the eight cases run it, so deleting `stripUserPrefix` no longer leaves the file green. The copy was the only use of the `strings` and `utils` imports in the test file, so both go with it.

`TestNormalizeArgsUsername` pins the username rule the copy left unreachable: `-u` outranks an inline user, and the first inline user outranks later ones. The old `if username == "" && sshTarget.User != ""` became `if username == "" { username = user }`; when `user` is empty that assigns `""` onto a variable already `""`, so the precedence is unchanged.

`utils.ParseSSHTarget` is untouched, so `websh`, `edit`, and `exec` are unaffected.

```
$ gofmt -l .                 (no output)
$ go vet ./...               (no output)
$ golangci-lint run ./...    0 issues.
$ go test -race ./...        39 ok, 0 FAIL
```

Closes #349

