### PR TITLE
fix(config): stop the identifier file's mode from widening, and say which file failed

### DIFF
--- a/config/device.go
+++ b/config/device.go
@@ -19,6 +19,9 @@ const (
 	// identifier must outlive it. This mirrors the web client, which keeps its
 	// own identifier in localStorage rather than alongside its session.
 	DeviceIDFileName = "device_id"
+
+	// deviceIDFileExcessPerm is every permission bit outside owner read and write.
+	deviceIDFileExcessPerm = os.FileMode(0177)
 )
 
 var (
@@ -335,10 +338,10 @@ func restrictDeviceIDFileMode(path string) error {
 		return fmt.Errorf("failed to inspect device id file: %v", err)
 	}
 	perm := fileInfo.Mode().Perm()
-	if perm&0177 == 0 {
+	if perm&deviceIDFileExcessPerm == 0 {
 		return nil
 	}
-	if err = os.Chmod(path, perm&^0177); err != nil {
+	if err = os.Chmod(path, perm&^deviceIDFileExcessPerm); err != nil {
 		return fmt.Errorf("failed to restrict device id file permissions: %v", err)
 	}
 

--- a/config/device.go
+++ b/config/device.go
@@ -170,8 +170,8 @@ func createDeviceID(path string) (string, error) {
 // exclusion—rename replaces whatever it lands on—and publishes the temporary
 // file's mode: 0600 from os.CreateTemp less the umask, a free path giving
 // writeDeviceIDTempFile nothing to narrow against. A file that appears there and
-// is gone again before the link narrows it further—the one direction this
-// package moves a mode.
+// is gone again before the link leaves that mode narrower still—the one
+// direction this package moves a mode.
 func createDeviceIDFile(path, deviceID string) error {
 	tempPath, err := writeDeviceIDTempFile(path, deviceID)
 	if err != nil {
@@ -271,7 +271,7 @@ func writeDeviceIDTempFile(path, deviceID string) (string, error) {
 // only removed, as in restrictDeviceIDFileMode: of the mode os.CreateTemp chose
 // and the mode being stood in for, the stricter wins.
 //
-// It runs while the scratch file is still nameless, because a rename publishes
+// It runs before the caller publishes the file, because a rename publishes
 // whatever mode the file carries at that instant and narrowing afterwards would
 // leave the wider one published in between. Through the open handle rather than
 // the path, as SaveStreamAtomic does—a path-based chmod can be pointed at

--- a/config/device.go
+++ b/config/device.go
@@ -168,7 +168,10 @@ func createDeviceID(path string) (string, error) {
 // readDeviceID reports as absent, so a concurrent invocation judges it malformed
 // and replaces the winner's identifier. Linking rather than renaming keeps the
 // exclusion—rename replaces whatever it lands on—and publishes the temporary
-// file's mode, 0600 from os.CreateTemp less the umask.
+// file's mode: 0600 from os.CreateTemp less the umask, a free path giving
+// writeDeviceIDTempFile nothing to narrow against. A file that appears there and
+// is gone again before the link narrows it further—the one direction this
+// package moves a mode.
 func createDeviceIDFile(path, deviceID string) error {
 	tempPath, err := writeDeviceIDTempFile(path, deviceID)
 	if err != nil {
@@ -214,9 +217,12 @@ func createDeviceIDFileWithoutLink(path, deviceID string) error {
 }
 
 // replaceDeviceIDFile overwrites the identifier file through a temporary file
-// and a rename, so no reader observes a half-written or empty file and so the
-// replacement carries its own mode instead of inheriting whatever the file it
-// replaced had.
+// and a rename, so no reader observes a half-written or empty file.
+//
+// The replacement carries the stricter of its own mode and the mode of the file
+// it replaces—see narrowToPublishedFileMode. Without that a rename would publish
+// whatever os.CreateTemp chose, handing a read-only identifier file back
+// writable: this package widening a mode it only ever promises to narrow.
 func replaceDeviceIDFile(path, deviceID string) error {
 	tempPath, err := writeDeviceIDTempFile(path, deviceID)
 	if err != nil {
@@ -232,8 +238,10 @@ func replaceDeviceIDFile(path, deviceID string) error {
 }
 
 // writeDeviceIDTempFile writes deviceID to a fresh file beside path and returns
-// its name for a caller that publishes it with a link or a rename. A path it
-// returns is the caller's to remove; on failure it removes its own.
+// its name for a caller that publishes it with a link or a rename, as it stands:
+// the mode is already narrowed against whatever sits at path—see
+// narrowToPublishedFileMode. A path it returns is the caller's to remove; on
+// failure it removes its own.
 func writeDeviceIDTempFile(path, deviceID string) (string, error) {
 	file, err := os.CreateTemp(filepath.Dir(path), DeviceIDFileName+"-*")
 	if err != nil {
@@ -244,6 +252,9 @@ func writeDeviceIDTempFile(path, deviceID string) (string, error) {
 	tempPath := file.Name()
 
 	_, err = file.WriteString(deviceID + "\n")
+	if err == nil {
+		err = narrowToPublishedFileMode(file, path)
+	}
 	if closeErr := file.Close(); err == nil {
 		err = closeErr
 	}
@@ -253,6 +264,50 @@ func writeDeviceIDTempFile(path, deviceID string) (string, error) {
 	}
 
 	return tempPath, nil
+}
+
+// narrowToPublishedFileMode drops from file every permission bit the file at
+// path lacks, so publishing over that file cannot widen what it had. Bits are
+// only removed, as in restrictDeviceIDFileMode: of the mode os.CreateTemp chose
+// and the mode being stood in for, the stricter wins.
+//
+// It runs while the scratch file is still nameless, because a rename publishes
+// whatever mode the file carries at that instant and narrowing afterwards would
+// leave the wider one published in between. Through the open handle rather than
+// the path, as SaveStreamAtomic does—a path-based chmod can be pointed at
+// another file by anyone able to drop a symlink in the config directory.
+func narrowToPublishedFileMode(file *os.File, path string) error {
+	if runtime.GOOS == "windows" {
+		// Windows has no Unix mode bits; Chmod there toggles the read-only
+		// attribute, so intersecting the modes Go synthesizes would set it
+		// rather than narrow anything.
+		return nil
+	}
+
+	// Nothing to stand in for: this is a fresh installation, or the file was
+	// removed after the caller found the path taken.
+	publishedInfo, err := os.Stat(path)
+	if errors.Is(err, fs.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("failed to inspect device id file: %v", err)
+	}
+	tempInfo, err := file.Stat()
+	if err != nil {
+		return fmt.Errorf("failed to inspect temporary device id file: %v", err)
+	}
+
+	tempPerm := tempInfo.Mode().Perm()
+	perm := tempPerm & publishedInfo.Mode().Perm()
+	if perm == tempPerm {
+		return nil
+	}
+	if err = file.Chmod(perm); err != nil {
+		return fmt.Errorf("failed to restrict temporary device id file permissions: %v", err)
+	}
+
+	return nil
 }
 
 // restrictDeviceIDFileMode drops from a file that already exists every

--- a/config/device.go
+++ b/config/device.go
@@ -247,7 +247,7 @@ func writeDeviceIDTempFile(path, deviceID string) (string, error) {
 	if err != nil {
 		// Flattened, not wrapped: os.CreateTemp reports fs.ErrExist once it runs out
 		// of names, which createDeviceID would read as the identifier file existing.
-		return "", fmt.Errorf("failed to create device id file: %v", err)
+		return "", fmt.Errorf("failed to create temporary device id file: %v", err)
 	}
 	tempPath := file.Name()
 
@@ -260,7 +260,7 @@ func writeDeviceIDTempFile(path, deviceID string) (string, error) {
 	}
 	if err != nil {
 		_ = os.Remove(tempPath)
-		return "", fmt.Errorf("failed to write device id file: %v", err)
+		return "", fmt.Errorf("failed to prepare temporary device id file: %v", err)
 	}
 
 	return tempPath, nil

--- a/config/device.go
+++ b/config/device.go
@@ -255,11 +255,15 @@ func writeDeviceIDTempFile(path, deviceID string) (string, error) {
 	return tempPath, nil
 }
 
-// restrictDeviceIDFileMode drops any group or other permission bits from a file
-// that already exists. A mode argument only applies to a file the call creates,
-// so an identifier file some other path left world-readable would otherwise
-// keep that mode for the life of the installation while this package claims
-// 0600.
+// restrictDeviceIDFileMode drops from a file that already exists every
+// permission bit outside owner read and write. A mode argument only applies to
+// a file the call creates, so an identifier file some other path left
+// world-readable would otherwise keep that mode for the life of the
+// installation while this package claims 0600.
+//
+// The mask covers the owner execute bit as well as group and other, so what
+// survives is at most 0600 and the claim above is the whole truth. Nothing runs
+// this file as a program, so that bit has nothing to say here.
 //
 // Bits are only ever removed, never added: a stricter umask legitimately
 // produces something tighter than 0600, and loosening that back would be this
@@ -276,10 +280,10 @@ func restrictDeviceIDFileMode(path string) error {
 		return fmt.Errorf("failed to inspect device id file: %v", err)
 	}
 	perm := fileInfo.Mode().Perm()
-	if perm&0077 == 0 {
+	if perm&0177 == 0 {
 		return nil
 	}
-	if err = os.Chmod(path, perm&^0077); err != nil {
+	if err = os.Chmod(path, perm&^0177); err != nil {
 		return fmt.Errorf("failed to restrict device id file permissions: %v", err)
 	}
 

--- a/config/device_test.go
+++ b/config/device_test.go
@@ -534,3 +534,51 @@ func TestGetOrCreateDeviceID_UnreadableFile(t *testing.T) {
 	assert.Error(t, err)
 	assert.Empty(t, deviceID)
 }
+
+// TestGetOrCreateDeviceID_NamesTheScratchFileInItsError keeps two failures
+// apart. One temporary file serves both the path that creates the identifier
+// file and the path that rewrites it, so a scratch file that could not be
+// opened used to be reported as the identifier file itself—telling a user whose
+// device_id is sitting right there that it could not be created.
+func TestGetOrCreateDeviceID_NamesTheScratchFileInItsError(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix file mode bits are not meaningful on Windows")
+	}
+	if os.Geteuid() == 0 {
+		t.Skip("root bypasses file permission checks")
+	}
+	setupTestConfig(t)
+	writeDeviceIDFile(t, "not_a_valid_id\n")
+	// Readable and traversable, but nothing new can be created in it.
+	dir := filepath.Dir(mustDeviceIDPath(t))
+	require.NoError(t, os.Chmod(dir, 0500))
+	t.Cleanup(func() { _ = os.Chmod(dir, 0700) })
+
+	deviceID, err := GetOrCreateDeviceID()
+
+	require.Error(t, err)
+	assert.Empty(t, deviceID)
+	assert.Contains(t, err.Error(), "temporary device id file")
+}
+
+// TestWriteDeviceIDTempFile_ReportsAFailureAfterTheScratchFileOpened covers the
+// other error the scratch file can produce: it opened, and something between
+// there and the caller receiving it failed. The mode narrowing is the reachable
+// one—a symlink loop is neither a file it can read nor an absent path—and the
+// write, the chmod, and the close report through the same message.
+func TestWriteDeviceIDTempFile_ReportsAFailureAfterTheScratchFileOpened(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("narrowToPublishedFileMode does nothing on Windows")
+	}
+	setupTestConfig(t)
+	path := mustDeviceIDPath(t)
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0700))
+	require.NoError(t, os.Symlink(path, path))
+
+	tempPath, err := writeDeviceIDTempFile(path, "0f6f3f2e-2a9d-4a1e-8f2b-1c2d3e4f5a6b")
+
+	require.Error(t, err)
+	assert.Empty(t, tempPath)
+	assert.Contains(t, err.Error(), "failed to prepare temporary device id file")
+	assertNoLeftoverTempFiles(t)
+}

--- a/config/device_test.go
+++ b/config/device_test.go
@@ -427,6 +427,11 @@ func TestGetOrCreateDeviceID_ConcurrentReplacementOfMalformedValue(t *testing.T)
 // what this package claims it is. os.WriteFile leaves the mode of an existing
 // file alone, so an identifier file created world-readable by some other path
 // used to keep that mode for the life of the installation.
+//
+// The bound asserted is 0600, the one the package documents, rather than the
+// group and other bits alone: an owner execute bit says this file is a program
+// to run, which it is not, and a mask that spared it would leave the documented
+// mode and the enforced one disagreeing.
 func TestGetOrCreateDeviceID_TightensAnExistingPermissiveFile(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("Unix file mode bits are not meaningful on Windows")
@@ -439,6 +444,7 @@ func TestGetOrCreateDeviceID_TightensAnExistingPermissiveFile(t *testing.T) {
 	}{
 		{"well-formed value is kept, mode is tightened", "0f6f3f2e-2a9d-4a1e-8f2b-1c2d3e4f5a6b\n", 0644},
 		{"malformed value is replaced, mode is tightened", "not_a_valid_id\n", 0666},
+		{"owner execute bit is dropped too", "0f6f3f2e-2a9d-4a1e-8f2b-1c2d3e4f5a6b\n", 0700},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -453,8 +459,8 @@ func TestGetOrCreateDeviceID_TightensAnExistingPermissiveFile(t *testing.T) {
 
 			fileInfo, err := os.Stat(path)
 			require.NoError(t, err)
-			assert.Zero(t, fileInfo.Mode().Perm()&0o077,
-				"device id file must not be readable by group or other, got %v", fileInfo.Mode().Perm())
+			assert.Zero(t, fileInfo.Mode().Perm()&^os.FileMode(0o600),
+				"device id file must be no more permissive than 0600, got %v", fileInfo.Mode().Perm())
 		})
 	}
 }

--- a/config/device_test.go
+++ b/config/device_test.go
@@ -487,6 +487,31 @@ func TestGetOrCreateDeviceID_KeepsAStricterMode(t *testing.T) {
 	assert.Equal(t, os.FileMode(0400), fileInfo.Mode().Perm())
 }
 
+// TestGetOrCreateDeviceID_KeepsAStricterModeWhenReplacing carries the property
+// above onto the path that rewrites the file. Replacing publishes a fresh
+// temporary file, which arrives with the mode os.CreateTemp chose rather than
+// the one the file it replaces had, so a read-only identifier file used to come
+// back writable—the package widening a mode it promises only ever to narrow.
+func TestGetOrCreateDeviceID_KeepsAStricterModeWhenReplacing(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix file mode bits are not meaningful on Windows")
+	}
+	setupTestConfig(t)
+	writeDeviceIDFile(t, "not_a_valid_id\n")
+	path := mustDeviceIDPath(t)
+	require.NoError(t, os.Chmod(path, 0400))
+	t.Cleanup(func() { _ = os.Chmod(path, 0600) })
+
+	deviceID, err := GetOrCreateDeviceID()
+	require.NoError(t, err)
+	assert.True(t, IsValidDeviceID(deviceID),
+		"replacement id must satisfy the Auth0 action pattern: %q", deviceID)
+
+	fileInfo, err := os.Stat(path)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0400), fileInfo.Mode().Perm())
+}
+
 // TestGetOrCreateDeviceID_UnreadableFile pins that a read failure is surfaced
 // rather than papered over with a fresh identifier: silently regenerating would
 // hide a permissions problem and change the identifier on every invocation.

--- a/config/device_test.go
+++ b/config/device_test.go
@@ -29,6 +29,19 @@ func readDeviceIDFile(t *testing.T) string {
 	return string(data)
 }
 
+// assertNoLeftoverTempFiles fails when a scratch file survived in the config
+// directory. Publishing and replacing both go through one, and either leaks it
+// on a path that returns before its cleanup runs.
+func assertNoLeftoverTempFiles(t *testing.T) {
+	t.Helper()
+	entries, err := os.ReadDir(filepath.Dir(mustDeviceIDPath(t)))
+	require.NoError(t, err)
+	for _, entry := range entries {
+		assert.False(t, strings.HasPrefix(entry.Name(), DeviceIDFileName+"-"),
+			"temporary file %q was left behind", entry.Name())
+	}
+}
+
 // writeDeviceIDFile plants raw contents so tests can exercise values the writer
 // would never produce.
 func writeDeviceIDFile(t *testing.T, raw string) {
@@ -198,6 +211,7 @@ func TestGetOrCreateDeviceID_ReplacesMalformedValue(t *testing.T) {
 			require.NoError(t, err)
 			assert.True(t, IsValidDeviceID(deviceID), "replacement id must satisfy the Auth0 action pattern: %q", deviceID)
 			assert.Equal(t, deviceID+"\n", readDeviceIDFile(t))
+			assertNoLeftoverTempFiles(t)
 		})
 	}
 }
@@ -356,12 +370,7 @@ func TestGetOrCreateDeviceID_ConcurrentCreation(t *testing.T) {
 	}
 
 	// A concurrent loser must not leave its scratch file behind either.
-	entries, err := os.ReadDir(filepath.Dir(mustDeviceIDPath(t)))
-	require.NoError(t, err)
-	for _, entry := range entries {
-		assert.False(t, strings.HasPrefix(entry.Name(), DeviceIDFileName+"-"),
-			"temporary file %q was left behind", entry.Name())
-	}
+	assertNoLeftoverTempFiles(t)
 }
 
 // TestGetOrCreateDeviceID_ConcurrentReplacementOfMalformedValue covers the same
@@ -411,6 +420,7 @@ func TestGetOrCreateDeviceID_ConcurrentReplacementOfMalformedValue(t *testing.T)
 		}
 	}
 	assert.True(t, handedOut, "the value left on disk must be one that was handed out, got %q", stored)
+	assertNoLeftoverTempFiles(t)
 }
 
 // TestGetOrCreateDeviceID_TightensAnExistingPermissiveFile pins that the mode is


### PR DESCRIPTION
## Background

`~/.alpacon/device_id` holds the per-installation identifier an MFA presence proof binds to under ADR 0054. It is not a secret, but it is not inert either, so `config/device.go` keeps it at 0600 inside the 0700 config directory and states in three separate comments that bits are only ever removed from that file, never added.

Two of the four items #376 collected are that claim being false. The other two are a message that names the wrong file and a test gap on the replace path.

## Changes

The first four commits take one issue item each, ordered so review reads top to bottom. Two follow-ups from review come after them.

### `test(config)`: fold the leftover-scratch-file check into a helper (issue item 2)

`TestGetOrCreateDeviceID_ConcurrentCreation` was the only test asserting that no `device_id-*` scratch file survived, even though the replace path goes through the same temporary file. The loop moves to `assertNoLeftoverTempFiles` and the two replace tests now call it. A leak on either path is observable from here on.

### `fix(config)`: drop the owner execute bit from the identifier file too (issue item 4)

`restrictDeviceIDFileMode` cleared `0077`, which spares the owner execute bit, so a `device_id` at 0700 stayed 0700 while the comment above it said 0600. The mask is now `0177` and what survives is at most 0600.

Nothing runs this file as a program, so the bit has nothing to say here—the choice is between tightening the mask and weakening the comment, and the mask is the half worth keeping. `TestGetOrCreateDeviceID_TightensAnExistingPermissiveFile` gains a 0700 case and asserts the documented bound (`perm &^ 0600`) rather than group and other alone.

### `fix(config)`: keep a stricter mode when the identifier file is replaced (issue item 3)

This is the substance of the issue. `replaceDeviceIDFile` publishes a fresh temporary file with `os.Rename`, and rename carries the new file's mode, not the old one's. `os.CreateTemp` creates at 0600, so a `device_id` the user had tightened to 0400 came back writable: this package widening a mode it promises only ever to narrow.

`narrowToPublishedFileMode` (`config/device.go:282`) intersects the scratch file's permissions with those of the file it is about to stand in for, so the stricter of the two wins. Two details are deliberate:

- It runs before the caller publishes the file. Rename publishes whatever mode the file carries at that instant, and narrowing afterwards would leave the wider mode published in between.
- It goes through the open handle rather than the path, as `SaveStreamAtomic` already does. A path-based `os.Chmod` here can be pointed at another file by anyone able to drop a symlink in the config directory.

The create path calls the same helper and is unaffected in practice: `os.Link` refuses to replace, so the path is free whenever the link succeeds and there is nothing to narrow against. One window stays and is written into the comment on `createDeviceIDFile`—a file present when the stat runs and gone again before `os.Link` leaves the published mode narrower than the free path called for. The direction is always stricter, so it costs a `chmod`, not an exposure.

`runtime.GOOS == "windows"` returns early. Windows has no Unix mode bits and `Chmod` there toggles the read-only attribute, so intersecting the modes Go synthesizes would set it rather than narrow anything.

### `fix(config)`: name the scratch file in the errors that are about it (issue item 1)

`writeDeviceIDTempFile` serves both the create path and the replace path, and reported a failed `os.CreateTemp` as `failed to create device id file`—telling a user whose `device_id` is sitting right there that it could not be created. The two failures are now distinct: `failed to create temporary device id file` when the scratch file cannot be opened, `failed to prepare temporary device id file` when the write, the narrowing, or the close fails after it opened.

The error stays flattened with `%v`. `os.CreateTemp` reports `fs.ErrExist` once it runs out of names, and `createDeviceID` matches on that to mean the identifier file already exists.

### `docs(config)`: say what the narrowing runs before, and what the link publishes

Two comments described the mechanism in terms that do not hold, both raised in review. `os.CreateTemp` gives the scratch file a real name on disk, so "still nameless" was wrong about what the narrowing runs ahead of—it runs ahead of the caller publishing the file, which is the part that matters. And `os.Link` does not touch permissions: the narrowing that a vanished file leaves behind happened earlier, inside `writeDeviceIDTempFile`.

Comments only. Neither the modes this package publishes nor the order it publishes them in changes.

### `refactor(config)`: name the permission mask restrictDeviceIDFileMode clears

The mask appeared twice as a bare `0177`—once as the test for whether anything needs clearing, once as the bits to clear. The two have to agree, and nothing in the code said so. It is now `deviceIDFileExcessPerm`, following `stagingPerm` and `groupOtherRead` in `utils/file_save.go`.

The test keeps its own literal bound (`perm &^ 0600`) rather than reusing the constant: a test written in terms of the value under test cannot catch that value being wrong.

## Safety

The change only ever removes permission bits. `narrowToPublishedFileMode` computes `tempPerm & publishedPerm` and returns early when that equals `tempPerm`, so there is no path on which it calls `Chmod` with a wider mode. A stricter umask still legitimately produces something tighter than 0600 and is left alone.

## Testing

`go test -race -count=1 ./...` passes on every package. `go vet ./...` is silent and `golangci-lint run ./...` reports `0 issues.`

Every new or changed assertion was seen red against the unfixed code:

- `TestGetOrCreateDeviceID_TightensAnExistingPermissiveFile/owner execute bit is dropped too`, with the mask reverted to `0077`: `Should be zero, but was ---x------ ... device id file must be no more permissive than 0600, got -rwx------`.
- `TestGetOrCreateDeviceID_KeepsAStricterModeWhenReplacing`, with the `narrowToPublishedFileMode` call removed: `expected: 0x100 / actual: 0x180`.
- `TestGetOrCreateDeviceID_NamesTheScratchFileInItsError`, with the first message reverted: `"failed to create device id file: open .../device_id-2821398180: permission denied" does not contain "temporary device id file"`.
- `TestWriteDeviceIDTempFile_ReportsAFailureAfterTheScratchFileOpened`, with the second message reverted: the error arrives as `failed to write device id file: failed to inspect device id file: ... too many levels of symbolic links` and the `Contains` fails.
- `assertNoLeftoverTempFiles`, with the cleanup `os.Remove` deleted: `temporary file "device_id-1324011417" was left behind`.

The last test reaches `writeDeviceIDTempFile` directly rather than through `GetOrCreateDeviceID`, as the sibling `TestCreateDeviceIDFile_*` tests already do. A self-referential symlink at the path is the reachable failure for the narrowing step—`readDeviceID` fails on the same symlink loop first, so the public entry point never gets there.

Closes #376
