### PR TITLE
refactor(api): drop the approve/reject clients ADR 0015 stranded

### DIFF
--- a/api/approval/approval.go
+++ b/api/approval/approval.go
@@ -74,16 +74,6 @@ func GetApprovalRequestRaw(ac *client.AlpaconClient, id string) ([]byte, error) 
 	return ac.SendGetRequest(utils.BuildURL(approvalURL, id, nil))
 }
 
-func ApproveRequest(ac *client.AlpaconClient, id string, opts ApproveOptions) error {
-	_, err := ac.SendPostRequest(utils.BuildURL(approvalURL, path.Join(id, "approve"), nil), opts)
-	return err
-}
-
-func RejectRequest(ac *client.AlpaconClient, id string) error {
-	_, err := ac.SendPostRequest(utils.BuildURL(approvalURL, path.Join(id, "reject"), nil), struct{}{})
-	return err
-}
-
 func CancelRequest(ac *client.AlpaconClient, id string) error {
 	_, err := ac.SendPostRequest(utils.BuildURL(approvalURL, path.Join(id, "cancel"), nil), struct{}{})
 	return err

--- a/api/approval/approval_test.go
+++ b/api/approval/approval_test.go
@@ -90,55 +90,6 @@ func TestGetApprovalRequest(t *testing.T) {
 	assert.Equal(t, "sudo", req.RequestType)
 }
 
-func TestApproveRequest_NoAdjustments(t *testing.T) {
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, http.MethodPost, r.Method)
-		assert.True(t, strings.HasSuffix(r.URL.Path, "apr-abc/approve/"))
-		var body ApproveOptions
-		assert.NoError(t, json.NewDecoder(r.Body).Decode(&body))
-		assert.Nil(t, body.AdjustedScopes)
-		assert.Nil(t, body.AdjustedServers)
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusOK)
-	}))
-	defer ts.Close()
-
-	err := ApproveRequest(newTestClient(ts), "apr-abc", ApproveOptions{})
-	assert.NoError(t, err)
-}
-
-func TestApproveRequest_WithAdjustments(t *testing.T) {
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.True(t, strings.HasSuffix(r.URL.Path, "apr-abc/approve/"))
-		var body ApproveOptions
-		assert.NoError(t, json.NewDecoder(r.Body).Decode(&body))
-		assert.Equal(t, []string{"command"}, body.AdjustedScopes)
-		assert.Equal(t, []string{"srv-uuid-1"}, body.AdjustedServers)
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusOK)
-	}))
-	defer ts.Close()
-
-	err := ApproveRequest(newTestClient(ts), "apr-abc", ApproveOptions{
-		AdjustedScopes:  []string{"command"},
-		AdjustedServers: []string{"srv-uuid-1"},
-	})
-	assert.NoError(t, err)
-}
-
-func TestRejectRequest(t *testing.T) {
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, http.MethodPost, r.Method)
-		assert.True(t, strings.HasSuffix(r.URL.Path, "apr-abc/reject/"))
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusOK)
-	}))
-	defer ts.Close()
-
-	err := RejectRequest(newTestClient(ts), "apr-abc")
-	assert.NoError(t, err)
-}
-
 func TestCancelRequest(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodPost, r.Method)
