### PR TITLE
fix(exec,utils): sanitize the server text in exec's raw result lines

### DIFF
--- a/cmd/exec/logs.go
+++ b/cmd/exec/logs.go
@@ -90,18 +90,23 @@ func init() {
 // awaiting_approval hold nor a rejection reaches here: the caller answers both on
 // the approval contract first.
 func logsCommandOutcome(details event.EventDetails) (stdoutLine, stderrLine string, exitCode int) {
+	// These lines are written raw, outside the Cli* sanitizing helpers (#364). A
+	// Status that reached one of these branches equals the literal it was compared
+	// against, so it needs no strip; the ID, an unknown phase, and the
+	// unrecognised-status fallback carry the server's own text and do.
 	if event.IsRunningStatus(details.Status) {
 		stderrLine = fmt.Sprintf(
 			"command is still running (status: %s).\nRun `alpacon exec logs %s` again to check later.\n",
-			details.Status, details.ID,
+			details.Status, utils.SanitizeTerminalText(details.ID),
 		)
 		return "", stderrLine, 0
 	}
 
 	if details.Status == "stuck" || details.Status == "error" || details.Status == "cancelled" {
 		if details.ErrorPhase != nil && *details.ErrorPhase != "" {
+			phase, desc := sanitizedPhaseParts(*details.ErrorPhase)
 			stderrLine = fmt.Sprintf("%s: [%s] %s (status=%s)\n",
-				utils.Red("Error"), *details.ErrorPhase, event.DescribePhase(*details.ErrorPhase), details.Status)
+				utils.Red("Error"), phase, desc, details.Status)
 		} else {
 			stderrLine = fmt.Sprintf("%s: command failed with status: %s\n",
 				utils.Red("Error"), details.Status)
@@ -115,8 +120,8 @@ func logsCommandOutcome(details event.EventDetails) (stdoutLine, stderrLine stri
 			exitCode = *details.ExitCode
 		}
 		if details.ErrorPhase != nil && *details.ErrorPhase != "" {
-			stderrLine = fmt.Sprintf("%s: [%s] %s\n",
-				utils.Red("Error"), *details.ErrorPhase, event.DescribePhase(*details.ErrorPhase))
+			phase, desc := sanitizedPhaseParts(*details.ErrorPhase)
+			stderrLine = fmt.Sprintf("%s: [%s] %s\n", utils.Red("Error"), phase, desc)
 		}
 		return details.Result, stderrLine, exitCode
 	}
@@ -131,6 +136,6 @@ func logsCommandOutcome(details event.EventDetails) (stdoutLine, stderrLine stri
 	}
 
 	stderrLine = fmt.Sprintf("%s: command ended with unrecognised status: %s\n",
-		utils.Red("Error"), details.Status)
+		utils.Red("Error"), utils.SanitizeTerminalText(details.Status))
 	return details.Result, stderrLine, 1
 }

--- a/cmd/exec/logs_test.go
+++ b/cmd/exec/logs_test.go
@@ -173,3 +173,55 @@ func TestLogsCommandOutcome(t *testing.T) {
 		})
 	}
 }
+
+// The stderr line bypasses the Cli* helpers, so server-controlled fields must be
+// sanitized where the line is assembled (#364). Each case injects into the one
+// field an attacker controls on that branch: Status must equal a known value to
+// reach the running/failed branches, so ID and ErrorPhase carry the payload
+// there, while the unrecognised-status fallback renders Status itself verbatim.
+func TestLogsCommandOutcomeSanitizesServerText(t *testing.T) {
+	tests := []struct {
+		name    string
+		details event.EventDetails
+		// The whole rendering, so a sanitize that ate the surrounding text fails here
+		// rather than passing a check that only looks for the payload's absence.
+		wantContains string
+	}{
+		{
+			name:         "running branch strips escape and bidi in ID",
+			details:      event.EventDetails{ID: "job-1\x1b[2K\u202e", Status: "running"},
+			wantContains: "`alpacon exec logs job-1` again",
+		},
+		{
+			name:         "stuck branch strips escape in unknown phase",
+			details:      event.EventDetails{ID: "job-1", Status: "stuck", ErrorPhase: strPtr("boom\x1b[31m\u202e")},
+			wantContains: "[boom] boom (status=stuck)",
+		},
+		{
+			name: "failure branch strips escape in unknown phase",
+			details: event.EventDetails{
+				ID:         "job-1",
+				Status:     "completed",
+				Success:    boolPtr(false),
+				ExitCode:   intPtr(2),
+				ErrorPhase: strPtr("phase\x1b]0;pwn\x07\u202e"),
+			},
+			wantContains: "[phase] phase",
+		},
+		{
+			name:         "unrecognised status renders sanitized",
+			details:      event.EventDetails{ID: "job-1", Status: "denied\x1b[2K\u202eapproved"},
+			wantContains: "unrecognised status: deniedapproved",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, stderrLine, _ := logsCommandOutcome(tt.details)
+
+			assert.Contains(t, stderrLine, tt.wantContains)
+			assert.NotContains(t, stderrLine, "\x1b")
+			assert.NotContains(t, stderrLine, "\u202e")
+		})
+	}
+}

