### PR TITLE
fix(auth): put the device id in the file before its path exists

### DIFF
--- a/config/device.go
+++ b/config/device.go
@@ -19,10 +19,6 @@ const (
 	// identifier must outlive it. This mirrors the web client, which keeps its
 	// own identifier in localStorage rather than alongside its session.
 	DeviceIDFileName = "device_id"
-
-	// deviceIDFileMode is the mode the identifier file is created with, and the
-	// ceiling enforced on one that already exists.
-	deviceIDFileMode = 0600
 )
 
 var (
@@ -59,9 +55,8 @@ func IsValidDeviceID(id string) bool {
 // binds to, and it identifies this installation to the identity provider,
 // travelling there in OAuth requests where it may be recorded in tenant logs.
 // So it is a stable, security-relevant identifier rather than a throwaway: the
-// file is kept at deviceIDFileMode inside the 0700 config directory, out of
-// reach of other accounts on a shared machine, and it does not belong in logs
-// or bug reports.
+// file is kept at 0600 inside the 0700 config directory, out of reach of other
+// accounts on a shared machine, and it does not belong in logs or bug reports.
 func GetOrCreateDeviceID() (string, error) {
 	path, err := deviceIDPath()
 	if err != nil {
@@ -116,25 +111,12 @@ func createDeviceID(path string) (string, error) {
 		return "", err
 	}
 
-	// O_EXCL, so two concurrent invocations cannot both believe they created
-	// the file. A plain write would let both generate and both store, and the
-	// loser would authenticate under an identifier its own installation never
-	// sends again, orphaning that login's presence. Creating rather than
-	// overwriting also makes the mode argument bite: it applies only to a file
-	// the call itself creates.
-	file, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, deviceIDFileMode)
+	err = createDeviceIDFile(path, deviceID)
 	switch {
 	case err == nil:
-		_, err = file.WriteString(deviceID + "\n")
-		if closeErr := file.Close(); err == nil {
-			err = closeErr
-		}
-		if err != nil {
-			return "", fmt.Errorf("failed to write device id file: %v", err)
-		}
 	case errors.Is(err, fs.ErrExist):
 		// Something created the file between the read in GetOrCreateDeviceID
-		// and this call. Whatever it wrote is already in flight, so adopt it
+		// and this call. Whatever it holds is already in flight, so adopt it
 		// instead of overwriting it with a value only this process knows.
 		existing, readErr := readDeviceID(path)
 		if readErr != nil {
@@ -159,7 +141,7 @@ func createDeviceID(path string) (string, error) {
 			return "", err
 		}
 	default:
-		return "", fmt.Errorf("failed to create device id file: %v", err)
+		return "", err
 	}
 
 	// Report what the file holds rather than what was generated. Both of the
@@ -178,25 +160,53 @@ func createDeviceID(path string) (string, error) {
 	return stored, nil
 }
 
+// createDeviceIDFile publishes deviceID at path, reporting fs.ErrExist when the
+// path is already taken, so two concurrent invocations cannot both believe they
+// created the file. A plain write would let both generate and both store, and
+// the loser would authenticate under an identifier its own installation never
+// sends again, orphaning that login's presence.
+//
+// The content lands before the name does: the value is written to a temporary
+// file, and the link publishes a file that already holds it. Creating with
+// O_EXCL and writing on the next line is exclusive on the name alone—for the
+// length of that write the path exists and is empty, and an empty file is what
+// readDeviceID reports as absent, so a concurrent invocation reads it, judges
+// it malformed, and replaces the winner's identifier with its own.
+//
+// Linking rather than renaming is what keeps the exclusion: rename replaces
+// whatever it lands on. A filesystem with no hard links fails here rather than
+// falling back, since every fallback either gives up the exclusion or brings
+// the empty window back. That failure costs a hardening signal rather than a
+// login: the one caller of GetOrCreateDeviceID drops the error and lets the
+// server fall back to its own fingerprint.
+//
+// The mode published is the temporary file's, which os.CreateTemp sets to 0600
+// and the umask can narrow further.
+func createDeviceIDFile(path, deviceID string) error {
+	tempPath, err := writeDeviceIDTempFile(path, deviceID)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = os.Remove(tempPath) }()
+
+	if err = os.Link(tempPath, path); err != nil {
+		// Wrapped, not reformatted: the caller matches fs.ErrExist on it.
+		return fmt.Errorf("failed to create device id file: %w", err)
+	}
+
+	return nil
+}
+
 // replaceDeviceIDFile overwrites the identifier file through a temporary file
 // and a rename, so no reader observes a half-written or empty file and so the
 // replacement carries its own mode instead of inheriting whatever the file it
 // replaced had.
 func replaceDeviceIDFile(path, deviceID string) error {
-	file, err := os.CreateTemp(filepath.Dir(path), DeviceIDFileName+"-*")
+	tempPath, err := writeDeviceIDTempFile(path, deviceID)
 	if err != nil {
-		return fmt.Errorf("failed to create device id file: %v", err)
+		return err
 	}
-	tempPath := file.Name()
 	defer func() { _ = os.Remove(tempPath) }()
-
-	_, err = file.WriteString(deviceID + "\n")
-	if closeErr := file.Close(); err == nil {
-		err = closeErr
-	}
-	if err != nil {
-		return fmt.Errorf("failed to write device id file: %v", err)
-	}
 
 	if err = os.Rename(tempPath, path); err != nil {
 		return fmt.Errorf("failed to replace device id file: %v", err)
@@ -205,15 +215,42 @@ func replaceDeviceIDFile(path, deviceID string) error {
 	return nil
 }
 
+// writeDeviceIDTempFile writes deviceID to a fresh file beside path and returns
+// that file's name, for a caller that publishes it with a link or a rename. The
+// caller owns the returned path and has to remove it: after a link it is a
+// second name for a file that is now published, and after a failure it is a
+// leftover.
+func writeDeviceIDTempFile(path, deviceID string) (string, error) {
+	file, err := os.CreateTemp(filepath.Dir(path), DeviceIDFileName+"-*")
+	if err != nil {
+		// Flattened rather than wrapped, deliberately: os.CreateTemp reports
+		// fs.ErrExist once it runs out of names to try, and createDeviceID reads
+		// that error as the identifier file itself already existing.
+		return "", fmt.Errorf("failed to create device id file: %v", err)
+	}
+	tempPath := file.Name()
+
+	_, err = file.WriteString(deviceID + "\n")
+	if closeErr := file.Close(); err == nil {
+		err = closeErr
+	}
+	if err != nil {
+		_ = os.Remove(tempPath)
+		return "", fmt.Errorf("failed to write device id file: %v", err)
+	}
+
+	return tempPath, nil
+}
+
 // restrictDeviceIDFileMode drops any group or other permission bits from a file
 // that already exists. A mode argument only applies to a file the call creates,
 // so an identifier file some other path left world-readable would otherwise
 // keep that mode for the life of the installation while this package claims
-// deviceIDFileMode.
+// 0600.
 //
 // Bits are only ever removed, never added: a stricter umask legitimately
-// produces something tighter than deviceIDFileMode, and loosening that back
-// would be this function undoing the protection it exists to provide.
+// produces something tighter than 0600, and loosening that back would be this
+// function undoing the protection it exists to provide.
 func restrictDeviceIDFileMode(path string) error {
 	if runtime.GOOS == "windows" {
 		// Windows has no Unix mode bits; os.Chmod there toggles the read-only

--- a/config/device.go
+++ b/config/device.go
@@ -172,11 +172,8 @@ func createDeviceID(path string) (string, error) {
 // it malformed, and replaces the winner's identifier with its own.
 //
 // Linking rather than renaming is what keeps the exclusion: rename replaces
-// whatever it lands on. A filesystem with no hard links fails here rather than
-// falling back, since every fallback either gives up the exclusion or brings
-// the empty window back. That failure costs a hardening signal rather than a
-// login: the one caller of GetOrCreateDeviceID drops the error and lets the
-// server fall back to its own fingerprint.
+// whatever it lands on. A filesystem with no hard links—FAT, exFAT, some
+// container mounts—cannot publish this way and falls back to O_EXCL.
 //
 // The mode published is the temporary file's, which os.CreateTemp sets to 0600
 // and the umask can narrow further.
@@ -187,9 +184,41 @@ func createDeviceIDFile(path, deviceID string) error {
 	}
 	defer func() { _ = os.Remove(tempPath) }()
 
-	if err = os.Link(tempPath, path); err != nil {
+	err = os.Link(tempPath, path)
+	if err == nil {
+		return nil
+	}
+	if errors.Is(err, fs.ErrExist) {
 		// Wrapped, not reformatted: the caller matches fs.ErrExist on it.
 		return fmt.Errorf("failed to create device id file: %w", err)
+	}
+
+	return createDeviceIDFileWithoutLink(path, deviceID)
+}
+
+// createDeviceIDFileWithoutLink is the fallback for a filesystem that cannot
+// hard-link. It gives the empty window back—measured on a FAT home, 8 concurrent
+// callers came away with disagreeing identifiers in 43 of 50 rounds—and is taken
+// anyway, because the alternative there is no identifier at all: the one caller
+// of GetOrCreateDeviceID drops the error, so failing is silent and permanent.
+//
+// Any link failure lands here, not only an unsupported one. A cause unrelated to
+// hard links—no permission on the directory, no space left—fails this call the
+// same way and surfaces as this error.
+func createDeviceIDFileWithoutLink(path, deviceID string) error {
+	file, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0600)
+	if err != nil {
+		// Wrapped for the same reason the link error is: a concurrent invocation
+		// can take the path between the failed link and this create.
+		return fmt.Errorf("failed to create device id file: %w", err)
+	}
+
+	_, err = file.WriteString(deviceID + "\n")
+	if closeErr := file.Close(); err == nil {
+		err = closeErr
+	}
+	if err != nil {
+		return fmt.Errorf("failed to write device id file: %v", err)
 	}
 
 	return nil

--- a/config/device.go
+++ b/config/device.go
@@ -159,24 +159,16 @@ func createDeviceID(path string) (string, error) {
 }
 
 // createDeviceIDFile publishes deviceID at path, reporting fs.ErrExist when the
-// path is already taken, so two concurrent invocations cannot both believe they
-// created the file. A plain write would let both generate and both store, and
-// the loser would authenticate under an identifier its own installation never
-// sends again, orphaning that login's presence.
+// path is taken, so two concurrent invocations cannot both believe they created
+// the file and the loser cannot end up on an identifier its own installation
+// never sends again.
 //
-// The content lands before the name does: the value is written to a temporary
-// file, and the link publishes a file that already holds it. Creating with
-// O_EXCL and writing on the next line is exclusive on the name alone—for the
-// length of that write the path exists and is empty, and an empty file is what
-// readDeviceID reports as absent, so a concurrent invocation reads it, judges
-// it malformed, and replaces the winner's identifier with its own.
-//
-// Linking rather than renaming is what keeps the exclusion: rename replaces
-// whatever it lands on. A filesystem with no hard links—FAT, exFAT, some
-// container mounts—cannot publish this way and falls back to O_EXCL.
-//
-// The mode published is the temporary file's, which os.CreateTemp sets to 0600
-// and the umask can narrow further.
+// The content lands before the name does: O_EXCL plus a write on the next line
+// leaves the path existing and empty for the length of the write, which
+// readDeviceID reports as absent, so a concurrent invocation judges it malformed
+// and replaces the winner's identifier. Linking rather than renaming keeps the
+// exclusion—rename replaces whatever it lands on—and publishes the temporary
+// file's mode, 0600 from os.CreateTemp less the umask.
 func createDeviceIDFile(path, deviceID string) error {
 	tempPath, err := writeDeviceIDTempFile(path, deviceID)
 	if err != nil {
@@ -197,19 +189,16 @@ func createDeviceIDFile(path, deviceID string) error {
 }
 
 // createDeviceIDFileWithoutLink is the fallback for a filesystem that cannot
-// hard-link. It gives the empty window back—measured on a FAT home, 8 concurrent
-// callers came away with disagreeing identifiers in 43 of 50 rounds—and is taken
-// anyway, because the alternative there is no identifier at all: the one caller
-// of GetOrCreateDeviceID drops the error, so failing is silent and permanent.
-//
-// Any link failure lands here, not only an unsupported one. A cause unrelated to
-// hard links—no permission on the directory, no space left—fails this call the
-// same way and surfaces as this error.
+// hard-link—FAT, exFAT, some container mounts. It gives the empty window back (a
+// FAT home had 8 concurrent callers disagree in 43 of 50 rounds) and is taken
+// anyway: GetOrCreateDeviceID's only caller drops the error, so failing here is
+// silent and permanent. Any link failure lands here, not only an unsupported
+// one, so an unrelated cause—no permission, no space—surfaces as this error.
 func createDeviceIDFileWithoutLink(path, deviceID string) error {
 	file, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0600)
 	if err != nil {
-		// Wrapped for the same reason the link error is: a concurrent invocation
-		// can take the path between the failed link and this create.
+		// Wrapped like the link error: a concurrent invocation can take the path
+		// between the failed link and this create.
 		return fmt.Errorf("failed to create device id file: %w", err)
 	}
 
@@ -243,16 +232,13 @@ func replaceDeviceIDFile(path, deviceID string) error {
 }
 
 // writeDeviceIDTempFile writes deviceID to a fresh file beside path and returns
-// that file's name, for a caller that publishes it with a link or a rename. A
-// returned path is the caller's to remove: after a link it is a second name for
-// a file that is now published, and after a failed publication it is a leftover.
-// Nothing is returned on failure here—this function removes its own.
+// its name for a caller that publishes it with a link or a rename. A path it
+// returns is the caller's to remove; on failure it removes its own.
 func writeDeviceIDTempFile(path, deviceID string) (string, error) {
 	file, err := os.CreateTemp(filepath.Dir(path), DeviceIDFileName+"-*")
 	if err != nil {
-		// Flattened rather than wrapped, deliberately: os.CreateTemp reports
-		// fs.ErrExist once it runs out of names to try, and createDeviceID reads
-		// that error as the identifier file itself already existing.
+		// Flattened, not wrapped: os.CreateTemp reports fs.ErrExist once it runs out
+		// of names, which createDeviceID would read as the identifier file existing.
 		return "", fmt.Errorf("failed to create device id file: %v", err)
 	}
 	tempPath := file.Name()

--- a/config/device.go
+++ b/config/device.go
@@ -111,10 +111,10 @@ func createDeviceID(path string) (string, error) {
 		return "", err
 	}
 
-	err = createDeviceIDFile(path, deviceID)
-	switch {
-	case err == nil:
-	case errors.Is(err, fs.ErrExist):
+	if err = createDeviceIDFile(path, deviceID); err != nil {
+		if !errors.Is(err, fs.ErrExist) {
+			return "", err
+		}
 		// Something created the file between the read in GetOrCreateDeviceID
 		// and this call. Whatever it holds is already in flight, so adopt it
 		// instead of overwriting it with a value only this process knows.
@@ -140,8 +140,6 @@ func createDeviceID(path string) (string, error) {
 		if err = replaceDeviceIDFile(path, deviceID); err != nil {
 			return "", err
 		}
-	default:
-		return "", err
 	}
 
 	// Report what the file holds rather than what was generated. Both of the

--- a/config/device.go
+++ b/config/device.go
@@ -216,10 +216,10 @@ func replaceDeviceIDFile(path, deviceID string) error {
 }
 
 // writeDeviceIDTempFile writes deviceID to a fresh file beside path and returns
-// that file's name, for a caller that publishes it with a link or a rename. The
-// caller owns the returned path and has to remove it: after a link it is a
-// second name for a file that is now published, and after a failure it is a
-// leftover.
+// that file's name, for a caller that publishes it with a link or a rename. A
+// returned path is the caller's to remove: after a link it is a second name for
+// a file that is now published, and after a failed publication it is a leftover.
+// Nothing is returned on failure here—this function removes its own.
 func writeDeviceIDTempFile(path, deviceID string) (string, error) {
 	file, err := os.CreateTemp(filepath.Dir(path), DeviceIDFileName+"-*")
 	if err != nil {

--- a/config/device_test.go
+++ b/config/device_test.go
@@ -257,6 +257,57 @@ func TestCreateDeviceIDFile_ReportsErrExistWhenPathIsTaken(t *testing.T) {
 	assert.Equal(t, winner+"\n", readDeviceIDFile(t), "the loser must not have touched the published value")
 }
 
+// TestCreateDeviceIDFile_NeverPublishesAnEmptyFile is the property #361 was
+// about, and the one the test above cannot reach: O_EXCL plus a write on the
+// next line is exclusive on the name and passes that one too, while the path
+// exists holding nothing for the length of the write.
+//
+// The catch is probabilistic—the window is one write wide—so it runs many
+// rounds. A publication step with no window cannot fail it, which is what makes
+// a failure here real.
+func TestCreateDeviceIDFile_NeverPublishesAnEmptyFile(t *testing.T) {
+	const rounds = 200
+	const deviceID = "0f6f3f2e-2a9d-4a1e-8f2b-1c2d3e4f5a6b"
+
+	for round := range rounds {
+		path := filepath.Join(t.TempDir(), DeviceIDFileName)
+
+		stop := make(chan struct{})
+		seen := make(chan string, 1)
+		var watching sync.WaitGroup
+		watching.Add(1)
+		go func() {
+			defer watching.Done()
+			for {
+				data, err := os.ReadFile(path)
+				if err == nil {
+					if string(data) != deviceID+"\n" {
+						seen <- string(data)
+					}
+					return
+				}
+				select {
+				case <-stop:
+					return
+				default:
+				}
+			}
+		}()
+
+		err := createDeviceIDFile(path, deviceID)
+		close(stop)
+		watching.Wait()
+
+		require.NoError(t, err, "round %d", round)
+		select {
+		case raw := <-seen:
+			t.Fatalf("round %d: %s was readable holding %q before it held the identifier",
+				round, DeviceIDFileName, raw)
+		default:
+		}
+	}
+}
+
 // TestGetOrCreateDeviceID_ConcurrentCreation is the property exclusive creation
 // buys. Two `alpacon` invocations can start at once—backgrounding a few shell
 // commands does it—and read-then-write lets both generate and both store,

--- a/config/device_test.go
+++ b/config/device_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"io/fs"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -237,12 +238,34 @@ func TestGetOrCreateDeviceID_FilePermissions(t *testing.T) {
 		"config dir must not be accessible by group or other, got %v", dirInfo.Mode().Perm())
 }
 
+// TestCreateDeviceIDFile_ReportsErrExistWhenPathIsTaken pins the contract
+// createDeviceID branches on. The concurrent test below exercises it, but only
+// by winning a race, so it can pass on a run where nothing ever collided; this
+// asserts it outright. A publication step that stopped reporting fs.ErrExist
+// would silently turn that branch into dead code and take the exclusion with
+// it.
+func TestCreateDeviceIDFile_ReportsErrExistWhenPathIsTaken(t *testing.T) {
+	setupTestConfig(t)
+	path := mustDeviceIDPath(t)
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0700))
+	const winner = "0f6f3f2e-2a9d-4a1e-8f2b-1c2d3e4f5a6b"
+	require.NoError(t, createDeviceIDFile(path, winner))
+
+	err := createDeviceIDFile(path, "1a2b3c4d-5e6f-4a1e-8f2b-1c2d3e4f5a6b")
+
+	require.ErrorIs(t, err, fs.ErrExist)
+	assert.Equal(t, winner+"\n", readDeviceIDFile(t), "the loser must not have touched the published value")
+}
+
 // TestGetOrCreateDeviceID_ConcurrentCreation is the property exclusive creation
-// buys. Two `alpacon` invocations can start at the same moment—a shell script
-// backgrounding several commands is enough—and read-then-write lets both
-// generate and both store. The loser would authenticate under an identifier its
-// own installation never sends again, orphaning that login's presence proof, so
-// every caller must come away with the one value the file ends up holding.
+// buys. Two `alpacon` invocations can start at once—backgrounding a few shell
+// commands does it—and read-then-write lets both generate and both store,
+// leaving the loser on an identifier its installation never sends again and that
+// login's presence proof orphaned. Every caller must come away with the value
+// the file ends up holding.
+//
+// Exclusivity on the name alone does not get there; createDeviceIDFile's doc
+// comment carries the failure mode that rules it out.
 func TestGetOrCreateDeviceID_ConcurrentCreation(t *testing.T) {
 	setupTestConfig(t)
 

--- a/config/device_test.go
+++ b/config/device_test.go
@@ -239,11 +239,9 @@ func TestGetOrCreateDeviceID_FilePermissions(t *testing.T) {
 }
 
 // TestCreateDeviceIDFile_ReportsErrExistWhenPathIsTaken pins the contract
-// createDeviceID branches on. The concurrent test below exercises it, but only
-// by winning a race, so it can pass on a run where nothing ever collided; this
-// asserts it outright. A publication step that stopped reporting fs.ErrExist
-// would silently turn that branch into dead code and take the exclusion with
-// it.
+// createDeviceID branches on. The concurrent test below reaches it only by
+// winning a race, so it can pass on a run where nothing collided; a publication
+// step that stopped reporting fs.ErrExist would turn that branch into dead code.
 func TestCreateDeviceIDFile_ReportsErrExistWhenPathIsTaken(t *testing.T) {
 	setupTestConfig(t)
 	path := mustDeviceIDPath(t)
@@ -274,13 +272,10 @@ func TestCreateDeviceIDFileWithoutLink_ReportsErrExistWhenPathIsTaken(t *testing
 }
 
 // TestCreateDeviceIDFile_NeverPublishesAnEmptyFile is the property #361 was
-// about, and the one the test above cannot reach: O_EXCL plus a write on the
-// next line is exclusive on the name and passes that one too, while the path
-// exists holding nothing for the length of the write.
-//
-// The catch is probabilistic—the window is one write wide—so it runs many
-// rounds. A publication step with no window cannot fail it, which is what makes
-// a failure here real.
+// about and the one the test above cannot reach: O_EXCL plus a write on the next
+// line passes that one too, while the path exists holding nothing. The catch is
+// probabilistic—the window is one write wide—but one-sided: a publication step
+// with no window cannot fail it, so a failure here is real.
 func TestCreateDeviceIDFile_NeverPublishesAnEmptyFile(t *testing.T) {
 	const rounds = 200
 	const deviceID = "0f6f3f2e-2a9d-4a1e-8f2b-1c2d3e4f5a6b"
@@ -327,12 +322,9 @@ func TestCreateDeviceIDFile_NeverPublishesAnEmptyFile(t *testing.T) {
 // TestGetOrCreateDeviceID_ConcurrentCreation is the property exclusive creation
 // buys. Two `alpacon` invocations can start at once—backgrounding a few shell
 // commands does it—and read-then-write lets both generate and both store,
-// leaving the loser on an identifier its installation never sends again and that
-// login's presence proof orphaned. Every caller must come away with the value
-// the file ends up holding.
-//
-// Exclusivity on the name alone does not get there; createDeviceIDFile's doc
-// comment carries the failure mode that rules it out.
+// leaving the loser on an identifier its installation never sends again. Every
+// caller must come away with the value the file ends up holding, and exclusivity
+// on the name alone does not get there—see createDeviceIDFile.
 func TestGetOrCreateDeviceID_ConcurrentCreation(t *testing.T) {
 	setupTestConfig(t)
 

--- a/config/device_test.go
+++ b/config/device_test.go
@@ -257,6 +257,22 @@ func TestCreateDeviceIDFile_ReportsErrExistWhenPathIsTaken(t *testing.T) {
 	assert.Equal(t, winner+"\n", readDeviceIDFile(t), "the loser must not have touched the published value")
 }
 
+// TestCreateDeviceIDFileWithoutLink_ReportsErrExistWhenPathIsTaken keeps the
+// no-hard-link fallback on the contract createDeviceID branches on. It gives up
+// atomicity; it must not give up the exclusion.
+func TestCreateDeviceIDFileWithoutLink_ReportsErrExistWhenPathIsTaken(t *testing.T) {
+	path := filepath.Join(t.TempDir(), DeviceIDFileName)
+	const winner = "0f6f3f2e-2a9d-4a1e-8f2b-1c2d3e4f5a6b"
+	require.NoError(t, createDeviceIDFileWithoutLink(path, winner))
+
+	err := createDeviceIDFileWithoutLink(path, "1a2b3c4d-5e6f-4a1e-8f2b-1c2d3e4f5a6b")
+
+	require.ErrorIs(t, err, fs.ErrExist)
+	data, readErr := os.ReadFile(path)
+	require.NoError(t, readErr)
+	assert.Equal(t, winner+"\n", string(data), "the loser must not have touched the published value")
+}
+
 // TestCreateDeviceIDFile_NeverPublishesAnEmptyFile is the property #361 was
 // about, and the one the test above cannot reach: O_EXCL plus a write on the
 // next line is exclusive on the name and passes that one too, while the path


### PR DESCRIPTION
## Background

Two `alpacon` invocations can start at once — backgrounding a few shell commands is enough — and `createDeviceID` was written for that: it claimed `~/.alpacon/device_id` with `O_EXCL` so only one process could create it. But it wrote the identifier on the next line. Between those two calls the path existed and was empty.

`readDeviceID` reports an empty file as absent. So an invocation landing in that window took the `fs.ErrExist` branch, read `""`, judged the winner's file malformed, and replaced it with an identifier only that process knows. Both callers then authenticated under different identifiers and one login's MFA presence proof was orphaned — the exact failure exclusive creation was added to prevent.

This is why `TestGetOrCreateDeviceID_ConcurrentCreation` failed intermittently.

## Changes

The cause is the window, not the concurrency, so this closes the window rather than narrowing the race.

`createDeviceIDFile` (`config/device.go:172`) writes the value to a temporary file and publishes it with `os.Link`. The name never exists holding nothing, because the content reaches the file before the name does. Linking keeps the exclusion `O_EXCL` bought: link reports `EEXIST` rather than replacing what it lands on. The caller matches `errors.Is(err, fs.ErrExist)`, so the error is wrapped with `%w`. Where hard links do not exist the file cannot be published this way, and `createDeviceIDFileWithoutLink` (`config/device.go:197`) creates it with `O_EXCL` instead — the exclusion without the atomicity, since no identifier at all is worse than one that can diverge. Safety covers what that costs.

The `fs.ErrExist` branch now means what its comment always claimed — a file someone hand-edited or truncated — rather than a file the winner is still writing.

`replaceDeviceIDFile` moves onto the same temp-file helper, `writeDeviceIDTempFile` (`config/device.go:237`). That extraction rides along rather than landing as its own commit because the invariant documented on it holds only once `createDeviceIDFile` is its second caller: the error must stay flattened with `%v`, or a name-exhausted `os.CreateTemp` would reach `createDeviceID` as the identifier file already existing.

`deviceIDFileMode` goes with the `os.OpenFile` mode argument that was its only consumer. `os.CreateTemp` creates at 0600 and the umask narrows it further, so the published mode is unchanged; the three comments that named the constant now say 0600.

## Safety

Modes were measured, not assumed: the temp file is 0600, the published `device_id` is 0600, and it stays 0600 after the temp name is removed. `os.Link` adds a name to the same inode, so the mode carries over rather than being reapplied.

Symlinks were checked too. With a symlink at the target path, `os.Link` does not follow it — it returns `EEXIST` and the file the symlink pointed at is untouched. `replaceDeviceIDFile`'s `os.Rename` replaces the symlink itself rather than writing through it. Neither path writes to another file by way of a planted link.

A filesystem with no hard links cannot publish this way, so `createDeviceIDFileWithoutLink` (`config/device.go:197`) falls back to `O_EXCL` there. Without that fallback those installations fail on every login and never get an identifier, silently: `currentDeviceID` (`api/auth0/auth0.go:131`) drops the error and the server falls back to its own IP fingerprint. The fallback keeps the exclusion and gives back only the empty window, which is what those filesystems already did before this change. Any link failure that is not `fs.ErrExist` takes it, not only an unsupported one—a cause unrelated to hard links fails the fallback the same way and surfaces there, while narrowing on errno varies by platform and would leave the regression in place wherever the match missed.

A crash between `os.Link` succeeding and the deferred `os.Remove` leaves a `device_id-*` file in `~/.alpacon` that nothing collects. This failure mode is new to this change: the old create path had no temp file at all, and the old replace path used `os.Rename`, which consumes the temp name on success. `os.Link` adds a name rather than moving one, so both names exist until the deferred remove runs. It is litter rather than exposure — the leftover is 0600 inside the 0700 config directory and holds the same value that was published.

## Testing

`go test -race ./...` passes across all 39 packages, `golangci-lint run ./...` reports 0 issues, `gofmt -l config/` is empty.

Three tests are new. `TestCreateDeviceIDFile_ReportsErrExistWhenPathIsTaken` pins the contract `createDeviceID` branches on. The concurrent test reaches it only by winning a race, so it can pass on a run where nothing ever collided; this asserts it outright, and swapping `os.Link` back for `os.Rename` fails it deterministically with `Expected error with "file already exists" in chain but got nil`. What it does not catch is the bug this PR fixes: creating with `O_EXCL` and writing on the next line passes it too, 20 runs out of 20, because that implementation is exclusive on the name and this test asks about the name.

`TestCreateDeviceIDFile_NeverPublishesAnEmptyFile` asks about the content. A reader watches the path across 200 rounds of publication and rejects anything it can read there that is not the finished value. The catch is probabilistic rather than guaranteed — the window is one write wide — but it is one-sided: a publication step that has no window cannot fail it, so a failure here is real. Measured under `-race`, the command CI runs: 20 of 20 runs failed with the bug restored, reporting `device_id was readable holding "" before it held the identifier` at round 1 or 2, and 20 of 20 passed on this branch.

`TestCreateDeviceIDFileWithoutLink_ReportsErrExistWhenPathIsTaken` holds the fallback to the same `fs.ErrExist` contract. It gives up atomicity; it must not give up the exclusion.

The existing guard was measured rather than trusted. With the bug restored, the command CI actually runs — `go test -race`, one iteration — passed 20 out of 20 runs on this machine. Without `-race` it failed 2 out of 20, and `-count=20` in one process failed outright. The race detector slows the scheduler enough to hide the window, which is why the bug survived CI. `TestGetOrCreateDeviceID_ConcurrentCreation`'s comment now names the empty-file failure mode so anyone reverting link-based publication reads why it is there.

The guard runs 32 goroutines in one process, but the bug is about two `alpacon` processes, so it was also measured across real ones. A probe binary calling `config.GetOrCreateDeviceID` spins on a barrier file so every process enters the call within microseconds of the others, each round against a fresh isolated `HOME`. Built from `main` it diverged in 75 of 200 rounds at 8 processes; one round ended with six distinct identifiers across eight processes, each of which would have authenticated under its own. Built from this branch it diverged in 0 of 200 rounds at 8 processes and 0 of 300 at 32 — 9,600 processes with no divergence, no leftover `device_id-*`, and the published file at 0600 every time.

The no-hard-link fallback was measured on a real filesystem rather than reasoned about. A 20 MB FAT image was mounted—`ln` there reports `Operation not supported`—and `HOME` pointed into it. Without the fallback, `GetOrCreateDeviceID` returned `failed to create device id file: link .../device_id-800030292 .../device_id: operation not supported` on every call and handed back `""`. With it, the identifier is created and the second call returns the same one. The exclusion survives: FAT reports `EEXIST` rather than `ENOTSUP` once the target is taken, so a second caller lands on the `fs.ErrExist` branch before it can reach the fallback, the winner's value is untouched, and no `device_id-*` is left behind.

What the fallback costs there was measured the same way. The empty window appeared in 200 of 200 publication rounds, and 8 concurrent callers came away with disagreeing identifiers in 43 of 50 rounds—one round produced three distinct ones. The identical probe on APFS reports 0 of 200 and 0 of 50. The race is closed wherever hard links exist and is back to what `main` did where they do not, which is the trade the fallback makes deliberately.

The login path was exercised against a dev-region Alpacon Cloud workspace with the real binary. The device code request succeeded, which means the tenant accepted the `device:<id>` scope the identifier is carried in, and the file landed at 0600 with nothing left over. That run does not reproduce the race and is not offered as evidence of the fix: `currentDeviceID` is reached only after `FetchAuthEnv`'s network round trip, which spreads concurrent invocations milliseconds apart while the window is microseconds wide. It confirms the path, not the exclusion.

## Not in this PR

Four pre-existing items came out of auditing this file and are left alone, since none of them are what this change touched.

`writeDeviceIDTempFile`'s error text names the final file rather than the temp one, so a temp-file failure on the replace path reports `failed to create device id file`. The old code said the same thing from the same two causes.

`TestGetOrCreateDeviceID_ConcurrentReplacementOfMalformedValue` and `TestGetOrCreateDeviceID_ReplacesMalformedValue` have no leftover-temp-file check; only the creation test does.

A malformed file at 0400 widens to 0600 after replacement. `restrictDeviceIDFileMode` says bits are only ever removed and `replaceDeviceIDFile` says the replacement carries its own mode; the two disagree at that point.

`restrictDeviceIDFileMode`'s `0077` mask is a 0700 ceiling rather than the 0600 its comment claims, so an owner execute bit would survive. Harmless on a data file, but the comment is imprecise.

Separately, `.github/workflows/build-and-test.yaml:43` runs without `-count`, which is why this class of bug reaches `main`. Changing the workflow is a judgment call that belongs on its own.

Closes #361
