### PR TITLE
fix(client): request the current-user path with its trailing slash

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -22,7 +22,7 @@ import (
 )
 
 const (
-	checkPrivilegesURL = "/api/iam/users/-"
+	checkPrivilegesURL = "/api/iam/users/-/"
 )
 
 type apiError struct {

--- a/client/client.go
+++ b/client/client.go
@@ -22,7 +22,7 @@ import (
 )
 
 const (
-	checkPrivilegesURL = "/api/iam/users/-/"
+	currentUserURL = "/api/iam/users/-/"
 )
 
 type apiError struct {
@@ -94,12 +94,12 @@ func NewAlpaconAPIClient() (*AlpaconClient, error) {
 
 func (ac *AlpaconClient) LoadCurrentUser() error {
 	ac.loadOnce.Do(func() {
-		body, err := ac.SendGetRequest(checkPrivilegesURL)
+		body, err := ac.SendGetRequest(currentUserURL)
 		if err != nil {
 			ac.loadErr = err
 			return
 		}
-		var resp CheckPrivilegesResponse
+		var resp CurrentUserResponse
 		if err := json.Unmarshal(body, &resp); err != nil {
 			ac.loadErr = err
 			return

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -405,8 +405,10 @@ func TestSendRequest_401CodedDenialNotMislabeledAsAuthFailure(t *testing.T) {
 
 func TestLoadCurrentUser_PopulatesFieldsAndCaches(t *testing.T) {
 	callCount := 0
+	var requestedPath string
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		callCount++
+		requestedPath = r.URL.Path
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(CheckPrivilegesResponse{
 			Username:    " alice ",
@@ -422,6 +424,9 @@ func TestLoadCurrentUser_PopulatesFieldsAndCaches(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "alice", ac.Username)
 	assert.Equal(t, "staff", ac.Privileges)
+
+	// Without the trailing slash Django's APPEND_SLASH answers a 301 and the client pays a second round trip.
+	assert.Equal(t, "/api/iam/users/-/", requestedPath)
 
 	_ = ac.LoadCurrentUser() // second call must be a no-op
 	assert.Equal(t, 1, callCount, "LoadCurrentUser must hit the server exactly once")

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -410,7 +410,7 @@ func TestLoadCurrentUser_PopulatesFieldsAndCaches(t *testing.T) {
 		callCount++
 		requestedPath = r.URL.Path
 		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(CheckPrivilegesResponse{
+		_ = json.NewEncoder(w).Encode(CurrentUserResponse{
 			Username:    " alice ",
 			IsStaff:     true,
 			IsSuperuser: false,
@@ -435,7 +435,7 @@ func TestLoadCurrentUser_PopulatesFieldsAndCaches(t *testing.T) {
 func TestLoadCurrentUser_SuperuserPrivileges(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(CheckPrivilegesResponse{
+		_ = json.NewEncoder(w).Encode(CurrentUserResponse{
 			Username:    "bob",
 			IsStaff:     true,
 			IsSuperuser: true,
@@ -451,7 +451,7 @@ func TestLoadCurrentUser_SuperuserPrivileges(t *testing.T) {
 func TestLoadCurrentUser_GeneralPrivileges(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(CheckPrivilegesResponse{
+		_ = json.NewEncoder(w).Encode(CurrentUserResponse{
 			Username:    "carol",
 			IsStaff:     false,
 			IsSuperuser: false,

--- a/client/types.go
+++ b/client/types.go
@@ -18,7 +18,7 @@ type AlpaconClient struct {
 	loadErr  error
 }
 
-type CheckPrivilegesResponse struct {
+type CurrentUserResponse struct {
 	Username    string `json:"username"`
 	IsStaff     bool   `json:"is_staff"`
 	IsSuperuser bool   `json:"is_superuser"`


### PR DESCRIPTION
## Background

`client/client.go` held the current-user endpoint as `/api/iam/users/-`, without a trailing slash. It is the only path in this repo that did.

On the server, `iam/api/urls.py` registers the IAM routes with a DRF `DefaultRouter` and passes no `trailing_slash` argument, so the default `True` applies and the detail route exists only as `users/<pk>/`. `django.middleware.common.CommonMiddleware` is in the stack (`alpacon/settings.py:307`) and nothing overrides `APPEND_SLASH`. The slashless request therefore failed URL resolution, came back a 404, and `CommonMiddleware` reissued it as a 301 to the slashed path. Go's default `http.Client` follows that redirect, so `LoadCurrentUser` spent two round trips where one would do.

The redirect never reached the view, so this is not the cost of `UserRetrieveSerializer` or its usage aggregation. What the extra request buys is one more pass through the middleware chain, tenant schema lookup included.

`LoadCurrentUser` is guarded by a `sync.Once`, so this cost at most one duplicated request per CLI invocation, on the commands that call it: `login`, `webhook create`, `user create`/`delete`/`invite`, `group create`/`delete`, and `approval list`.

## Changes

The fix is one character in `client/client.go:25`—`/api/iam/users/-` becomes `/api/iam/users/-/`.

I swept the other 54 `/api/` literals in the repo and found no second occurrence. Three constants do not end in a slash, but only this one reaches the wire that way:

| Constant | Path | Reaches the wire slashless |
|---|---|---|
| `client/client.go:25` | `/api/iam/users/-` | yes, passed straight to `SendGetRequest` |
| `api/mfa/mfa.go:17` | `/api/auth0/mfa` | no, goes through `utils.BuildURL` at `mfa.go:171` |
| `api/auth0/auth0.go:24` | `/api/auth/env` | no, goes through `utils.BuildURL` at `auth0.go:49` |

`utils.BuildURL` (`utils/utils.go:458`) appends a trailing slash when the joined path lacks one, which is what makes those two safe. The same helper covers the pagination layer—`FetchAllPages`, `FetchPagesUpTo`, and `FetchCursorPages` all call `BuildURL(endpoint, "", params)` before sending—so `api/websh/websh.go:83`, which builds its endpoint with `path.Join` and loses the slash there, gets it back before the request goes out. Every remaining raw constant already ends in a slash, and the `fmt.Sprintf` templates do too.

A second commit renames two symbols that the review raised, with no behavior change:

| Before | After | Where |
|---|---|---|
| `checkPrivilegesURL` | `currentUserURL` | `client/client.go` |
| `CheckPrivilegesResponse` | `CurrentUserResponse` | `client/types.go`, `client/client.go`, `client/client_test.go` |

Both names were accurate when 9068bed added them, because the only caller was `checkPrivileges()` and the constant sat beside `checkAuthURL` under a `check*URL` convention. 89da0a1 replaced that caller with `LoadCurrentUser()`, which reads `Username` off the same response as well, and left the names behind. The endpoint was never privilege-specific either: the `-` in `/api/iam/users/-/` stands for the authenticated caller, so the route returns the current user and privileges are one part of it. `checkAuthURL`, the other half of the convention, is already gone (deb3371), so nothing in `client/` still follows it.

`CurrentUserResponse` is exported, but the type has no reference outside the `client` package in this repo, and this repo ships a binary rather than a library.

## Testing

`TestLoadCurrentUser_PopulatesFieldsAndCaches` now records the path its `httptest` handler receives and asserts it. The test was seen red by reverting the constant:

```
--- FAIL: TestLoadCurrentUser_PopulatesFieldsAndCaches (0.00s)
    client_test.go:429:
        	Error:      	Not equal:
        	            	expected: "/api/iam/users/-/"
        	            	actual  : "/api/iam/users/-"
```

The rename adds no test. It changes identifiers only, so there is no behavior for a test to fail on; the compiler is what pins it, and the three existing `LoadCurrentUser` tests still construct the response type and assert the fields it carries.

Suite and linters on the final diff:

- `go test -race ./...`: 39 `ok`, no `FAIL`.
- `go vet ./...`: no output.
- `golangci-lint run ./...`: `0 issues.`

The redirect behavior itself is not covered by a test. `httptest` would exercise Go's redirect handling rather than Django's, so the assertion pins the path the client asks for, which is the part this repo controls.