@@ -149,32 +100,6 @@ func TestCancelRequest(t *testing.T) {
 
 	err := CancelRequest(newTestClient(ts), "apr-abc")
 	assert.NoError(t, err)
-}
-
-func TestApproveRequest_403PropagatesError(t *testing.T) {
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusForbidden)
-		_, _ = w.Write([]byte(`{"detail": "you do not have permission to perform this action"}`))
-	}))
-	defer ts.Close()
-
-	err := ApproveRequest(newTestClient(ts), "apr-abc", ApproveOptions{})
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "permission")
-}
-
-func TestRejectRequest_404PropagatesError(t *testing.T) {
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusNotFound)
-		_, _ = w.Write([]byte(`{"detail": "not found"}`))
-	}))
-	defer ts.Close()
-
-	err := RejectRequest(newTestClient(ts), "apr-missing")
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "not found")
 }
 
 func TestCancelRequest_403PropagatesError(t *testing.T) {

--- a/api/approval/types.go
+++ b/api/approval/types.go
@@ -26,8 +26,3 @@ type ApprovalRequestAttributes struct {
 	RequestedBy string `json:"requested_by" table:"Requested By"`
 	AddedAt     string `json:"added_at"     table:"Added At"`
 }
-
-type ApproveOptions struct {
-	AdjustedScopes  []string `json:"adjusted_scopes,omitempty"`
-	AdjustedServers []string `json:"adjusted_servers,omitempty"`
-}

--- a/api/worksession/types.go
+++ b/api/worksession/types.go
@@ -115,11 +115,6 @@ type WorkSessionExtendRequest struct {
 	ExpiresAt string `json:"expires_at"`
 }
 
-type WorkSessionApproveRequest struct {
-	AdjustedScopes  []string `json:"adjusted_scopes,omitempty"`
-	AdjustedServers []string `json:"adjusted_servers,omitempty"`
-}
-
 // TimelineItem represents a single event in a work session's activity timeline.
 // All event types share this struct; type-specific fields are zero-valued for other types.
 type TimelineItem struct {

--- a/api/worksession/worksession.go
+++ b/api/worksession/worksession.go
@@ -109,16 +109,6 @@ func ExtendWorkSession(ac *client.AlpaconClient, id string, req WorkSessionExten
 	return err
 }
 
-func ApproveWorkSession(ac *client.AlpaconClient, id string, req WorkSessionApproveRequest) error {
-	_, err := ac.SendPostRequest(utils.BuildURL(workSessionURL, path.Join(id, "approve"), nil), req)
-	return err
-}
-
-func RejectWorkSession(ac *client.AlpaconClient, id string) error {
-	_, err := ac.SendPostRequest(utils.BuildURL(workSessionURL, path.Join(id, "reject"), nil), struct{}{})
-	return err
-}
-
 func RevokeWorkSession(ac *client.AlpaconClient, id string) error {
 	_, err := ac.SendPostRequest(utils.BuildURL(workSessionURL, path.Join(id, "revoke"), nil), struct{}{})
 	return err

--- a/api/worksession/worksession_test.go
+++ b/api/worksession/worksession_test.go
@@ -193,19 +193,6 @@ func TestGetWorkSessionList_ScopesJoined(t *testing.T) {
 	assert.Equal(t, "command, websh, webftp", list[0].Scopes)
 }
 
-func TestRejectWorkSession(t *testing.T) {
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, http.MethodPost, r.Method)
-		assert.True(t, strings.HasSuffix(r.URL.Path, "ses-abc/reject/"))
-		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(WorkSession{ID: "ses-abc", Status: "rejected"})
-	}))
-	defer ts.Close()
-
-	err := RejectWorkSession(newTestClient(ts), "ses-abc")
-	assert.NoError(t, err)
-}
-
 func TestRevokeWorkSession(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodPost, r.Method)
@@ -229,48 +216,6 @@ func TestCancelWorkSession(t *testing.T) {
 	defer ts.Close()
 
 	err := CancelWorkSession(newTestClient(ts), "ses-abc")
-	assert.NoError(t, err)
-}
-
-func TestApproveWorkSession_NoAdjustments(t *testing.T) {
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, http.MethodPost, r.Method)
-		assert.True(t, strings.HasSuffix(r.URL.Path, "ses-abc/approve/"))
-
-		var req WorkSessionApproveRequest
-		assert.NoError(t, json.NewDecoder(r.Body).Decode(&req))
-		assert.Nil(t, req.AdjustedScopes)
-		assert.Nil(t, req.AdjustedServers)
-
-		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(WorkSession{ID: "ses-abc", Status: "approved"})
-	}))
-	defer ts.Close()
-
-	err := ApproveWorkSession(newTestClient(ts), "ses-abc", WorkSessionApproveRequest{})
-	assert.NoError(t, err)
-}
-
-func TestApproveWorkSession_WithAdjustments(t *testing.T) {
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, http.MethodPost, r.Method)
-		assert.True(t, strings.HasSuffix(r.URL.Path, "ses-abc/approve/"))
-
-		var req WorkSessionApproveRequest
-		assert.NoError(t, json.NewDecoder(r.Body).Decode(&req))
-		assert.Equal(t, []string{"command"}, req.AdjustedScopes)
-		assert.Equal(t, []string{"srv-uuid-1"}, req.AdjustedServers)
-
-		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(WorkSession{ID: "ses-abc", Status: "approved"})
-	}))
-	defer ts.Close()
-
-	req := WorkSessionApproveRequest{
-		AdjustedScopes:  []string{"command"},
-		AdjustedServers: []string{"srv-uuid-1"},
-	}
-	err := ApproveWorkSession(newTestClient(ts), "ses-abc", req)
 	assert.NoError(t, err)
 }
 

--- a/cmd/approval/approval.go
+++ b/cmd/approval/approval.go
@@ -27,7 +27,7 @@ Subcommands for tracking:
 		if err := cmd.Help(); err != nil {
 			return err
 		}
