### PR TITLE
fix(utils): let a stopped spinner start again, and hand its goroutine the channels it waits on

### DIFF
--- a/cmd/exec/run.go
+++ b/cmd/exec/run.go
@@ -456,14 +456,12 @@ func RunExecWithApprovalWait(ac *client.AlpaconClient, serverName, command, user
 	// command's own output once approved. StopWriter retires the spinner at the
 	// first byte of it.
 	spinnerOut := spinner.StopWriter(out)
-	// That retirement is permanent (StopWriter fires once, and Stop closes
-	// channels Start does not reopen) and the first still-pending tick spends it,
-	// so every further stretch of waiting gets a spinner and a writer of its own.
-	// Stop first: a tick that returned without writing left the previous spinner
-	// animating, and two of them would draw over each other.
+	// A writer retires the spinner once and the first still-pending tick spends
+	// it, so every further stretch of waiting restarts the spinner and takes a
+	// fresh writer. Stop first: a tick that returned without writing left the
+	// spinner animating, and Start on a running spinner is a no-op.
 	restartSpinner := func() {
 		spinner.Stop()
-		spinner = utils.NewSpinner(approvalWaitMessage)
 		spinner.Start()
 		spinnerOut = spinner.StopWriter(out)
 	}

--- a/cmd/exec/run.go
+++ b/cmd/exec/run.go
@@ -451,6 +451,10 @@ func RunExecWithApprovalWait(ac *client.AlpaconClient, serverName, command, user
 
 	spinner := utils.NewSpinner(approvalWaitMessage)
 	spinner.Start()
+	// Every return path below stops the spinner before it writes, which is
+	// load-bearing for output ordering; this backstops paths added later. Stop
+	// on a stopped spinner is a no-op.
+	defer spinner.Stop()
 	// Every tick re-submits, so a tick's output starts while the spinner is
 	// animating—the denial line of a request still pending as much as the
 	// command's own output once approved. StopWriter retires the spinner at the

--- a/cmd/exec/run_test.go
+++ b/cmd/exec/run_test.go
@@ -321,6 +321,39 @@ func TestRunExecWithApprovalWait_EachTickWaitsBehindItsOwnWriter(t *testing.T) {
 	assert.NotSame(t, writers[2], writers[3], "and so does the third")
 }
 
+// Off a TTY every Start prints the wait message once, so the number of message
+// lines on stderr is exactly the number of Start calls. That pins the heartbeat
+// contract—a redirected log gets one line per stretch of waiting—and it is the
+// only test that notices restartSpinner forgetting to restart: drop its Start
+// and every other test stays green while the user sees no spinner after the
+// first tick.
+func TestRunExecWithApprovalWait_EachRestartPrintsTheHeartbeatLine(t *testing.T) {
+	denial := stubApprovalWaitSeams(t, 10*time.Millisecond, "SUDO_APPROVAL_REQUIRED")
+
+	calls := 0
+	runPresenceStepUp = func(_ *client.AlpaconClient, _, _, _, _ string, _ map[string]string, _ string, w io.Writer) error {
+		calls++
+		_, _ = w.Write([]byte(denialLine("SUDO_APPROVAL_REQUIRED")))
+		if calls < 4 {
+			return denial
+		}
+		return nil
+	}
+	streamApprovedCommand = func(*client.AlpaconClient, string, io.Writer, time.Duration) error {
+		t.Fatal("a denial-code wait re-attempts the command; it never resumes a held job")
+		return nil
+	}
+
+	var err error
+	stderr := captureStderr(t, func() {
+		err = RunExecWithApprovalWait(nil, "srv", "whoami", "", "", nil, "", time.Second, io.Discard)
+	})
+
+	assert.NoError(t, err)
+	// One line for the wait's opening Start, one per still-pending tick's restart.
+	assert.Equal(t, 3, strings.Count(stderr, approvalWaitMessage))
+}
+
 // Reporting the last poll failure instead would exit 1 on a request still open.
 func TestRunExecWithApprovalWait_TimeoutReportsThePendingDenial(t *testing.T) {
 	const waitTimeout = 80 * time.Millisecond

--- a/cmd/exec/run_test.go
+++ b/cmd/exec/run_test.go
@@ -294,8 +294,8 @@ func TestRunExecWithApprovalWait_TransientPollFailureKeepsWaiting(t *testing.T) 
 // that reused a single writer would therefore animate through its first poll gap
 // and sit silent for the rest of what --wait is there to cover. Writer identity
 // is all a test can see of the spinner from here, and one writer per tick means
-// one spinner per tick.
-func TestRunExecWithApprovalWait_EachTickWaitsBehindItsOwnSpinner(t *testing.T) {
+// one restart per tick.
+func TestRunExecWithApprovalWait_EachTickWaitsBehindItsOwnWriter(t *testing.T) {
 	denial := stubApprovalWaitSeams(t, 10*time.Millisecond, "SUDO_APPROVAL_REQUIRED")
 
 	var writers []io.Writer
@@ -317,7 +317,7 @@ func TestRunExecWithApprovalWait_EachTickWaitsBehindItsOwnSpinner(t *testing.T) 
 	assert.NoError(t, err)
 	// writers[0] is the first attempt, which runs before any spinner exists.
 	require.Len(t, writers, 4)
-	assert.NotSame(t, writers[1], writers[2], "the second wait needs a spinner of its own")
+	assert.NotSame(t, writers[1], writers[2], "the second wait needs a writer of its own")
 	assert.NotSame(t, writers[2], writers[3], "and so does the third")
 }
 

--- a/utils/spinner.go
+++ b/utils/spinner.go
@@ -67,51 +67,57 @@ func (s *Spinner) Start() {
 	stopCh := make(chan struct{})
 	doneCh := make(chan struct{})
 	s.stopCh, s.doneCh = stopCh, doneCh
+	// The rest of what the goroutine needs is copied in the same critical
+	// section, so it never reaches back into the struct during its run.
+	msg := s.message
+	frames, dots := s.frames, s.dots
+	interval := s.interval
 	s.mu.Unlock()
 
 	if !s.enabled {
-		// Print a static message so users still see progress in non-TTY output
-		fmt.Fprintln(os.Stderr, s.message)
+		// Print a static message so users still see progress in non-TTY output.
+		// Deliberately printed again on every restart: a long approval wait
+		// restarts the spinner each poll tick, and the repeated line is the
+		// heartbeat a redirected log gets from an otherwise silent wait.
+		fmt.Fprintln(os.Stderr, msg)
 		return
 	}
 	activeSpinners.Add(1)
 
 	go func() {
 		defer close(doneCh)
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
 		frameIdx := 0
 		dotIdx := 0
 		dotCounter := 0
 		for {
+			frame := frames[frameIdx%len(frames)]
+
+			// Animate dots if message ends with "..."
+			displayMsg := msg
+			if baseMsg, ok := strings.CutSuffix(msg, "..."); ok {
+				displayMsg = baseMsg + dots[dotIdx%len(dots)]
+			}
+
+			fmt.Fprintf(os.Stderr, "\r%s %s", Yellow(frame), displayMsg)
+			frameIdx++
+
+			// Update dots every 3 frames (300ms)
+			dotCounter++
+			if dotCounter >= 3 {
+				dotIdx++
+				dotCounter = 0
+			}
+
+			// Blocking here instead of sleeping lets Stop return as soon as it
+			// closes stopCh rather than up to a frame later.
 			select {
 			case <-stopCh:
 				// Clear the spinner line
 				fmt.Fprint(os.Stderr, "\r\033[K")
 				return
-			default:
-				s.mu.Lock()
-				msg := s.message
-				s.mu.Unlock()
-
-				frame := s.frames[frameIdx%len(s.frames)]
-
-				// Animate dots if message ends with "..."
-				displayMsg := msg
-				if strings.HasSuffix(msg, "...") {
-					baseMsg := strings.TrimSuffix(msg, "...")
-					displayMsg = baseMsg + s.dots[dotIdx%len(s.dots)]
-				}
-
-				fmt.Fprintf(os.Stderr, "\r%s %s", Yellow(frame), displayMsg)
-				frameIdx++
-
-				// Update dots every 3 frames (300ms)
-				dotCounter++
-				if dotCounter >= 3 {
-					dotIdx++
-					dotCounter = 0
-				}
-
-				time.Sleep(s.interval)
+			case <-ticker.C:
 			}
 		}
 	}()

--- a/utils/spinner.go
+++ b/utils/spinner.go
@@ -91,6 +91,9 @@ func (s *Spinner) Start() {
 		frameIdx := 0
 		dotIdx := 0
 		dotCounter := 0
+		// Drawing before the first stopCh check is deliberate: a Start answered
+		// at once paints one frame and erases it, and Stop waits on doneCh, so
+		// both land before the caller's own output.
 		for {
 			frame := frames[frameIdx%len(frames)]
 

--- a/utils/spinner.go
+++ b/utils/spinner.go
@@ -61,9 +61,12 @@ func (s *Spinner) Start() {
 		return
 	}
 	s.running = true
-	// Stop closes both channels, so a restart needs a fresh pair.
-	s.stopCh = make(chan struct{})
-	s.doneCh = make(chan struct{})
+	// Stop closes both channels, so a restart needs a fresh pair—and the
+	// goroutine below takes its own copy, since the fields belong to whichever
+	// Start ran last rather than to the run it was spawned for.
+	stopCh := make(chan struct{})
+	doneCh := make(chan struct{})
+	s.stopCh, s.doneCh = stopCh, doneCh
 	s.mu.Unlock()
 
 	if !s.enabled {
@@ -74,13 +77,13 @@ func (s *Spinner) Start() {
 	activeSpinners.Add(1)
 
 	go func() {
-		defer close(s.doneCh)
+		defer close(doneCh)
 		frameIdx := 0
 		dotIdx := 0
 		dotCounter := 0
 		for {
 			select {
-			case <-s.stopCh:
+			case <-stopCh:
 				// Clear the spinner line
 				fmt.Fprint(os.Stderr, "\r\033[K")
 				return

--- a/utils/spinner.go
+++ b/utils/spinner.go
@@ -49,8 +49,6 @@ func NewSpinner(message string) *Spinner {
 		frames:   []string{"⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"},
 		dots:     []string{".  ", ".. ", "..."},
 		interval: 100 * time.Millisecond,
-		stopCh:   make(chan struct{}),
-		doneCh:   make(chan struct{}),
 		enabled:  term.IsTerminal(int(os.Stderr.Fd())),
 	}
 }
@@ -63,6 +61,9 @@ func (s *Spinner) Start() {
 		return
 	}
 	s.running = true
+	// Stop closes both channels, so a restart needs a fresh pair.
+	s.stopCh = make(chan struct{})
+	s.doneCh = make(chan struct{})
 	s.mu.Unlock()
 
 	if !s.enabled {
@@ -121,14 +122,16 @@ func (s *Spinner) Stop() {
 		return
 	}
 	s.running = false
+	// Read under the lock: a concurrent restart replaces the fields.
+	stopCh, doneCh := s.stopCh, s.doneCh
 	s.mu.Unlock()
 
 	if !s.enabled {
 		return
 	}
 
-	close(s.stopCh)
-	<-s.doneCh
+	close(stopCh)
+	<-doneCh
 	// After the goroutine has returned, so the window where the last frame is
 	// still on screen keeps its line break.
 	activeSpinners.Add(-1)

--- a/utils/spinner.go
+++ b/utils/spinner.go
@@ -12,6 +12,10 @@ import (
 	"golang.org/x/term"
 )
 
+// defaultSpinnerInterval is the frame period NewSpinner hands out, and the
+// fallback Start uses when the field holds something a ticker cannot take.
+const defaultSpinnerInterval = 100 * time.Millisecond
+
 // activeSpinners counts the spinners currently animating stderr. A warning
 // printed while one is running lands mid-frame, so CliWarning breaks to a new
 // line first—but only then, since off a TTY there is no frame to step off.
@@ -48,7 +52,7 @@ func NewSpinner(message string) *Spinner {
 		message:  message,
 		frames:   []string{"⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"},
 		dots:     []string{".  ", ".. ", "..."},
-		interval: 100 * time.Millisecond,
+		interval: defaultSpinnerInterval,
 		enabled:  term.IsTerminal(int(os.Stderr.Fd())),
 	}
 }
@@ -72,6 +76,11 @@ func (s *Spinner) Start() {
 	msg := s.message
 	frames, dots := s.frames, s.dots
 	interval := s.interval
+	if interval <= 0 {
+		// time.NewTicker panics where the sleep this replaced took a zero
+		// happily, and a stderr animation must never take the CLI down with it.
+		interval = defaultSpinnerInterval
+	}
 	s.mu.Unlock()
 
 	if !s.enabled {

--- a/utils/spinner_test.go
+++ b/utils/spinner_test.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"bytes"
+	"sync"
 	"testing"
 	"time"
 
@@ -98,5 +99,34 @@ func TestSpinner_RestartsAfterStop(t *testing.T) {
 		s.Stop()
 		assert.Equal(t, int32(0), activeSpinners.Load(), "and its Stop disarms it")
 		assert.False(t, spinnerRunning(s), "Stop must leave the spinner stopped")
+	})
+}
+
+// Start and Stop each guard the fields, but the goroutine waits on what it was
+// handed for its whole run—a restart that swapped the fields under it would
+// leave it listening to a channel nobody closes. Only -race can see that, and
+// only if a second goroutine drives the restart: StopWriter hands Stop to
+// whoever writes the output, which need not be the goroutine that restarts.
+func TestSpinner_RestartAndStopRaceOnTheSameSpinner(t *testing.T) {
+	captureStderr(t, func() {
+		s := NewSpinner("Waiting for approval...")
+		s.enabled = true
+		s.interval = time.Millisecond
+
+		var wg sync.WaitGroup
+		wg.Add(2)
+		for range 2 {
+			go func() {
+				defer wg.Done()
+				for range 50 {
+					s.Start()
+					s.Stop()
+				}
+			}()
+		}
+		wg.Wait()
+
+		s.Stop()
+		assert.Equal(t, int32(0), activeSpinners.Load(), "every Start that armed the line break is paired with a Stop")
 	})
 }

--- a/utils/spinner_test.go
+++ b/utils/spinner_test.go
@@ -102,6 +102,30 @@ func TestSpinner_RestartsAfterStop(t *testing.T) {
 	})
 }
 
+// The goroutine blocks in a select on stopCh instead of sleeping a frame away,
+// so Stop returns the moment it closes that channel. Sleeping first would make
+// Stop wait out the rest of the frame, and an approval wait pays that on every
+// poll tick. The frame here is far longer than the budget, so only the blocking
+// select can come back in time.
+func TestSpinner_StopDoesNotWaitOutAFrame(t *testing.T) {
+	captureStderr(t, func() {
+		s := NewSpinner("Waiting for approval...")
+		s.enabled = true
+		s.interval = 2 * time.Second
+
+		s.Start()
+		// Wait for the goroutine to reach the select. A Stop that lands before it
+		// is even scheduled returns at once however the loop is written, so the
+		// frame has to be underway for the timing to mean anything.
+		time.Sleep(100 * time.Millisecond)
+
+		start := time.Now()
+		s.Stop()
+
+		assert.Less(t, time.Since(start), 500*time.Millisecond)
+	})
+}
+
 // time.NewTicker panics on a non-positive period where the sleep it replaced
 // took one happily, and the panic would fire on the spinner's own goroutine—far
 // from the caller and fatal to the process. No caller can set that today, so

--- a/utils/spinner_test.go
+++ b/utils/spinner_test.go
@@ -78,3 +78,24 @@ func TestSpinner_AnimatingBranchPairsTheActiveCount(t *testing.T) {
 		assert.Equal(t, int32(0), activeSpinners.Load(), "and Stop disarms it")
 	})
 }
+
+// Stop closes stopCh and doneCh; a Start that reuses them launches a goroutine
+// whose select falls straight through the closed stopCh and then closes doneCh a
+// second time. Off a TTY Start never reaches the goroutine, so enabled is
+// forced here as well—no test that leaves it alone can see the panic.
+func TestSpinner_RestartsAfterStop(t *testing.T) {
+	captureStderr(t, func() {
+		s := NewSpinner("Waiting for approval...")
+		s.enabled = true
+		s.interval = time.Millisecond
+
+		s.Start()
+		s.Stop()
+
+		s.Start()
+		assert.Equal(t, int32(1), activeSpinners.Load(), "a restarted spinner arms the line break again")
+		s.Stop()
+		assert.Equal(t, int32(0), activeSpinners.Load(), "and its Stop disarms it")
+		assert.False(t, spinnerRunning(s), "Stop must leave the spinner stopped")
+	})
+}

--- a/utils/spinner_test.go
+++ b/utils/spinner_test.go
@@ -89,6 +89,7 @@ func TestSpinner_RestartsAfterStop(t *testing.T) {
 		s.enabled = true
 		s.interval = time.Millisecond
 
+		require.Equal(t, int32(0), activeSpinners.Load())
 		s.Start()
 		s.Stop()
 

--- a/utils/spinner_test.go
+++ b/utils/spinner_test.go
@@ -102,6 +102,23 @@ func TestSpinner_RestartsAfterStop(t *testing.T) {
 	})
 }
 
+// time.NewTicker panics on a non-positive period where the sleep it replaced
+// took one happily, and the panic would fire on the spinner's own goroutine—far
+// from the caller and fatal to the process. No caller can set that today, so
+// without the fallback this test does not fail, it takes the test binary down.
+func TestSpinner_NonPositiveIntervalFallsBackToTheDefault(t *testing.T) {
+	captureStderr(t, func() {
+		s := NewSpinner("Waiting for approval...")
+		s.enabled = true
+		s.interval = 0
+
+		s.Start()
+		s.Stop()
+
+		assert.Equal(t, int32(0), activeSpinners.Load(), "the goroutine ran to its own exit rather than dying on the ticker")
+	})
+}
+
 // Start and Stop each guard the fields, but the goroutine waits on what it was
 // handed for its whole run—a restart that swapped the fields under it would
 // leave it listening to a channel nobody closes. Only -race can see that, and


### PR DESCRIPTION
## Background

`Spinner.Stop()` closes `stopCh` and `doneCh`, and `NewSpinner` was the only place either was made. A second `Start()` therefore launched a goroutine whose `select` fell straight through the already-closed `stopCh`, returned, and ran its deferred `close(s.doneCh)` on a channel the first goroutine had closed: `panic: close of closed channel`.

Nothing was broken in practice, because no caller restarted a spinner. `cmd/exec/run.go` built a fresh `Spinner` for every stretch of approval waiting, and a comment was the only thing enforcing that. What makes the panic worth closing anyway is that `go test` is never a TTY: `Start` returns at the `!s.enabled` branch before the goroutine exists, so a regression here passes the whole suite and panics on a user's terminal. Reaching the path at all requires a same-package test that sets `enabled` by hand, which is what `TestSpinner_AnimatingBranchPairsTheActiveCount` already does.

## Changes

### A stopped spinner can start again

`Start()` now makes a fresh `stopCh`/`doneCh` pair inside the same critical section that flips `running`, and `Stop()` copies both out under that lock before closing them.

The `activeSpinners` accounting is untouched: `Start` still increments after the `!s.enabled` early return and `Stop` still decrements after the goroutine has exited, so a reusable spinner does not drift the count that `CliWarning` reads to decide whether to break off the animated line.

### The goroutine holds the channels it was handed

Making the pair per run introduced a second problem: the goroutine read both back off the struct, `doneCh` once at spawn and `stopCh` on every turn of the `select`. A restart that lands between `Stop` flipping `running` and the old goroutine noticing its close leaves that goroutine selecting on the new `stopCh`, which nobody closes. It animates forever while the `Stop` that meant to end it blocks on a `doneCh` that never closes.

`Start` now captures both channels in locals and the goroutine closes over those. No caller can hit this today—every `Start`/`Stop` pair in the tree runs on one goroutine, and the writes `StopWriter` retires a spinner from come from that same goroutine—but `Spinner` is exported and `Stop`'s own comment already promised the guard.

### exec keeps one spinner

`restartSpinner` in `cmd/exec/run.go` no longer rebuilds the `Spinner`; it stops it, starts it again, and takes a fresh `StopWriter` per tick. The writer's retirement is still one-shot, which is what the existing test observes, so `TestRunExecWithApprovalWait_EachTickWaitsBehindItsOwnSpinner` is renamed to `...EachTickWaitsBehindItsOwnWriter` to say what it actually asserts.

## Testing

`go test -race ./...` passes. Both new tests were seen red against the unfixed code:

- `TestSpinner_RestartsAfterStop` forces `enabled` and a 1ms interval, then runs `Start`/`Stop` twice. Without the per-run channels it fails with `panic: close of closed channel` at `utils/spinner.go:89`.
- `TestSpinner_RestartAndStopRaceOnTheSameSpinner` drives `Start`/`Stop` from two goroutines. With the goroutine reading the struct fields again, `-race` reports a read at `utils/spinner.go:80` in `Start.func1` against a write at `utils/spinner.go:69` in `Start`.

Closes #373


## Review follow-up

Three commits address the review's two warnings and three suggestions.

- **Heartbeat made explicit** (warning 2): the `!s.enabled` branch keeps printing the static line on every restart on purpose—during a long approval wait that repeated line is the only sign of life a redirected log gets—and now says so in a comment.
- **Restart regression is observable** (warning 1): `TestRunExecWithApprovalWait_EachRestartPrintsTheHeartbeatLine` asserts the message-line count on captured stderr, which off a TTY is exactly the number of `Start` calls. Deleting `spinner.Start()` from `restartSpinner` now fails it (expected 3, got 1).
- **The goroutine runs on locals** (suggestion 1): `Start()` copies `message`, `frames`, `dots`, and `interval` in the same critical section that hands over the channels, so the goroutine touches no struct field and the per-frame lock is gone.
- **`Stop()` returns immediately** (suggestion 2): the `default:` + `time.Sleep` loop is now a two-way select on a `time.Ticker`, so a close of `stopCh` is seen without waiting out a frame.
- **Deferred backstop** (suggestion 3): the poll-loop spinner gets `defer spinner.Stop()` for return paths added later; the explicit `Stop()` calls that order against `CliWarning` output stay.


## Second review follow-up

The re-review left one optional suggestion and two nits. All three are now closed.

- **The prompt-`Stop` property has a test** (suggestion 1): `TestSpinner_StopDoesNotWaitOutAFrame` gives the spinner a 2s frame, waits for the goroutine to reach the select, and asserts `Stop` returns inside 500ms. Reverting the select to `default:` plus `time.Sleep(interval)` fails it at 1.9s.
- **A non-positive interval no longer reaches the ticker** (nit 2): `Start` falls back to `defaultSpinnerInterval` when the field is not positive. `time.NewTicker` panics where the `time.Sleep` it replaced took a zero happily, and it panics on the spinner's own goroutine, so the process dies. Unreachable today, but a stderr animation should not be able to take the CLI down.
- **The draw-before-check ordering is on record** (nit 3): intended. A `Start` answered immediately paints one frame and erases it, and `Stop` blocks on `doneCh`, so both writes land before the caller's output and nothing is left on screen. The comment now says so.

`go test -race ./...`, `go vet ./...`, and `golangci-lint run` are all clean. Both new tests were seen red: the ticker revert fails the timing test at 1.9s against a 500ms budget, and dropping the interval fallback takes the test binary down with `panic: non-positive interval for NewTicker`.