--- a/cmd/exec/logs_test.go
+++ b/cmd/exec/logs_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/alpacax/alpacon-cli/api/event"
+	"github.com/alpacax/alpacon-cli/utils"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -174,28 +175,25 @@ func TestLogsCommandOutcome(t *testing.T) {
 	}
 }
 
-// The stderr line bypasses the Cli* helpers, so server-controlled fields must be
-// sanitized where the line is assembled (#364). Each case injects into the one
-// field an attacker controls on that branch: Status must equal a known value to
-// reach the running/failed branches, so ID and ErrorPhase carry the payload
-// there, while the unrecognised-status fallback renders Status itself verbatim.
+// The stderr line bypasses the Cli* helpers, so each case injects into the one
+// field the server controls on that branch: Status must equal a known value to
+// reach the running and failed branches, so ID and ErrorPhase carry the payload
+// there, while the unrecognised-status fallback renders Status itself (#364).
 func TestLogsCommandOutcomeSanitizesServerText(t *testing.T) {
 	tests := []struct {
-		name    string
-		details event.EventDetails
-		// The whole rendering, so a sanitize that ate the surrounding text fails here
-		// rather than passing a check that only looks for the payload's absence.
-		wantContains string
+		name       string
+		details    event.EventDetails
+		wantStderr string
 	}{
 		{
-			name:         "running branch strips escape and bidi in ID",
-			details:      event.EventDetails{ID: "job-1\x1b[2K\u202e", Status: "running"},
-			wantContains: "`alpacon exec logs job-1` again",
+			name:       "running branch strips escape and bidi in ID",
+			details:    event.EventDetails{ID: "job-1\x1b[2K\u202e", Status: "running"},
+			wantStderr: "command is still running (status: running).\nRun `alpacon exec logs job-1` again to check later.\n",
 		},
 		{
-			name:         "stuck branch strips escape in unknown phase",
-			details:      event.EventDetails{ID: "job-1", Status: "stuck", ErrorPhase: strPtr("boom\x1b[31m\u202e")},
-			wantContains: "[boom] boom (status=stuck)",
+			name:       "stuck branch strips escape in unknown phase",
+			details:    event.EventDetails{ID: "job-1", Status: "stuck", ErrorPhase: strPtr("boom\x1b[31m\u202e")},
+			wantStderr: utils.Red("Error") + ": [boom] boom (status=stuck)\n",
 		},
 		{
 			name: "failure branch strips escape in unknown phase",
@@ -206,12 +204,12 @@ func TestLogsCommandOutcomeSanitizesServerText(t *testing.T) {
 				ExitCode:   intPtr(2),
 				ErrorPhase: strPtr("phase\x1b]0;pwn\x07\u202e"),
 			},
-			wantContains: "[phase] phase",
+			wantStderr: utils.Red("Error") + ": [phase] phase\n",
 		},
 		{
-			name:         "unrecognised status renders sanitized",
-			details:      event.EventDetails{ID: "job-1", Status: "denied\x1b[2K\u202eapproved"},
-			wantContains: "unrecognised status: deniedapproved",
+			name:       "unrecognised status renders sanitized",
+			details:    event.EventDetails{ID: "job-1", Status: "denied\x1b[2K\u202eapproved"},
+			wantStderr: utils.Red("Error") + ": command ended with unrecognised status: deniedapproved\n",
 		},
 	}
 
@@ -219,9 +217,7 @@ func TestLogsCommandOutcomeSanitizesServerText(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			_, stderrLine, _ := logsCommandOutcome(tt.details)
 
-			assert.Contains(t, stderrLine, tt.wantContains)
-			assert.NotContains(t, stderrLine, "\x1b")
-			assert.NotContains(t, stderrLine, "\u202e")
+			assert.Equal(t, tt.wantStderr, stderrLine)
 		})
 	}
 }