-		return errors.New("a subcommand is required. Use 'alpacon approval ls', 'alpacon approval describe', or 'alpacon approval cancel'. Approval and rejection happen in the Alpacon console (web). Run 'alpacon approval --help' for more information")
+		return errors.New("a subcommand is required. Use 'alpacon approval ls', 'alpacon approval describe', or 'alpacon approval cancel'. Approval and rejection happen in the Alpacon console (web) or Slack. Run 'alpacon approval --help' for more information")
 	},
 }
 

--- a/cmd/approval/approval.go
+++ b/cmd/approval/approval.go
@@ -27,7 +27,7 @@ Subcommands for tracking:
 		if err := cmd.Help(); err != nil {
 			return err
 		}
-		return errors.New("a subcommand is required. Use 'alpacon approval ls', 'alpacon approval describe', or 'alpacon approval cancel'. Approve and reject happen in the Alpacon console (web). Run 'alpacon approval --help' for more information")
+		return errors.New("a subcommand is required. Use 'alpacon approval ls', 'alpacon approval describe', or 'alpacon approval cancel'. Approval and rejection happen in the Alpacon console (web). Run 'alpacon approval --help' for more information")
 	},
 }
 

--- a/cmd/approval/approval_approve.go
+++ b/cmd/approval/approval_approve.go
@@ -12,7 +12,7 @@ import (
 // The subcommands remain registered so the message is discoverable and existing
 // scripts get an actionable, intentional exit instead of an "unknown command".
 const approveRejectExcludedMessage = "Approvals must be done in the Alpacon console (web), not the CLI. " +
-	"The CLI is an execution and request surface only; approve and reject happen out of band. " +
+	"The CLI is an execution and request surface only; approval and rejection happen out of band. " +
 	"Use 'alpacon approval ls' to track a request's status."
 
 var approvalApproveCmd = &cobra.Command{

--- a/cmd/approval/approval_guidance_test.go
+++ b/cmd/approval/approval_guidance_test.go
@@ -1,0 +1,39 @@
+package approval
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// consoleOnlySubcommands stay registered so a script calling them gets an
+// actionable exit, but ADR 0015 moved the action itself to the console, so the
+// no-subcommand guidance must never offer them as something to run.
+var consoleOnlySubcommands = map[string]bool{"approve": true, "reject": true}
+
+func TestApprovalGuidanceMatchesRegisteredSubcommands(t *testing.T) {
+	var help bytes.Buffer
+	ApprovalCmd.SetOut(&help)
+	ApprovalCmd.SetErr(&help)
+	t.Cleanup(func() {
+		ApprovalCmd.SetOut(nil)
+		ApprovalCmd.SetErr(nil)
+	})
+
+	err := ApprovalCmd.RunE(ApprovalCmd, nil)
+	require.Error(t, err)
+	guidance := err.Error()
+
+	for _, sub := range ApprovalCmd.Commands() {
+		name := sub.Name()
+		mention := fmt.Sprintf("'alpacon approval %s'", name)
+		if consoleOnlySubcommands[name] {
+			assert.NotContains(t, guidance, mention)
+			continue
+		}
+		assert.Contains(t, guidance, mention)
+	}
+}

--- a/cmd/worksession/worksession.go
+++ b/cmd/worksession/worksession.go
@@ -63,7 +63,7 @@ Run 'alpacon whoami' to check your WorkSession requirement and active session.`,
 		if err := cmd.Help(); err != nil {
 			return err
 		}
-		return errors.New("a subcommand is required. Use 'alpacon work-session ls', 'alpacon work-session create', 'alpacon work-session describe', 'alpacon work-session use', 'alpacon work-session current', 'alpacon work-session activate', 'alpacon work-session complete', 'alpacon work-session extend', 'alpacon work-session update', 'alpacon work-session approve', 'alpacon work-session reject', 'alpacon work-session revoke', 'alpacon work-session cancel', 'alpacon work-session timeline', or 'alpacon work-session recording'. Run 'alpacon work-session --help' for more information")
+		return errors.New("a subcommand is required. Use 'alpacon work-session ls', 'alpacon work-session create', 'alpacon work-session describe', 'alpacon work-session use', 'alpacon work-session current', 'alpacon work-session activate', 'alpacon work-session complete', 'alpacon work-session extend', 'alpacon work-session update', 'alpacon work-session revoke', 'alpacon work-session cancel', 'alpacon work-session timeline', or 'alpacon work-session recording'. Approve and reject happen in the Alpacon console (web). Run 'alpacon work-session --help' for more information")
 	},
 }
 

--- a/cmd/worksession/worksession.go
+++ b/cmd/worksession/worksession.go
@@ -63,7 +63,7 @@ Run 'alpacon whoami' to check your WorkSession requirement and active session.`,
 		if err := cmd.Help(); err != nil {
 			return err
 		}
-		return errors.New("a subcommand is required. Use 'alpacon work-session ls', 'alpacon work-session create', 'alpacon work-session describe', 'alpacon work-session use', 'alpacon work-session current', 'alpacon work-session activate', 'alpacon work-session complete', 'alpacon work-session extend', 'alpacon work-session update', 'alpacon work-session revoke', 'alpacon work-session cancel', 'alpacon work-session timeline', or 'alpacon work-session recording'. Approve and reject happen in the Alpacon console (web). Run 'alpacon work-session --help' for more information")
+		return errors.New("a subcommand is required. Use 'alpacon work-session ls', 'alpacon work-session create', 'alpacon work-session describe', 'alpacon work-session use', 'alpacon work-session current', 'alpacon work-session activate', 'alpacon work-session complete', 'alpacon work-session extend', 'alpacon work-session update', 'alpacon work-session revoke', 'alpacon work-session cancel', 'alpacon work-session timeline', or 'alpacon work-session recording'. Approval and rejection happen in the Alpacon console (web). Run 'alpacon work-session --help' for more information")
 	},
 }
 

