### PR TITLE
fix(server,login): sanitize the guide commands and the device code prompt

### DIFF
--- a/cmd/login.go
+++ b/cmd/login.go
@@ -530,9 +530,13 @@ func shouldFailOnProfileError(token string) bool {
 // printDeviceCodePrompt sanitizes the URL and the code before Blue and Bold go
 // on—the reverse order would strip the highlight along with the escapes. Both
 // come from the authorization server, and a person reads them off the screen.
+//
+// The line strip and not the block one: a URL and a device code are single
+// values, so a newline in either is the server writing its own line into a
+// prompt the CLI is supposed to own.
 func printDeviceCodePrompt(w io.Writer, verificationURI, userCode string) {
-	uri, uriAltered := utils.SanitizeTerminalBlock(verificationURI)
-	code, codeAltered := utils.SanitizeTerminalBlock(userCode)
+	uri, uriAltered := utils.SanitizeTerminalLine(verificationURI)
+	code, codeAltered := utils.SanitizeTerminalLine(userCode)
 	if uriAltered || codeAltered {
 		utils.WarnTerminalTextAltered(w, "")
 	}

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -132,9 +132,9 @@ with the saved target as the default. Non-interactive login requires a HOST or
 				utils.CliErrorWithExit("Device code request failed. %v", err)
 			}
 
-			printDeviceCodePrompt(os.Stderr, deviceCode.VerificationURIComplete, deviceCode.UserCode)
+			promptURI := printDeviceCodePrompt(os.Stderr, deviceCode.VerificationURIComplete, deviceCode.UserCode)
 			if !noBrowser {
-				utils.OpenBrowser(deviceCode.VerificationURIComplete)
+				utils.OpenBrowser(promptURI)
 			}
 
 			tokenRes, err := auth0.PollForToken(deviceCode, envInfo)
@@ -534,7 +534,12 @@ func shouldFailOnProfileError(token string) bool {
 // The line strip and not the block one: a URL and a device code are single
 // values, so a newline in either is the server writing its own line into a
 // prompt the CLI is supposed to own.
-func printDeviceCodePrompt(w io.Writer, verificationURI, userCode string) {
+//
+// It hands back the URL it printed, because that is the one the browser has to
+// be opened on. Opening the raw value would take the operator somewhere other
+// than the address they just read off the screen, which is the whole thing this
+// is here to prevent.
+func printDeviceCodePrompt(w io.Writer, verificationURI, userCode string) (printedURI string) {
 	uri, uriAltered := utils.SanitizeTerminalLine(verificationURI)
 	code, codeAltered := utils.SanitizeTerminalLine(userCode)
 	if uriAltered || codeAltered {
@@ -542,4 +547,5 @@ func printDeviceCodePrompt(w io.Writer, verificationURI, userCode string) {
 	}
 	_, _ = fmt.Fprintf(w, "\nPlease authenticate by visiting:\n%s\n\n", utils.Blue(uri))
 	_, _ = fmt.Fprintf(w, "Verification code: %s\n\n", utils.Bold(code))
+	return uri
 }

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -4,6 +4,7 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 	"os"
@@ -131,8 +132,7 @@ with the saved target as the default. Non-interactive login requires a HOST or
 				utils.CliErrorWithExit("Device code request failed. %v", err)
 			}
 
-			fmt.Fprintf(os.Stderr, "\nPlease authenticate by visiting:\n%s\n\n", utils.Blue(deviceCode.VerificationURIComplete))
-			fmt.Fprintf(os.Stderr, "Verification code: %s\n\n", utils.Bold(deviceCode.UserCode))
+			printDeviceCodePrompt(os.Stderr, deviceCode.VerificationURIComplete, deviceCode.UserCode)
 			if !noBrowser {
 				utils.OpenBrowser(deviceCode.VerificationURIComplete)
 			}
@@ -525,4 +525,17 @@ func verifyLoginLegacy(ac *client.AlpaconClient, token string) {
 // LoginAndSaveCredentials, so a failed preload is non-fatal.
 func shouldFailOnProfileError(token string) bool {
 	return token == ""
+}
+
+// printDeviceCodePrompt sanitizes the URL and the code before Blue and Bold go
+// on—the reverse order would strip the highlight along with the escapes. Both
+// come from the authorization server, and a person reads them off the screen.
+func printDeviceCodePrompt(w io.Writer, verificationURI, userCode string) {
+	uri, uriAltered := utils.SanitizeTerminalBlock(verificationURI)
+	code, codeAltered := utils.SanitizeTerminalBlock(userCode)
+	if uriAltered || codeAltered {
+		utils.WarnTerminalTextAltered(w, "")
+	}
+	_, _ = fmt.Fprintf(w, "\nPlease authenticate by visiting:\n%s\n\n", utils.Blue(uri))
+	_, _ = fmt.Fprintf(w, "Verification code: %s\n\n", utils.Bold(code))
 }

--- a/cmd/login_test.go
+++ b/cmd/login_test.go
@@ -854,12 +854,14 @@ func TestPrintDeviceCodePrompt(t *testing.T) {
 		userCode        string
 		wantContains    []string
 		wantWarning     bool
+		wantPrintedURI  string
 	}{
 		{
 			name:            "prints a clean pair without a warning",
 			verificationURI: "https://demo.alpacon.io/activate?code=ABCD-1234",
 			userCode:        "ABCD-1234",
 			wantContains:    []string{"https://demo.alpacon.io/activate?code=ABCD-1234", "ABCD-1234"},
+			wantPrintedURI:  "https://demo.alpacon.io/activate?code=ABCD-1234",
 		},
 		{
 			name:            "warns when the URL carried an escape",
@@ -867,6 +869,7 @@ func TestPrintDeviceCodePrompt(t *testing.T) {
 			userCode:        "ABCD-1234",
 			wantContains:    []string{"https://demo.alpacon.iohttps://evil.example.com"},
 			wantWarning:     true,
+			wantPrintedURI:  "https://demo.alpacon.iohttps://evil.example.com",
 		},
 		{
 			name:            "warns when the URL carried an injected line",
@@ -874,6 +877,7 @@ func TestPrintDeviceCodePrompt(t *testing.T) {
 			userCode:        "ABCD-1234",
 			wantContains:    []string{"https://demo.alpacon.ioVerification code: FAKE-0000"},
 			wantWarning:     true,
+			wantPrintedURI:  "https://demo.alpacon.ioVerification code: FAKE-0000",
 		},
 		{
 			name:            "warns when the code carried a bidi override",
@@ -881,14 +885,17 @@ func TestPrintDeviceCodePrompt(t *testing.T) {
 			userCode:        "ABCD\u202e-1234",
 			wantContains:    []string{"ABCD-1234"},
 			wantWarning:     true,
+			wantPrintedURI:  "https://demo.alpacon.io/activate",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var buf bytes.Buffer
-			printDeviceCodePrompt(&buf, tt.verificationURI, tt.userCode)
+			printedURI := printDeviceCodePrompt(&buf, tt.verificationURI, tt.userCode)
 
 			got := buf.String()
+			assert.Equal(t, tt.wantPrintedURI, printedURI)
+			assert.Contains(t, got, printedURI, "the browser must open the URL the operator was shown")
 			assert.NotContains(t, got, "\x1b[2K")
 			assert.NotContains(t, got, "\u202e")
 			for _, want := range tt.wantContains {

--- a/cmd/login_test.go
+++ b/cmd/login_test.go
@@ -869,6 +869,13 @@ func TestPrintDeviceCodePrompt(t *testing.T) {
 			wantWarning:     true,
 		},
 		{
+			name:            "warns when the URL carried an injected line",
+			verificationURI: "https://demo.alpacon.io\n\nVerification code: FAKE-0000",
+			userCode:        "ABCD-1234",
+			wantContains:    []string{"https://demo.alpacon.ioVerification code: FAKE-0000"},
+			wantWarning:     true,
+		},
+		{
 			name:            "warns when the code carried a bidi override",
 			verificationURI: "https://demo.alpacon.io/activate",
 			userCode:        "ABCD\u202e-1234",

--- a/cmd/login_test.go
+++ b/cmd/login_test.go
@@ -846,3 +846,52 @@ func writeLoginCommandTestConfig(t *testing.T, home string) {
 	require.NoError(t, err)
 	require.NoError(t, os.WriteFile(filepath.Join(cfgDir, "config.json"), data, 0600))
 }
+
+func TestPrintDeviceCodePrompt(t *testing.T) {
+	tests := []struct {
+		name            string
+		verificationURI string
+		userCode        string
+		wantContains    []string
+		wantWarning     bool
+	}{
+		{
+			name:            "prints a clean pair without a warning",
+			verificationURI: "https://demo.alpacon.io/activate?code=ABCD-1234",
+			userCode:        "ABCD-1234",
+			wantContains:    []string{"https://demo.alpacon.io/activate?code=ABCD-1234", "ABCD-1234"},
+		},
+		{
+			name:            "warns when the URL carried an escape",
+			verificationURI: "https://demo.alpacon.io\x1b[2Khttps://evil.example.com",
+			userCode:        "ABCD-1234",
+			wantContains:    []string{"https://demo.alpacon.iohttps://evil.example.com"},
+			wantWarning:     true,
+		},
+		{
+			name:            "warns when the code carried a bidi override",
+			verificationURI: "https://demo.alpacon.io/activate",
+			userCode:        "ABCD\u202e-1234",
+			wantContains:    []string{"ABCD-1234"},
+			wantWarning:     true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			printDeviceCodePrompt(&buf, tt.verificationURI, tt.userCode)
+
+			got := buf.String()
+			assert.NotContains(t, got, "\x1b[2K")
+			assert.NotContains(t, got, "\u202e")
+			for _, want := range tt.wantContains {
+				assert.Contains(t, got, want)
+			}
+			if tt.wantWarning {
+				assert.Contains(t, got, "Warning")
+			} else {
+				assert.NotContains(t, got, "Warning")
+			}
+		})
+	}
+}

--- a/cmd/server/server_create.go
+++ b/cmd/server/server_create.go
@@ -293,19 +293,30 @@ func printGuideVerifyFooter(stepNum int) {
 	fmt.Fprintln(os.Stderr, "  Your server will appear in the Servers list within moments.")
 }
 
+// printGuideCommand warns rather than withholds: the operator decides, and an
+// automation reading this guide keeps working. The warning goes above the
+// value, so a guide with several altered fields says which ones.
+func printGuideCommand(w io.Writer, s string) {
+	clean, altered := utils.SanitizeTerminalBlock(s)
+	if altered {
+		utils.WarnTerminalTextAltered(w, "  ")
+	}
+	_, _ = fmt.Fprintln(w, clean)
+}
+
 func displayGuideFromJSON(guide server.RegistrationMethodGuideJsonResponse) {
 	printGuideHeader(guide.PlatformLabel, guide.ServerName, guide.AlpaconURL)
 
 	fmt.Fprintln(os.Stderr, utils.Bold("Step 1 — Install Alpamon"))
 	fmt.Fprintln(os.Stderr)
 	for _, installCmd := range guide.InstallCommands {
-		fmt.Fprintln(os.Stderr, installCmd)
+		printGuideCommand(os.Stderr, installCmd)
 	}
 	fmt.Fprintln(os.Stderr)
 
 	fmt.Fprintln(os.Stderr, utils.Bold("Step 2 — Register"))
 	fmt.Fprintln(os.Stderr)
-	fmt.Fprintln(os.Stderr, guide.RegisterCommand)
+	printGuideCommand(os.Stderr, guide.RegisterCommand)
 	fmt.Fprintln(os.Stderr)
 
 	printGuideVerifyFooter(3)
@@ -316,31 +327,31 @@ func displayAnsibleGuideFromJSON(guide server.AnsibleGuideJsonResponse) {
 
 	fmt.Fprintln(os.Stderr, utils.Bold("Step 1 — Install Ansible collection"))
 	fmt.Fprintln(os.Stderr)
-	fmt.Fprintln(os.Stderr, guide.CollectionInstall)
+	printGuideCommand(os.Stderr, guide.CollectionInstall)
 	fmt.Fprintln(os.Stderr)
 
 	fmt.Fprintln(os.Stderr, utils.Bold("Step 2 — Configure inventory"))
 	fmt.Fprintln(os.Stderr)
 	fmt.Fprintln(os.Stderr, "Save as inventory.ini:")
 	fmt.Fprintln(os.Stderr)
-	fmt.Fprintln(os.Stderr, guide.InventorySnippet)
+	printGuideCommand(os.Stderr, guide.InventorySnippet)
 	fmt.Fprintln(os.Stderr)
 
 	fmt.Fprintln(os.Stderr, utils.Bold("Step 3 — Register"))
 	fmt.Fprintln(os.Stderr)
 	fmt.Fprintln(os.Stderr, utils.Bold("Option A — Bundled playbook (recommended):"))
 	fmt.Fprintln(os.Stderr)
-	fmt.Fprintln(os.Stderr, guide.RunCommandQuick)
+	printGuideCommand(os.Stderr, guide.RunCommandQuick)
 	fmt.Fprintln(os.Stderr)
 	fmt.Fprintln(os.Stderr, utils.Bold("Option B — Custom playbook:"))
 	fmt.Fprintln(os.Stderr)
 	fmt.Fprintln(os.Stderr, "Save as playbook.yml:")
 	fmt.Fprintln(os.Stderr)
-	fmt.Fprintln(os.Stderr, guide.PlaybookSnippet)
+	printGuideCommand(os.Stderr, guide.PlaybookSnippet)
 	fmt.Fprintln(os.Stderr)
 	fmt.Fprintln(os.Stderr, "Then run:")
 	fmt.Fprintln(os.Stderr)
-	fmt.Fprintln(os.Stderr, guide.RunCommandCustom)
+	printGuideCommand(os.Stderr, guide.RunCommandCustom)
 	fmt.Fprintln(os.Stderr)
 
 	printGuideVerifyFooter(4)

--- a/cmd/server/server_create_test.go
+++ b/cmd/server/server_create_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/alpacax/alpacon-cli/api/server"
+	"github.com/alpacax/alpacon-cli/pkg/testutil"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -34,4 +35,130 @@ func TestPrintGuideFields_StripsControlSequences(t *testing.T) {
 	assert.Equal(t, 3, strings.Count(got, "\n"), "one line per field")
 	assert.Contains(t, got, "  Platform : Debian\n")
 	assert.Contains(t, got, "  Server   : web-01URL      : https://evil.example.com\n")
+}
+
+func captureGuideStderr(t *testing.T, fn func()) string {
+	t.Helper()
+	_, stderr := testutil.CaptureOutput(t, fn)
+	return stderr
+}
+
+// The guide strings are what the operator pastes into a root shell, so the
+// warning has to name the command it is about—one banner at the top would not.
+func TestPrintGuideCommand(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       string
+		wantLine    string
+		wantWarning bool
+	}{
+		{
+			name:     "prints a clean command untouched and without a warning",
+			input:    "curl -fsSL https://demo.alpacon.io/i.sh | sudo bash",
+			wantLine: "curl -fsSL https://demo.alpacon.io/i.sh | sudo bash\n",
+		},
+		{
+			name:     "keeps a multi-line snippet pasteable",
+			input:    "[servers]\nweb-01 ansible_host=10.0.0.1",
+			wantLine: "[servers]\nweb-01 ansible_host=10.0.0.1\n",
+		},
+		{
+			name:        "warns above a command that carried an escape",
+			input:       "curl real.example.com\x1b[2Kcurl evil.example.com",
+			wantLine:    "curl real.example.comcurl evil.example.com\n",
+			wantWarning: true,
+		},
+		{
+			name:        "warns above a command that carried a bidi override",
+			input:       "curl \u202ereal.example.com",
+			wantLine:    "curl real.example.com\n",
+			wantWarning: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			printGuideCommand(&buf, tt.input)
+
+			got := buf.String()
+			assert.True(t, strings.HasSuffix(got, tt.wantLine), "the command must be the last thing printed: %q", got)
+			if tt.wantWarning {
+				assert.Contains(t, got, "Warning")
+			} else {
+				assert.NotContains(t, got, "Warning")
+			}
+		})
+	}
+}
+
+// Every command the guide echoes has to go through the same door; a new one
+// added to the response and printed straight would slip past unnoticed.
+func TestDisplayAnsibleGuideFromJSON_WarnsOnEveryAlteredField(t *testing.T) {
+	fields := []struct {
+		name  string
+		build func(string) server.AnsibleGuideJsonResponse
+	}{
+		{name: "CollectionInstall", build: func(v string) server.AnsibleGuideJsonResponse {
+			return server.AnsibleGuideJsonResponse{CollectionInstall: v}
+		}},
+		{name: "InventorySnippet", build: func(v string) server.AnsibleGuideJsonResponse {
+			return server.AnsibleGuideJsonResponse{InventorySnippet: v}
+		}},
+		{name: "RunCommandQuick", build: func(v string) server.AnsibleGuideJsonResponse {
+			return server.AnsibleGuideJsonResponse{RunCommandQuick: v}
+		}},
+		{name: "PlaybookSnippet", build: func(v string) server.AnsibleGuideJsonResponse {
+			return server.AnsibleGuideJsonResponse{PlaybookSnippet: v}
+		}},
+		{name: "RunCommandCustom", build: func(v string) server.AnsibleGuideJsonResponse {
+			return server.AnsibleGuideJsonResponse{RunCommandCustom: v}
+		}},
+	}
+	for _, f := range fields {
+		t.Run(f.name, func(t *testing.T) {
+			got := captureGuideStderr(t, func() {
+				displayAnsibleGuideFromJSON(f.build("ansible-galaxy install\x1b[2Kevil"))
+			})
+
+			assert.NotContains(t, got, "\x1b[2K")
+			assert.Contains(t, got, "Warning")
+		})
+	}
+}
+
+func TestDisplayGuideFromJSON_WarnsOnEveryAlteredField(t *testing.T) {
+	fields := []struct {
+		name  string
+		build func(string) server.RegistrationMethodGuideJsonResponse
+	}{
+		{name: "InstallCommands", build: func(v string) server.RegistrationMethodGuideJsonResponse {
+			return server.RegistrationMethodGuideJsonResponse{InstallCommands: []string{v}}
+		}},
+		{name: "RegisterCommand", build: func(v string) server.RegistrationMethodGuideJsonResponse {
+			return server.RegistrationMethodGuideJsonResponse{RegisterCommand: v}
+		}},
+	}
+	for _, f := range fields {
+		t.Run(f.name, func(t *testing.T) {
+			got := captureGuideStderr(t, func() {
+				displayGuideFromJSON(f.build("curl real.example.com\x1b[2Kevil"))
+			})
+
+			assert.NotContains(t, got, "\x1b[2K")
+			assert.Contains(t, got, "Warning")
+		})
+	}
+}
+
+func TestDisplayGuideFromJSON_StaysQuietOnACleanGuide(t *testing.T) {
+	got := captureGuideStderr(t, func() {
+		displayGuideFromJSON(server.RegistrationMethodGuideJsonResponse{
+			InstallCommands: []string{"curl -fsSL https://demo.alpacon.io/i.sh | sudo bash"},
+			RegisterCommand: "alpamon register --token abc",
+		})
+	})
+
+	assert.NotContains(t, got, "Warning")
+	assert.Contains(t, got, "curl -fsSL https://demo.alpacon.io/i.sh | sudo bash\n")
+	assert.Contains(t, got, "alpamon register --token abc\n")
 }

--- a/utils/log.go
+++ b/utils/log.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"strings"
 )
@@ -19,26 +20,29 @@ func reportCLIError() {
 	fmt.Fprintln(os.Stderr, "For issues, check the latest version or report on", gitIssueURL)
 }
 
-// cliMessage sanitizes a rendered message before it reaches the terminal:
-// client.parseAPIError puts the server's error detail into every one of these
-// helpers through %s, and the --output json envelope is the only path escaping
-// it today (escapeJSONControls).
+// cliMessage exists because client.parseAPIError puts the server's error detail
+// into every one of these helpers through %s; the --output json envelope is the
+// only path escaping it instead (escapeJSONControls).
 //
-// Per line, because SanitizeTerminalText drops \n and callers pass multi-line
-// guidance. Splitting after the format is rendered means a \n from the server
-// survives too, so the detail can add a line that looks like our own prefix.
-// Accepted: \r is still dropped, so it can only append below, never overwrite
-// what is already on screen.
+// Sanitizing after the format is rendered means a \n from the server survives
+// too, so the detail can add a line that looks like our own prefix. Accepted:
+// \r is still dropped, so it can only append below, never overwrite what is
+// already on screen.
 //
 // The arguments go through the same strip, so never hand a Color()-wrapped
 // value to a Cli* helper—it loses its highlight. Colorize after sanitizing,
 // the way cmd/server prints a registration key.
 func cliMessage(msg string, args ...any) string {
-	lines := strings.Split(fmt.Sprintf(msg, args...), "\n")
-	for i, line := range lines {
-		lines[i] = SanitizeTerminalText(line)
-	}
-	return strings.Join(lines, "\n")
+	clean, _ := SanitizeTerminalBlock(fmt.Sprintf(msg, args...))
+	return clean
+}
+
+// WarnTerminalTextAltered takes a writer and an indent because its callers
+// print outside the Cli* helpers and line the warning up with the value it is
+// about.
+func WarnTerminalTextAltered(w io.Writer, indent string) {
+	_, _ = fmt.Fprintf(w, "%s%s: control characters from the server were removed from the text below.\n",
+		indent, Yellow("Warning"))
 }
 
 // CliError handles all error messages in the CLI.

--- a/utils/log_test.go
+++ b/utils/log_test.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"bytes"
 	"os"
 	"strings"
 	"testing"
@@ -176,4 +177,26 @@ func TestCliDebug_BreaksTheLineOnlyWhileASpinnerRuns(t *testing.T) {
 
 		assert.True(t, strings.HasPrefix(stderr, "\n"), "the break must lead the write: %q", stderr)
 	})
+}
+
+func TestWarnTerminalTextAltered(t *testing.T) {
+	pinColor(t, false)
+
+	var buf bytes.Buffer
+	WarnTerminalTextAltered(&buf, "  ")
+
+	got := buf.String()
+	assert.True(t, strings.HasPrefix(got, "  Warning"), "the indent must come before the label: %q", got)
+	assert.True(t, strings.HasSuffix(got, "\n"), "the warning must end with a newline: %q", got)
+	assert.Equal(t, 1, strings.Count(got, "\n"))
+	assert.Contains(t, got, "control characters")
+}
+
+func TestWarnTerminalTextAltered_ColorsTheLabel(t *testing.T) {
+	pinColor(t, true)
+
+	var buf bytes.Buffer
+	WarnTerminalTextAltered(&buf, "")
+
+	assert.Contains(t, buf.String(), Yellow("Warning"))
 }

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -528,6 +528,15 @@ func SanitizeTerminalText(s string) string {
 	return StripControlChars(StripFormatAndANSI(s))
 }
 
+// SanitizeTerminalLine is SanitizeTerminalText plus the answer to whether it had
+// to take anything out. A \n counts as altered here: the caller's value is one
+// line by contract, so a newline in it is a forged line and not a line ending
+// worth keeping.
+func SanitizeTerminalLine(s string) (clean string, altered bool) {
+	clean = SanitizeTerminalText(s)
+	return clean, clean != s
+}
+
 // SanitizeTerminalBlock sanitizes per line, because SanitizeTerminalText drops
 // \n and callers print multi-line values the operator saves as files. CRLF is
 // folded first, or a server sending DOS line endings would report every value

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -528,6 +528,20 @@ func SanitizeTerminalText(s string) string {
 	return StripControlChars(StripFormatAndANSI(s))
 }
 
+// SanitizeTerminalBlock sanitizes per line, because SanitizeTerminalText drops
+// \n and callers print multi-line values the operator saves as files. CRLF is
+// folded first, or a server sending DOS line endings would report every value
+// as altered; a lone \r is still dropped, and does report altered.
+func SanitizeTerminalBlock(s string) (clean string, altered bool) {
+	normalized := strings.ReplaceAll(s, "\r\n", "\n")
+	lines := strings.Split(normalized, "\n")
+	for i, line := range lines {
+		lines[i] = SanitizeTerminalText(line)
+	}
+	clean = strings.Join(lines, "\n")
+	return clean, clean != normalized
+}
+
 // ProcessEditedData facilitates user modifications to original data,
 // formats it, supports editing via a temp file, compares the edited data against the original,
 // and parses it into JSON. If no changes are made, the update is aborted and an error is returned.

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -591,3 +591,60 @@ func TestRequirePositiveIntHelperProcess(t *testing.T) {
 	}
 	RequirePositiveInt("tail", 0)
 }
+
+func TestSanitizeTerminalBlock(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       string
+		wantClean   string
+		wantAltered bool
+	}{
+		{
+			name:      "keeps the line count of a clean block",
+			input:     "[servers]\nweb-01 ansible_host=10.0.0.1",
+			wantClean: "[servers]\nweb-01 ansible_host=10.0.0.1",
+		},
+		{
+			name:      "folds CRLF without reporting a change",
+			input:     "[servers]\r\nweb-01",
+			wantClean: "[servers]\nweb-01",
+		},
+		{
+			name:        "drops a lone carriage return and reports it",
+			input:       "curl real.example.com\rcurl evil.example.com",
+			wantClean:   "curl real.example.comcurl evil.example.com",
+			wantAltered: true,
+		},
+		{
+			name:        "drops a tab and reports it",
+			input:       "hosts:\n\tweb-01",
+			wantClean:   "hosts:\nweb-01",
+			wantAltered: true,
+		},
+		{
+			name:        "drops an ANSI escape and reports it",
+			input:       "curl real.example.com\x1b[2Kcurl evil.example.com",
+			wantClean:   "curl real.example.comcurl evil.example.com",
+			wantAltered: true,
+		},
+		{
+			name:        "drops a bidi override and reports it",
+			input:       "curl \u202ereal.example.com",
+			wantClean:   "curl real.example.com",
+			wantAltered: true,
+		},
+		{
+			name:      "reports nothing for an empty value",
+			input:     "",
+			wantClean: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clean, altered := SanitizeTerminalBlock(tt.input)
+
+			assert.Equal(t, tt.wantClean, clean)
+			assert.Equal(t, tt.wantAltered, altered)
+		})
+	}
+}

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -592,6 +592,58 @@ func TestRequirePositiveIntHelperProcess(t *testing.T) {
 	RequirePositiveInt("tail", 0)
 }
 
+func TestSanitizeTerminalLine(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       string
+		wantClean   string
+		wantAltered bool
+	}{
+		{
+			name:      "leaves a clean value alone",
+			input:     "https://demo.alpacon.io/activate?code=ABCD-1234",
+			wantClean: "https://demo.alpacon.io/activate?code=ABCD-1234",
+		},
+		{
+			name:        "drops an injected newline and reports it",
+			input:       "https://demo.alpacon.io\n\nVerification code: FAKE-0000",
+			wantClean:   "https://demo.alpacon.ioVerification code: FAKE-0000",
+			wantAltered: true,
+		},
+		{
+			name:        "drops a CRLF and reports it",
+			input:       "https://demo.alpacon.io\r\nVerification code: FAKE-0000",
+			wantClean:   "https://demo.alpacon.ioVerification code: FAKE-0000",
+			wantAltered: true,
+		},
+		{
+			name:        "drops an ANSI escape and reports it",
+			input:       "https://demo.alpacon.io\x1b[2Khttps://evil.example.com",
+			wantClean:   "https://demo.alpacon.iohttps://evil.example.com",
+			wantAltered: true,
+		},
+		{
+			name:        "drops a bidi override and reports it",
+			input:       "ABCD\u202e-1234",
+			wantClean:   "ABCD-1234",
+			wantAltered: true,
+		},
+		{
+			name:      "reports nothing for an empty value",
+			input:     "",
+			wantClean: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clean, altered := SanitizeTerminalLine(tt.input)
+
+			assert.Equal(t, tt.wantClean, clean)
+			assert.Equal(t, tt.wantAltered, altered)
+		})
+	}
+}
+
 func TestSanitizeTerminalBlock(t *testing.T) {
 	tests := []struct {
 		name        string


### PR DESCRIPTION
## Background

`alpacon server create` finishes by printing an installation guide, and the guide is a list of commands the operator is told to paste into a root shell. Every one of those commands comes from the server verbatim. `printGuideFields` already sanitized the three header values—platform, server name, URL—because a newline in one of them forges a field line, but the commands underneath went to the terminal untouched.

That is the wrong way round. A header field being forged is a display problem; a command being forged is the operator running something they did not read. An escape sequence inside `RegisterCommand` can erase what was drawn and leave a different command on screen while the real one sits in the paste buffer, and this is the one screen in the CLI where the operator has been explicitly instructed to copy what they see and run it as root.

The device flow prints the same kind of thing. `alpacon login` shows a verification URL and a code, both handed over by the authorization server, both read off the screen by a person who is about to authenticate against that URL. They also went out unsanitized.

This is the last of the sanitize series—#324, #359, #364 covered the exec result lines, the `NextAction` fields, and the token choices.

## Changes

### `SanitizeTerminalBlock` in `utils/utils.go`

`SanitizeTerminalText` strips a single line and drops `\n` on the way. `cliMessage` already worked around that by splitting on `\n` and sanitizing each line, because callers pass multi-line guidance. The guide needs the same split and one thing more: whether anything was actually removed, so the caller can say so instead of silently handing over a rewritten command.

```go
func SanitizeTerminalBlock(s string) (clean string, altered bool)
```

CRLF is folded before the comparison. Without that fold, a server that ends its lines the DOS way reports every value as altered and the warning becomes permanent noise that means nothing. A lone `\r` is still dropped and still reports `altered`—it returns the cursor to the start of the line, which is exactly how one command is made to look like another.

`cliMessage` now calls it and discards the flag. Its output is byte for byte what it was: a trailing `\r` inside a split line was already being stripped by `StripControlChars`.

### `SanitizeTerminalLine` in `utils/utils.go`

The sibling for a value that is one line by contract. `SanitizeTerminalText` plus the same flag, comparing against the raw original:

```go
func SanitizeTerminalLine(s string) (clean string, altered bool)
```

No CRLF fold here, deliberately. The block sanitizer forgives a CRLF because a multi-line value may legitimately end its lines the DOS way; a single-line field has no such case, so a CRLF in one is injection and reports `altered` like any other removal.

### `WarnTerminalTextAltered` in `utils/log.go`

One wording, shared by both callers:

```
Warning: control characters from the server were removed from the text below.
```

It takes an `io.Writer` and an indent because these callers print outside the `Cli*` helpers and line the warning up with the value it is about—`"  "` for the guide, `""` for the login prompt.

### Seven guide fields go through `printGuideCommand`

`cmd/server/server_create.go:296`. Covers `InstallCommands`, `RegisterCommand`, `CollectionInstall`, `InventorySnippet`, `RunCommandQuick`, `PlaybookSnippet`, and `RunCommandCustom`—every value either `displayGuideFromJSON` or `displayAnsibleGuideFromJSON` echoes.

Warned rather than withheld. The operator is the one deciding whether to run the command, and an automation reading this guide keeps working instead of finding a field gone. The warning sits above the value rather than at the top of the guide, so a response with several altered fields says which ones were rewritten.

This is the block sanitizer and not `SanitizeTerminalText` because `InventorySnippet` and `PlaybookSnippet` are multi-line files the operator saves as `inventory.ini` and `playbook.yml`. The one-line strip would drop the newlines and the snippets would stop being pasteable.

### The device code prompt goes through `printDeviceCodePrompt`

`cmd/login.go:530`. Sanitizes the URL and the code, warns once above the pair if either changed, and only then applies `Blue` and `Bold`. That order matters: handing a `Color()`-wrapped value to the strip takes the highlight out along with the escapes. One warning covers both values, because they are printed as a single prompt and the operator acts on them together.

This is the line strip, not the block one. A newline is legitimate content in a playbook snippet and forgery in a prompt field: with the block sanitizer a server could put one in the URL and write its own line into a prompt the CLI is supposed to own, and the newline would survive the strip so nothing would warn.

The function returns the URL it printed, and the call site opens that one:

```go
promptURI := printDeviceCodePrompt(os.Stderr, deviceCode.VerificationURIComplete, deviceCode.UserCode)
if !noBrowser {
	utils.OpenBrowser(promptURI)
}
```

Sanitizing the display while handing the browser the raw value would be the same substitution wearing a different hat—one address on screen, another one opened, with a warning above the prompt claiming the value had been cleaned. Returning it rather than sanitizing twice leaves one value and no way to reach for the raw one by accident.

## Safety

| Path | Before | After |
|---|---|---|
| Guide header fields | sanitized, silent | unchanged |
| Guide commands and snippets | printed verbatim | sanitized, warned when changed |
| Device flow URL and code | printed verbatim | sanitized as single lines, warned when changed |
| Browser opened by the device flow | raw URL from the response | the same URL the prompt printed |
| `Cli*` messages | sanitized per line, silent | unchanged output, now through the shared helper |

Nothing is withheld and nothing exits non-zero. The change is that a rewritten value is announced instead of passing as genuine.

The two callers each do sanitize-then-warn-then-print, which is close enough to look like a duplicate. It was left as two: they differ in indent, in value count, and in whether a color wraps the result, so the only genuinely shared part is the warning wording—and that is what `WarnTerminalTextAltered` extracts.

## Testing

Every new test was seen red against a mutated target.

`printGuideCommand` printing its argument raw, which is the original bug:

```
--- FAIL: TestPrintGuideCommand/warns_above_a_command_that_carried_an_escape
    Error:    Should be true
    Messages: the command must be the last thing printed: "curl real.example.com\x1b[2Kcurl evil.example.com\n"
    Error:    "curl real.example.com\x1b[2Kcurl evil.example.com\n" does not contain "Warning"
```

`SanitizeTerminalBlock` without the CRLF fold:

```
--- FAIL: TestSanitizeTerminalBlock/folds_CRLF_without_reporting_a_change
    Error:    Not equal:
              expected: false
              actual  : true
```

`printDeviceCodePrompt` on the block sanitizer, which is what let a newline in the URL forge a second prompt line:

```
--- FAIL: TestPrintDeviceCodePrompt/warns_when_the_URL_carried_an_injected_line
    Error: "\nPlease authenticate by visiting:\nhttps://demo.alpacon.io\n\nVerification code: FAKE-0000\n\nVerification code: ABCD-1234\n\n" does not contain "Warning"
```

`printDeviceCodePrompt` with the warning suppressed:

```
--- FAIL: TestPrintDeviceCodePrompt/warns_when_the_URL_carried_an_escape
    Error: "\nPlease authenticate by visiting:\nhttps://demo.alpacon.iohttps://evil.example.com\n\nVerification code: ABCD-1234\n\n" does not contain "Warning"
```

`printDeviceCodePrompt` returning its raw argument instead of the printed one, which is what let the browser open a different address than the screen showed:

```
--- FAIL: TestPrintDeviceCodePrompt/warns_when_the_URL_carried_an_escape
    Error: Not equal:
           expected: "https://demo.alpacon.iohttps://evil.example.com"
           actual  : "https://demo.alpacon.io\x1b[2Khttps://evil.example.com"
```

`TestDisplayGuideFromJSON_WarnsOnEveryAlteredField` and `TestDisplayAnsibleGuideFromJSON_WarnsOnEveryAlteredField` drive the two display functions once per field, so a field added to the response later and printed straight fails the table rather than slipping past. `TestDisplayGuideFromJSON_StaysQuietOnACleanGuide` pins the other direction: an untouched guide prints exactly what it did before, with no warning.

Suite and linters on the final diff:

- `go test -race ./...`: no `FAIL`.
- `go vet ./...`: exit 0.
- `golangci-lint run ./...`: `0 issues.`

The four other `OpenBrowser` call sites—`api/mfa/mfa.go` (two), `api/event/sudolistener.go`, and the two workspace update commands—print their URL raw and open that same raw value, so none of them shows one address and opens another. They are unsanitized output paths in their own right and this branch does not touch them; that is a separate fix.

A newline inside a guide command or snippet is not warned about, on purpose. Those values are genuinely multi-line—the operator saves two of them as `inventory.ini` and `playbook.yml`—so a newline there cannot be told apart from content the server meant to send. The single-line contract is what makes the device flow different.

Not verified against a live workspace. The altered-value paths need a server that returns control characters in the guide response, which no dev workspace does, so they are covered by the unit tests only.

Closes #360