--- a/cmd/exec/run.go
+++ b/cmd/exec/run.go
@@ -730,9 +730,24 @@ func clientTimeoutLine() string {
 	return fmt.Sprintf("%s: [%s] %s\n", utils.Red("Error"), phase, event.DescribePhase(phase))
 }
 
+// detachResultLines renders the --detach confirmation. The job id comes from the
+// server's submit response and both lines are written raw, outside the Cli*
+// helpers—sanitize here (#364).
 func detachResultLines(jobID string) (string, string) {
+	jobID = utils.SanitizeTerminalText(jobID)
 	return fmt.Sprintf("Job submitted: %s", jobID),
 		fmt.Sprintf("Run `alpacon exec logs %s` to check the result.", jobID)
+}
+
+// sanitizedPhaseParts returns the phase identifier and its description ready for
+// a raw stderr write, outside the Cli* sanitizing helpers (#364). The identifier
+// is always the server's; the description is a constant from phaseDescriptions
+// for a known phase, and the raw phase echoed back for an unknown one. Describing
+// before stripping is what keeps a payload that only becomes a known phase once
+// sanitized from borrowing that phase's description.
+func sanitizedPhaseParts(phase string) (id, desc string) {
+	return utils.SanitizeTerminalText(phase),
+		utils.SanitizeTerminalText(event.DescribePhase(phase))
 }
 
 // remoteCommandOutcome renders the stderr phase line and exit code for a remote
@@ -740,10 +755,8 @@ func detachResultLines(jobID string) (string, string) {
 // so it is not re-emitted here. stderrLine already includes its trailing newline.
 func remoteCommandOutcome(remoteErr *event.RemoteCommandError) (stderrLine string, exitCode int) {
 	if remoteErr.ErrorPhase != "" {
-		stderrLine = fmt.Sprintf("%s: [%s] %s\n",
-			utils.Red("Error"),
-			remoteErr.ErrorPhase,
-			event.DescribePhase(remoteErr.ErrorPhase))
+		phase, desc := sanitizedPhaseParts(remoteErr.ErrorPhase)
+		stderrLine = fmt.Sprintf("%s: [%s] %s\n", utils.Red("Error"), phase, desc)
 	}
 	return stderrLine, remoteErr.ExitCode
 }

--- a/cmd/exec/run_test.go
+++ b/cmd/exec/run_test.go
@@ -121,10 +121,62 @@ func TestRemoteCommandOutcome(t *testing.T) {
 	}
 }
 
