### PR TITLE
fix(cp): reject conflicting inline users instead of silently using the first

### DIFF
--- a/cmd/ftp/cp.go
+++ b/cmd/ftp/cp.go
@@ -77,7 +77,7 @@ Requires an active WorkSession when using Browser login (Auth0); Token auth (API
 
 		username, err := normalizeArgs(args, username)
 		if err != nil {
-			utils.CliErrorWithExit("%s", err.Error())
+			utils.CliErrorWithExit("%v", err)
 			return
 		}
 

--- a/cmd/ftp/cp.go
+++ b/cmd/ftp/cp.go
@@ -21,6 +21,7 @@ var CpCmd = &cobra.Command{
 	Long: `Copy files between your local machine and a remote server.
 Supports SSH-like user@host:path syntax for specifying the username inline with the remote path.
 Remote paths use the format [USER@]SERVER:/path.
+All inline users must name the same user; -u overrides them all.
 
 Use --work-session to attach this transfer to a specific work-session. This
 overrides the workspace's active work-session set via 'alpacon work-session use'.
@@ -74,7 +75,11 @@ Requires an active WorkSession when using Browser login (Auth0); Token auth (API
 			return
 		}
 
-		username = normalizeArgs(args, username)
+		username, err := normalizeArgs(args, username)
+		if err != nil {
+			utils.CliErrorWithExit("%s", err.Error())
+			return
+		}
 
 		sources := args[:len(args)-1]
 		dest := args[len(args)-1]
@@ -199,17 +204,28 @@ func isLocalPaths(paths []string) bool {
 	return true
 }
 
-// normalizeArgs strips inline user prefixes in place and resolves the username:
-// the -u flag wins, then the first inline user.
-func normalizeArgs(args []string, username string) string {
-	for i, arg := range args {
-		rewritten, user := stripUserPrefix(arg)
-		if username == "" {
-			username = user
+// normalizeArgs resolves the username, then strips the inline user prefixes in
+// place: the -u flag wins and inline users are ignored; without it the inline
+// users must agree, and two different ones are an error. Resolution finishes
+// before the first rewrite, so a rejected argument list is left untouched.
+func normalizeArgs(args []string, username string) (string, error) {
+	if username == "" {
+		for _, arg := range args {
+			_, user := stripUserPrefix(arg)
+			if user == "" {
+				continue
+			}
+			if username == "" {
+				username = user
+			} else if username != user {
+				return "", fmt.Errorf("all arguments must use the same user (got %q and %q); use -u USER to apply one user to every path", username, user)
+			}
 		}
-		args[i] = rewritten
 	}
-	return username
+	for i, arg := range args {
+		args[i], _ = stripUserPrefix(arg)
+	}
+	return username, nil
 }
 
 // stripUserPrefix rewrites user@host:path as host:path, handing back the user.

--- a/cmd/ftp/cp_test.go
+++ b/cmd/ftp/cp_test.go
@@ -272,8 +272,9 @@ func TestCpCommandSSHParsing(t *testing.T) {
 			args := make([]string, len(tt.args))
 			copy(args, tt.args)
 
-			username := normalizeArgs(args, "")
+			username, err := normalizeArgs(args, "")
 
+			assert.NoError(t, err)
 			assert.Equal(t, tt.expectedArgs, args)
 			assert.Equal(t, tt.expectedUser, username)
 		})
@@ -371,26 +372,53 @@ func TestStripUserPrefix(t *testing.T) {
 
 func TestNormalizeArgsUsername(t *testing.T) {
 	tests := []struct {
-		name     string
-		args     []string
-		flagUser string
-		wantUser string
+		name         string
+		args         []string
+		flagUser     string
+		wantUser     string
+		wantArgs     []string
+		wantErrUsers []string
 	}{
 		{
 			name:     "the -u flag wins over an inline user",
 			args:     []string{"test.txt", "alice@myserver:/tmp/"},
 			flagUser: "carol",
 			wantUser: "carol",
+			wantArgs: []string{"test.txt", "myserver:/tmp/"},
 		},
 		{
-			name:     "the first inline user wins",
+			name:     "the -u flag suppresses an inline user conflict",
 			args:     []string{"alice@myserver:/tmp/f", "bob@myserver:/tmp/g"},
+			flagUser: "carol",
+			wantUser: "carol",
+			wantArgs: []string{"myserver:/tmp/f", "myserver:/tmp/g"},
+		},
+		{
+			name:     "agreeing inline users resolve to that user",
+			args:     []string{"alice@myserver:/tmp/f", "alice@other:/tmp/g"},
 			wantUser: "alice",
+			wantArgs: []string{"myserver:/tmp/f", "other:/tmp/g"},
+		},
+		{
+			name:         "conflicting inline users are rejected",
+			args:         []string{"alice@myserver:/tmp/f", "bob@myserver:/tmp/g"},
+			wantArgs:     []string{"alice@myserver:/tmp/f", "bob@myserver:/tmp/g"},
+			wantErrUsers: []string{"alice", "bob"},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.wantUser, normalizeArgs(tt.args, tt.flagUser))
+			user, err := normalizeArgs(tt.args, tt.flagUser)
+			if len(tt.wantErrUsers) > 0 {
+				for _, u := range tt.wantErrUsers {
+					assert.ErrorContains(t, err, u)
+				}
+				assert.Equal(t, tt.wantArgs, tt.args)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, tt.wantUser, user)
+			assert.Equal(t, tt.wantArgs, tt.args)
 		})
 	}
 }


### PR DESCRIPTION
## Background

`cp` is the one command that takes several `[USER@]SERVER:/path` arguments at once, so it is the one command where two arguments can name two different inline users. `normalizeArgs` walked the arguments, took the first inline user it saw, and ignored every later one. `alpacon cp alice@srv:/f bob@srv:/g ./` transferred both files as alice and printed nothing about bob.

The username is not a display detail. It is the identity the agent performs the file operation under and records it under, so a silently dropped second user means the transfer ran—and was audited—as somebody the caller did not name. First-wins is a reasonable rule for a formatting flag; for an identity it is a wrong answer delivered as a successful one.

`websh`, `exec`, and `edit` also strip an inline user, but each takes a single target, so none of them can reach this state. The duplication of the strip itself across those four call sites is #369 and is untouched here.

## Changes

### Two different inline users are now an error

`normalizeArgs` returns an error naming both users when two arguments disagree, and `cp` exits before it builds an API client, so nothing reaches the network. This mirrors the same-server guard already in `api/ftp/ftp.go:807`—`all sources must be on the same server (got %q and %q)`—which is the closest existing precedent in the same command's path. The two messages are deliberately not extracted into a shared helper: they sit in different layers and say different things, and the shared part is a sentence shape rather than a rule.

`-u` is unchanged and still wins. With the flag set, inline users are not read at all, so a mismatch among them cannot produce an error—`cp -u carol alice@srv:/f bob@srv:/g ./` runs as carol.

### Resolution finishes before the first rewrite

`normalizeArgs` strips the inline prefixes in place, which is how `args` reaches `validatePaths` as plain `SERVER:/path`. Doing that in the same loop as the resolution left a rejected argument list half-stripped: the first argument rewritten, the rest as the caller typed them. The only caller exits immediately, so nothing is broken today, but the function's own comment promises the strip and a future caller that kept going would inherit the mess.

Resolution is now its own pass ahead of the rewrite pass, so a rejected list comes back exactly as it arrived.

### The error names the way out

`use -u USER to apply one user to every path` is appended to the message. The override rule was only written in the `--help` text, which is not what the caller is reading at the moment the error appears.

That `--help` text now states the rule at all. The old text described the single-path form and said nothing about what several inline users mean together, so it is a line short of the behavior this PR introduces:

```
All inline users must name the same user; -u overrides them all.
```

## Testing

`TestNormalizeArgsUsername` covers four cases: `-u` beating an inline user, `-u` suppressing a conflict, agreeing inline users resolving to that user, and a conflict rejected. Each case also asserts the resulting `args`, which is what pins the rewrite itself rather than only the returned username.

Every assertion was seen red against a mutated target.

Removing the conflict check, so the first user wins silently again—the original bug:

```
--- FAIL: TestNormalizeArgsUsername/conflicting_inline_users_are_rejected
    Error: An error is expected but got nil.
```

Returning early when `-u` is set, on the theory that inline users need not be read:

```
--- FAIL: TestNormalizeArgsUsername/the_-u_flag_wins_over_an_inline_user
    Error: Not equal:
        expected: []string{"test.txt", "myserver:/tmp/"}
        actual  : []string{"test.txt", "alice@myserver:/tmp/"}
```

Folding resolution back into the rewrite loop:

```
--- FAIL: TestNormalizeArgsUsername/conflicting_inline_users_are_rejected
    Error: Not equal:
        expected: []string{"alice@myserver:/tmp/f", "bob@myserver:/tmp/g"}
        actual  : []string{"myserver:/tmp/f", "bob@myserver:/tmp/g"}
```

Suite and linters on the final diff:

- `go test -race ./...`: no `FAIL`.
- `go vet ./...`: exit 0.
- `golangci-lint run ./...`: `0 issues.`

Checked by hand against a dev workspace server, with a real remote account:

- A conflict exits 1 with `Error: all arguments must use the same user (got "chaejisung" and "test-cjs"); use -u USER to apply one user to every path`. It prints before `Refreshing access token...`, so the exit happens ahead of any request.
- The same command with `-u` set passes the check and goes on to server lookup.
- An upload with agreeing inline users still succeeds: `Success: Uploaded [a.txt, b.txt] to <server>:/tmp/`.

One case is verified only as far as the parse. A download with two agreeing inline users clears the check and reaches `Downloading 2 files...`, then hangs without writing the files. That hang is not from this branch: a single-argument download hangs the same way, and so does a binary built from `main` at `9677582`. It is a dev-environment problem and is not investigated here.

Closes #372