--- a/cmd/worksession/worksession.go
+++ b/cmd/worksession/worksession.go
@@ -63,7 +63,7 @@ Run 'alpacon whoami' to check your WorkSession requirement and active session.`,
 		if err := cmd.Help(); err != nil {
 			return err
 		}
-		return errors.New("a subcommand is required. Use 'alpacon work-session ls', 'alpacon work-session create', 'alpacon work-session describe', 'alpacon work-session use', 'alpacon work-session current', 'alpacon work-session activate', 'alpacon work-session complete', 'alpacon work-session extend', 'alpacon work-session update', 'alpacon work-session revoke', 'alpacon work-session cancel', 'alpacon work-session timeline', or 'alpacon work-session recording'. Approval and rejection happen in the Alpacon console (web). Run 'alpacon work-session --help' for more information")
+		return errors.New("a subcommand is required. Use 'alpacon work-session ls', 'alpacon work-session create', 'alpacon work-session describe', 'alpacon work-session use', 'alpacon work-session current', 'alpacon work-session activate', 'alpacon work-session complete', 'alpacon work-session extend', 'alpacon work-session update', 'alpacon work-session revoke', 'alpacon work-session cancel', 'alpacon work-session timeline', or 'alpacon work-session recording'. Approval and rejection happen in the Alpacon console (web) or Slack. Run 'alpacon work-session --help' for more information")
 	},
 }
 

--- a/cmd/worksession/worksession_approve.go
+++ b/cmd/worksession/worksession_approve.go
@@ -12,7 +12,7 @@ import (
 // subcommands stay registered so the message is discoverable and existing scripts
 // get an intentional, actionable exit instead of an "unknown command".
 const approveRejectExcludedMessage = "Approvals must be done in the Alpacon console (web), not the CLI. " +
-	"The CLI is an execution and request surface only; approve and reject happen out of band. " +
+	"The CLI is an execution and request surface only; approval and rejection happen out of band. " +
 	"Use 'alpacon work-session ls' to track a session's status."
 
 var workSessionApproveCmd = &cobra.Command{

--- a/cmd/worksession/worksession_guidance_test.go
+++ b/cmd/worksession/worksession_guidance_test.go
@@ -1,0 +1,39 @@
+package worksession
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// consoleOnlySubcommands stay registered so a script calling them gets an
+// actionable exit, but ADR 0015 moved the action itself to the console, so the
+// no-subcommand guidance must never offer them as something to run.
+var consoleOnlySubcommands = map[string]bool{"approve": true, "reject": true}
+
+func TestWorkSessionGuidanceMatchesRegisteredSubcommands(t *testing.T) {
+	var help bytes.Buffer
+	WorkSessionCmd.SetOut(&help)
+	WorkSessionCmd.SetErr(&help)
+	t.Cleanup(func() {
+		WorkSessionCmd.SetOut(nil)
+		WorkSessionCmd.SetErr(nil)
+	})
+
+	err := WorkSessionCmd.RunE(WorkSessionCmd, nil)
+	require.Error(t, err)
+	guidance := err.Error()
+
+	for _, sub := range WorkSessionCmd.Commands() {
+		name := sub.Name()
+		mention := fmt.Sprintf("'alpacon work-session %s'", name)
+		if consoleOnlySubcommands[name] {
+			assert.NotContains(t, guidance, mention)
+			continue
+		}
+		assert.Contains(t, guidance, mention)
+	}
+}


### PR DESCRIPTION
## Background

ADR 0015 made the CLI an execution and request surface only. Approval and rejection happen out of band in the Alpacon console, and the server refuses both from the CLI credential channel, so `6d0c754` stopped the command layer from calling the API: `alpacon approval approve|reject` and `alpacon work-session approve|reject` print guidance and exit 1 without a request.

That left four API-layer functions with no caller outside their own tests—`ApproveRequest`, `RejectRequest`, `ApproveWorkSession`, `RejectWorkSession`. `deadcode` reports all four as unreachable from `main`.

`#221` kept them on the grounds that the 403-propagation tests document the server behavior. Reading the tests, they do not. `TestApproveRequest_403PropagatesError` stands up an `httptest` server that the test itself tells to return 403, so what it pins is that a `detail` body reaches the caller as an error—work that lives in `client.SendPostRequest`, not in the deleted function. `TestCancelRequest_403PropagatesError` asserts the same thing through `CancelRequest`, which is still reachable, and the reason the server refuses CLI approvals is already written down at `cmd/approval/approval_approve.go:8-13`.