+// The phase line bypasses the Cli* helpers, and DescribePhase echoes an unknown
+// phase verbatim, so an attacker-chosen error_phase must be sanitized where the
+// line is assembled (#364). The second case pins the order: the lookup runs on
+// the raw phase, so a payload that only becomes a known phase after sanitizing
+// still renders as an identifier and cannot borrow that phase's description.
+func TestRemoteCommandOutcomeSanitizesPhase(t *testing.T) {
+	tests := []struct {
+		name         string
+		phase        string
+		wantContains string
+		wantAbsent   string
+	}{
+		{
+			name:         "unknown phase keeps its safe characters",
+			phase:        "boom\x1b[2K\u202e_phase",
+			wantContains: "[boom_phase] boom_phase",
+		},
+		{
+			name:         "payload sanitizing into a known phase does not borrow its description",
+			phase:        "agent_\x1b[2K\u202etimeout",
+			wantContains: "[agent_timeout] agent_timeout",
+			wantAbsent:   event.DescribePhase("agent_timeout"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stderrLine, exitCode := remoteCommandOutcome(&event.RemoteCommandError{
+				ExitCode:   1,
+				ErrorPhase: tt.phase,
+			})
+
+			assert.Equal(t, 1, exitCode)
+			assert.Contains(t, stderrLine, tt.wantContains)
+			assert.NotContains(t, stderrLine, "\x1b")
+			assert.NotContains(t, stderrLine, "\u202e")
+			if tt.wantAbsent != "" {
+				assert.NotContains(t, stderrLine, tt.wantAbsent)
+			}
+		})
+	}
+}
+
 func TestDetachResultLines(t *testing.T) {
 	line1, line2 := detachResultLines("a1b2c3d4-1234-5678-abcd-000000000000")
 	assert.Equal(t, "Job submitted: a1b2c3d4-1234-5678-abcd-000000000000", line1)
 	assert.Equal(t, "Run `alpacon exec logs a1b2c3d4-1234-5678-abcd-000000000000` to check the result.", line2)
+}
+
+// The job id comes from the server's submit response and both lines are written
+// raw (stdout and stderr), outside the Cli* helpers—same class as #364.
+func TestDetachResultLinesSanitizesJobID(t *testing.T) {
+	line1, line2 := detachResultLines("job-1\x1b[2K\u202e")
+
+	assert.Equal(t, "Job submitted: job-1", line1)
+	assert.Equal(t, "Run `alpacon exec logs job-1` to check the result.", line2)
 }
 
 // stubApprovalWaitSeams swaps the loop's seams/interval (restored on cleanup) and returns a denial carrying the plugin line the loop keys on for that code.

--- a/cmd/exec/run_test.go
+++ b/cmd/exec/run_test.go
@@ -128,21 +128,21 @@ func TestRemoteCommandOutcome(t *testing.T) {
 // still renders as an identifier and cannot borrow that phase's description.
 func TestRemoteCommandOutcomeSanitizesPhase(t *testing.T) {
 	tests := []struct {
-		name         string
-		phase        string
-		wantContains string
-		wantAbsent   string
+		name       string
+		phase      string
+		wantStderr string
 	}{
 		{
-			name:         "unknown phase keeps its safe characters",
-			phase:        "boom\x1b[2K\u202e_phase",
-			wantContains: "[boom_phase] boom_phase",
+			name:       "unknown phase keeps its safe characters",
+			phase:      "boom\x1b[2K\u202e_phase",
+			wantStderr: utils.Red("Error") + ": [boom_phase] boom_phase\n",
 		},
 		{
-			name:         "payload sanitizing into a known phase does not borrow its description",
-			phase:        "agent_\x1b[2K\u202etimeout",
-			wantContains: "[agent_timeout] agent_timeout",
-			wantAbsent:   event.DescribePhase("agent_timeout"),
+			// Describing before stripping is what keeps the payload from borrowing
+			// agent_timeout's own description once it sanitizes into that phase.
+			name:       "payload sanitizing into a known phase does not borrow its description",
+			phase:      "agent_\x1b[2K\u202etimeout",
+			wantStderr: utils.Red("Error") + ": [agent_timeout] agent_timeout\n",
 		},
 	}
 
@@ -154,12 +154,7 @@ func TestRemoteCommandOutcomeSanitizesPhase(t *testing.T) {
 			})
 
 			assert.Equal(t, 1, exitCode)
-			assert.Contains(t, stderrLine, tt.wantContains)
-			assert.NotContains(t, stderrLine, "\x1b")
-			assert.NotContains(t, stderrLine, "\u202e")
-			if tt.wantAbsent != "" {
-				assert.NotContains(t, stderrLine, tt.wantAbsent)
-			}
+			assert.Equal(t, tt.wantStderr, stderrLine)
 		})
 	}
 }

--- a/utils/output.go
+++ b/utils/output.go
@@ -45,16 +45,21 @@ type NextAction struct {
 }
 
 // PlainText renders the action as a human-facing line: "command  # description",
