### PR TITLE
fix(exec): hint on a sudo denial that carries no code

### DIFF
--- a/cmd/exec/run.go
+++ b/cmd/exec/run.go
@@ -25,6 +25,13 @@ import (
 // command whose own output prints "(SUDO_RISK_DENIED)" from forging a hint.
 const sudoDenialLinePrefix = "Alpacon denied this sudo command ("
 
+// sudoDenialCodelessLine is the denial line the agent emits with no code to
+// name: alpacon_approval.c with an empty error_code_buf, pam_alpamon.c with
+// code[0] == '\0'. Its own literal rather than sudoDenialLinePrefix with an
+// empty slot—the sanitizer rejects a bad code whole, so the parentheses go with
+// it and no empty-slot form ever reaches the terminal.
+const sudoDenialCodelessLine = "Alpacon denied this sudo command."
+
 // sudoPresenceRequiredCode is the one denial code the CLI resolves in-flow (an
 // MFA step-up). The hint table and hasSudoPresenceDenial both name it from
 // here, so renaming it cannot leave one of them behind and silently stop the
@@ -242,6 +249,9 @@ func isSanitizedDenialCode(code string) bool {
 // on its own release train and nothing enforces this table's sync with
 // alpacon-server utils/error_codes.py, so returning "" for one would leave the
 // next drift invisible until someone reported a bare denial line.
+//
+// A denial carrying no code gets a last, thinner hint: without a category from
+// the server there is only the console to point at.
 func sudoDenialHint(output string) string {
 	for _, h := range sudoDenialHints {
 		if denialCodePresent(output, h.code) {
@@ -252,6 +262,15 @@ func sudoDenialHint(output string) string {
 		return denialHintLine(fmt.Sprintf(
 			"sudo was denied (%s). This build carries no guidance for that code—the server may be newer than the CLI.\n"+
 				"Read the denial in the Alpacon console (web), and update the CLI so a later run explains it.\n", code))
+	}
+	// No code slot to anchor on, so a command printing the same sentence in its own
+	// output gets the hint too. Accepted: this branch only prints a fixed line—a
+	// forged match reaches no step-up, no --wait loop, and echoes nothing the
+	// command chose. Anchoring harder re-opens the silent denial this closes.
+	if strings.Contains(output, sudoDenialCodelessLine) {
+		return denialHintLine(
+			"sudo was denied, and the denial carried no code to explain it.\n" +
+				"Read the denial in the Alpacon console (web).\n")
 	}
 	return ""
 }

--- a/cmd/exec/sudo_hint_test.go
+++ b/cmd/exec/sudo_hint_test.go
@@ -290,7 +290,6 @@ func TestSudoDenialHintFallsBackToTheRawCode(t *testing.T) {
 			output:       denialLine("not a code") + denialLine("SUDO_BRAND_NEW_CODE"),
 			wantContains: []string{"SUDO_BRAND_NEW_CODE"},
 		},
-		{"prefix without the code slot", "Alpacon denied this sudo command.\n", nil},
 		{"the code slot without the prefix", "build finished (SUDO_BRAND_NEW_CODE).\n", nil},
 		{"empty output", "", nil},
 		{
@@ -307,6 +306,8 @@ func TestSudoDenialHintFallsBackToTheRawCode(t *testing.T) {
 		{"escape sequence in the code slot", denialLine("\x1b[31mSUDO_FAKE"), nil},
 		{"lowercase code", denialLine("sudo_lowercase"), nil},
 		{"space in the code", denialLine("SUDO FAKE"), nil},
+		// nil, not a coverage gap: the sanitizer drops a bad code whole, parentheses
+		// included, so an empty slot is not a shape the agent ever emits.
 		{"empty code slot", denialLine(""), nil},
 	}
 
@@ -331,6 +332,56 @@ func TestSudoDenialHintFallsBackToTheRawCode(t *testing.T) {
 		assert.Contains(t, sudoDenialHint(denialLine(atCap)), atCap)
 		assert.Empty(t, sudoDenialHint(denialLine(strings.Repeat("A", 64))))
 	})
+}
+
+func TestSudoDenialHintCodelessDenial(t *testing.T) {
+	// Spelled out, not reused from sudoDenialCodelessLine, so changing that constant
+	// fails these tests instead of moving along with them.
+	const codelessLine = "Alpacon denied this sudo command.\n"
+
+	tests := []struct {
+		name            string
+		output          string
+		wantContains    []string
+		wantNotContains []string
+	}{
+		{
+			name:         "the codeless line points at the console",
+			output:       codelessLine,
+			wantContains: []string{"no code", "Alpacon console"},
+		},
+		{
+			// Fires deliberately, not by accident—see sudoDenialHint's codeless
+			// branch for why a forged match is accepted.
+			name:         "a failed command that printed the sentence itself",
+			output:       "echo \"Alpacon denied this sudo command.\"\n",
+			wantContains: []string{"Alpacon console"},
+		},
+		{
+			name:            "a code the table carries still wins on the same output",
+			output:          denialLine("SUDO_RISK_DENIED") + codelessLine,
+			wantContains:    []string{"runtime risk assessment"},
+			wantNotContains: []string{"no code"},
+		},
+		{
+			name:            "a code the table does not carry still wins on the same output",
+			output:          denialLine("SUDO_BRAND_NEW_CODE") + codelessLine,
+			wantContains:    []string{"SUDO_BRAND_NEW_CODE"},
+			wantNotContains: []string{"no code"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			hint := sudoDenialHint(tt.output)
+			for _, want := range tt.wantContains {
+				assert.Contains(t, hint, want)
+			}
+			for _, notWant := range tt.wantNotContains {
+				assert.NotContains(t, hint, notWant)
+			}
+		})
+	}
 }
 
 func TestIsApprovalDenial(t *testing.T) {


### PR DESCRIPTION
## Background

A sudo denial can reach the terminal with no error code in it. The agent prints `Alpacon denied this sudo command.`—no parentheses, no code—and until this PR the CLI had nothing to say about it.

`sudoDenialHint` had two paths and both anchored on `sudoDenialLinePrefix` (`cmd/exec/run.go:26`), which ends at the opening parenthesis of the code slot: the table scan through `denialCodePresent`, and the unknown-code fallback through `firstDenialCode`. A line with no slot matched neither, so the function returned `""` and the user got the bare denial and no next step.

Two agent branches reach that line on a real denial: `alpacon_approval.c` when `error_code_buf` came out empty, and `pam_alpamon.c` when `code[0] == '\0'`. `error_code_buf` ends up empty either because the server sent no `error_code`, or because the agent's sanitizer rejected the one it sent. That sanitizer rejects a bad code whole rather than truncating it—on any character outside `[A-Z0-9_]`, and on overflow past a `char[64]`—so a server shipping a malformed or over-63-character code landed on this silent path instead of the unknown-code fallback #344 added for exactly that drift.

This was the last path where a real denial arrived with nothing actionable beside it. It is not a regression; the table scan missed this line before #344 as well.

## Changes

### A third branch, running last

`sudoDenialHint` gains a branch after the table scan and the `firstDenialCode` fallback have both missed, so a denial that does carry a code still gets the guidance written for it. With no category from the server there is genuinely less to say, so the hint only points at the Alpacon console—but that is a next step where there was none.

The guidance says the denial carried no code rather than that the server named no reason, which is how the issue sketched it. The code may well have been sent and then rejected by the agent, and telling the user the server was silent points them at the wrong place to look.

### The literal is spelled out, not derived

`sudoDenialCodelessLine` is its own constant rather than `sudoDenialLinePrefix` with an empty slot. Because the sanitizer drops a bad code whole, the parentheses go with it, so `Alpacon denied this sudo command ().` is not a shape the agent ever emits. The pre-existing test row `empty code slot` still expects no hint for that reason, and now carries a comment saying so instead of reading as a coverage gap.

## Safety

The match is a plain `strings.Contains`, so a failed command that printed the same sentence in its own output gets the hint too. That is the decision the issue asked to settle, and it is deliberate.

The code-carrying detectors anchor on the full line for a reason: a forged match there can trigger the MFA step-up (`hasSudoPresenceDenial`), wedge `--wait` into a re-run loop (`hasSudoApprovalDenial`), or echo attacker-chosen text back to the terminal. This branch reaches none of those. It returns a fixed advisory line, interpolates nothing, and does not touch the exit code—`HandleCommandResult` writes the hint to stderr and exits on the code it already computed. What a forged match buys is one extra advisory line on a command that has already failed, since `sudoDenialHint` is reachable only from a `RemoteCommandError`.

Anchoring harder buys nothing against that and risks a false negative on the silent denial this branch exists to close. The commit carries a `Directive` trailer saying as much.

## Testing

`TestSudoDenialHintCodelessDenial` pins four cases: the codeless line producing the hint, the forged-input decision above, and a table code and an unknown code each still winning on output that also carries the codeless line.

The pre-existing row `prefix without the code slot` pinned the old empty return as deliberate, so it had to go; it is replaced by the new test rather than dropped. The row `the code slot without the prefix` is untouched and still yields no hint (`cmd/exec/sudo_hint_test.go:293`).

Every case was seen red against a mutated target.

Removing the branch entirely—the original bug:

```
--- FAIL: TestSudoDenialHintCodelessDenial/the_codeless_line_points_at_the_console
    Error:      	"" does not contain "no code"
    Error:      	"" does not contain "Alpacon console"
--- FAIL: TestSudoDenialHintCodelessDenial/a_failed_command_that_printed_the_sentence_itself
    Error:      	"" does not contain "Alpacon console"
```

Anchoring the match on a whole line instead of a substring, so a command echoing the sentence no longer matches. Only the forged-input case fails, which is what makes that case the one pinning the decision:

```
--- FAIL: TestSudoDenialHintCodelessDenial/a_failed_command_that_printed_the_sentence_itself
    Error:      	"" does not contain "Alpacon console"
```

Hoisting the branch above the two code-carrying paths:

```
--- FAIL: TestSudoDenialHintCodelessDenial/a_code_the_table_carries_still_wins_on_the_same_output
    Error:      	"Hint: sudo was denied, and the denial carried no code to explain it.\nRead the denial in the Alpacon console (web).\n" does not contain "runtime risk assessment"
--- FAIL: TestSudoDenialHintCodelessDenial/a_code_the_table_does_not_carry_still_wins_on_the_same_output
    Error:      	"Hint: sudo was denied, and the denial carried no code to explain it.\nRead the denial in the Alpacon console (web).\n" does not contain "SUDO_BRAND_NEW_CODE"
```

Suite and linters on the final diff:

- `go test -race ./...`: exit 0, 39 `ok`, no `FAIL`.
- `go vet ./...`: no output.
- `golangci-lint run ./...`: `0 issues.`

README is unchanged on purpose. Its "When a command is denied" section documents the WorkSession gate and the inline-credential refusal, not the sudo hint table, and a codeless denial creates no approval request—so it stays exit code `1`, which the existing table row already covers.

Closes #353