## Changes

### Dead clients and their tests are gone

The four functions, their payload types (`ApproveOptions`, `WorkSessionApproveRequest`—used by nothing else), and the eight tests that only covered them. The remaining six of those tests checked the shape of a request nobody builds any more: the POST method, an `/approve/` or `/reject/` URL suffix, and the two adjustment fields in the body.

The shared URL constants stay: `approvalURL` and `workSessionURL` are read by `ls`, `describe`, `cancel`, `extend`, and the rest.

### The two command groups now answer the same way

Separate from the deletion, `cmd/worksession/worksession.go:66` listed `alpacon work-session approve` and `alpacon work-session reject` among the subcommands to use, though both exit 1. `cmd/approval/approval.go:30` already leaves them out and points at the console instead, so that closing sentence now appears in both groups and they read alike.

Copilot flagged the sentence it had carried since `6d0c754`: "Approve and reject" put bare verbs in the subject slot. Both groups now say "Approval and rejection happen in the Alpacon console (web) or Slack."

The subcommands stay registered. `6d0c754` kept them so a script that calls one gets an actionable exit instead of "unknown command", and only the guidance text changes.

This drift dates to `6d0c754` rather than to the deletion, but it is the same ADR 0015 leftover and reads better reviewed together.

### Review follow-ups

Three commits were added after review.

`2d51ec6` finishes the noun-form fix. `915017e` had changed only the two group-level fallbacks, leaving `approveRejectExcludedMessage` in both packages still reading "approve and reject happen out of band". That constant is the more visible of the two: the fallback prints only for a bare group command, while the constant prints on every `approve` or `reject` invocation.

`409e5cd` names Slack alongside the web console. The new closing sentence said "in the Alpacon console (web)" while the `Long` text above it says "in the Alpacon console (web) or Slack", so the two read as different guidance.

`0ee95e3` adds `TestWorkSessionGuidanceMatchesRegisteredSubcommands` and `TestApprovalGuidanceMatchesRegisteredSubcommands`. Each walks the group's registered subcommands and asserts that `approve` and `reject` are absent from the guidance while every other command is named, so the drift this PR fixes cannot return unnoticed. Both directions were seen failing first: putting `approve` back into the list, and dropping `revoke` from it.

Two review points are deliberately not in this PR. The hand-maintained enumeration is the root cause of the drift, but it spans 23 group commands under `cmd/` and is tracked in #385. The duplicated `approveRejectExcludedMessage` constant is left in place under the rule of three—two copies do not yet justify a shared home, and a third group needing the same message is the trigger to extract it.

## Testing

No user-visible behavior changes from the deletion. `cmd/` carries guidance text changes and nothing else.

- `go build -v .`, `go vet ./...`: exit 0.
- `go test -race ./...`: no `FAIL`; `api/approval`, `api/worksession`, `cmd/approval`, and `cmd/worksession` all `ok`.
- `golangci-lint run ./...`: `0 issues.` The `unused` linter is enabled, so an orphaned symbol would have been caught.
- `deadcode` reports nothing on this branch. On the pre-deletion commit the same command reports exactly the four functions, so the empty output is the tool working rather than the tool failing.
- The built binary still exits 1 with guidance for `approval approve`, `approval reject`, `work-session approve`, and `work-session reject`, and each now prints "approval and rejection happen out of band". `alpacon work-session` and `alpacon approval` with no subcommand close with the console-or-Slack sentence.

Closes #381