-// or just the command or description when the other is empty.
+// or just the command or description when the other is empty. Sanitized here
+// because its callers write to the terminal outside the Cli* helpers and call
+// sites interpolate server-returned ids into Command; the JSON envelope marshals
+// the fields themselves and escapes via escapeJSONControls instead.
 func (a NextAction) PlainText() string {
+	var line string
 	switch {
 	case a.Command != "" && a.Description != "":
-		return a.Command + "  # " + a.Description
+		line = a.Command + "  # " + a.Description
 	case a.Command != "":
-		return a.Command
+		line = a.Command
 	default:
-		return a.Description
+		line = a.Description
 	}
+	return SanitizeTerminalText(line)
 }
 
 // escapeJSONControls rewrites DEL, the C1 block, and Unicode format characters as

--- a/utils/output.go
+++ b/utils/output.go
@@ -50,16 +50,16 @@ type NextAction struct {
 // sites interpolate server-returned ids into Command; the JSON envelope marshals
 // the fields themselves and escapes via escapeJSONControls instead.
 func (a NextAction) PlainText() string {
-	var line string
+	command := SanitizeTerminalText(a.Command)
+	description := SanitizeTerminalText(a.Description)
 	switch {
-	case a.Command != "" && a.Description != "":
-		line = a.Command + "  # " + a.Description
-	case a.Command != "":
-		line = a.Command
+	case command != "" && description != "":
+		return command + "  # " + description
+	case command != "":
+		return command
 	default:
-		line = a.Description
+		return description
 	}
-	return SanitizeTerminalText(line)
 }
 
 // escapeJSONControls rewrites DEL, the C1 block, and Unicode format characters as

--- a/utils/output_test.go
+++ b/utils/output_test.go
@@ -262,3 +262,22 @@ func TestPrintJSONError(t *testing.T) {
 		"next_actions": [{"command": "alpacon work-session use <ID>"}]
 	}`, buf.String())
 }
+
+// PlainText feeds the two terminal writers (pending-approval next-action lines
+// and the WorkSession diagnostic) directly, outside the Cli* sanitizing helpers,
+// and call sites interpolate server-returned ids into Command—so the rendering
+// itself must sanitize (#364). The JSON envelope marshals the struct fields and
+// is covered by escapeJSONControls instead.
+func TestNextActionPlainTextSanitizesTerminalText(t *testing.T) {
+	action := NextAction{
+		Command:     "alpacon exec logs job-1\x1b[2K\u202e",
+		Description: "after\x1b]0;pwn\x07 approval\u202e",
+	}
+
+	line := action.PlainText()
+
+	assert.NotContains(t, line, "\x1b")
+	assert.NotContains(t, line, "\u202e")
+	assert.Contains(t, line, "alpacon exec logs job-1")
+	assert.Contains(t, line, "# after")
+}

--- a/utils/output_test.go
+++ b/utils/output_test.go
@@ -263,21 +263,38 @@ func TestPrintJSONError(t *testing.T) {
 	}`, buf.String())
 }
 
-// PlainText feeds the two terminal writers (pending-approval next-action lines
-// and the WorkSession diagnostic) directly, outside the Cli* sanitizing helpers,
-// and call sites interpolate server-returned ids into Command—so the rendering
-// itself must sanitize (#364). The JSON envelope marshals the struct fields and
-// is covered by escapeJSONControls instead.
+// Callers write PlainText raw, outside the Cli* helpers, and interpolate
+// server-returned ids into Command (#364).
 func TestNextActionPlainTextSanitizesTerminalText(t *testing.T) {
-	action := NextAction{
-		Command:     "alpacon exec logs job-1\x1b[2K\u202e",
-		Description: "after\x1b]0;pwn\x07 approval\u202e",
+	const (
+		command     = "alpacon exec logs job-1\x1b[2K\u202e"
+		description = "after\x1b]0;pwn\x07 approval\u202e"
+	)
+	tests := []struct {
+		name   string
+		action NextAction
+		want   string
+	}{
+		{
+			name:   "command and description",
+			action: NextAction{Command: command, Description: description},
+			want:   "alpacon exec logs job-1  # after approval",
+		},
+		{
+			name:   "command only",
+			action: NextAction{Command: command},
+			want:   "alpacon exec logs job-1",
+		},
+		{
+			name:   "description only",
+			action: NextAction{Description: description},
+			want:   "after approval",
+		},
 	}
 
-	line := action.PlainText()
-
-	assert.NotContains(t, line, "\x1b")
-	assert.NotContains(t, line, "\u202e")
-	assert.Contains(t, line, "alpacon exec logs job-1")
-	assert.Contains(t, line, "# after")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.action.PlainText())
+		})
+	}
 }

--- a/utils/output_test.go
+++ b/utils/output_test.go
@@ -290,6 +290,11 @@ func TestNextActionPlainTextSanitizesTerminalText(t *testing.T) {
 			action: NextAction{Description: description},
 			want:   "after approval",
 		},
+		{
+			name:   "command sanitizes to empty leaves no dangling separator",
+			action: NextAction{Command: "\x1b[2K\u202e", Description: description},
+			want:   "after approval",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Background

Every string the CLI writes to the terminal passes through a single gate, `utils.cliMessage`, which strips escape sequences, 8-bit C1 controls, and bidi overrides. All of the `CliError`/`CliInfo`/`CliWarning` helpers go through that gate.

The result lines of `exec` do not. They are assembled with `fmt.Sprintf` and written directly via `fmt.Fprint(os.Stderr, ...)`, with server response values embedded verbatim: `EventDetails.ID`, `EventDetails.Status`, and the original string that `event.DescribePhase` returns when it meets a phase name it does not know. The `--detach` confirmation line's job id and the pending-approval next-action line had the same shape.

A single bidi override makes a denial read as an approval, and a single erase-line sequence wipes lines printed earlier. This is the same class of problem as #294 and #324.

## Changes

Sanitize at the point where the value is rendered. The reason for not fixing each call site instead: of the four places that print an id, three have no validated substitute in function scope, and the next caller to be added would come in unsanitized again. #324 settled the same question the same way.

| File | Target |
|---|---|
| `cmd/exec/logs.go` | `details.ID`, the final branch that prints an unknown `Status`, two failed-phase lines |
| `cmd/exec/run.go` | the job id in `detachResultLines`, the phase line in `remoteCommandOutcome` |
| `utils/output.go` | the line built by `NextAction.PlainText()` |

A `Status` that passed a comparison against a known status value equals that literal, so it is not sanitized.

The two lines the three phase-line sites shared are now grouped in `sanitizedPhaseParts` (`cmd/exec/run.go`), which returns the phase identifier and its description, both sanitized.

`--output json` is unaffected. The JSON envelope marshals struct fields as-is and escapes them with `escapeJSONControls`, so a decoder can still read back the original values.

## Safety

The order—look up the description first, then sanitize—is the key. Reversed, a value like `agent_<ESC>timeout` becomes `agent_timeout` after sanitizing and borrows the description of the real `agent_timeout`, which means the server gets to print a sentence vouched for under the CLI's name. So the lookup uses the original value and only the two rendered pieces are sanitized. This order is pinned by a test.

In the current alpacon-server these fields are not user-writable: `error_phase` and `status` are computed properties that return fixed strings, and `id` is a server-generated UUID primary key. No exploitable legitimate path exists today that I could find.

The CLI still defends on its side. The endpoint is decided by the config file and self-hosted workspaces are not operated by us, so server responses sit outside the trust boundary. The server's current implementation is not written down as a contract anywhere, so if user text ever leaks into these fields later, the CLI would get no signal.

## Testing

Verified with the built binary against an adversarial API stand-in. For each affected field, the stand-in returned `ESC[2K`, an OSC title-setting sequence, and U+202E. Before the fix, five screens printed those bytes verbatim; after the fix, none did: the in-progress guidance line, the stuck-phase line, the unknown-status line, the `--detach` confirmation line, and the remote failed-phase line. The pending-approval next-action line was checked the same way. In all five cases the exit codes are unchanged, and `--output json` still emits the two bytes as backslash-u escapes.

The unit tests pin the entire rendered line with `assert.Equal` rather than fragment checks—a fragment check still passes when the text around the payload is cut off or when the separator and trailing punctuation change.

Every new assertion was seen RED first by breaking the implementation: shrinking the separator from two spaces to one, turning the command-only branch into an empty string, appending a trailing space to the stuck line, and moving the phase lookup after sanitization. All four passed under the old assertions.

`go test -race ./...` passes and `golangci-lint run ./...` reports `0 issues`.

Closes #364
