### PR TITLE
fix(event): provision a fresh session per dial and re-subscribe on connect

### DIFF
--- a/api/event/commandoutput_listener.go
+++ b/api/event/commandoutput_listener.go
@@ -3,6 +3,7 @@ package event
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"sync"
 	"time"
 
@@ -115,11 +116,11 @@ func (l *CommandOutputListener) subscribeTo(commandID, serverID string) error {
 func (l *CommandOutputListener) subscribe() error {
 	// A fatal session failure can stop the listener between the caller's WaitConnected
 	// and its subscribeTo. Subscribing then succeeds against a channel nothing reads,
-	// so the caller would stream from a dead listener instead of falling back.
-	select {
-	case <-l.done:
-		return errors.New("event listener stopped before the subscription")
-	default:
+	// so the caller would stream from a dead listener instead of falling back. Checking
+	// again once the subscriptions are in narrows the window to their round trips rather
+	// than closing it: a Stop landing after the second check still goes unnoticed.
+	if err := l.halted(); err != nil {
+		return err
 	}
 
 	l.cmdMu.Lock()
@@ -146,11 +147,31 @@ func (l *CommandOutputListener) subscribe() error {
 		_ = SubscribeEvent(l.ac, channelID, EventTypeCommandFin, serverID)
 	}
 
+	if err := l.halted(); err != nil {
+		return err
+	}
+
 	l.stateMu.Lock()
 	l.subscribed = true
 	l.stateMu.Unlock()
 
 	return nil
+}
+
+// halted reports why the listener stopped, or nil while it is live. provisionSession
+// records the reason on its way out, and carrying it here is what keeps the caller's
+// fallback warning naming the server's own refusal rather than the halt.
+func (l *CommandOutputListener) halted() error {
+	select {
+	case <-l.done:
+	default:
+		return nil
+	}
+
+	if cause := l.Err(); cause != nil {
+		return fmt.Errorf("event listener stopped while subscribing: %w", cause)
+	}
+	return errors.New("event listener stopped while subscribing")
 }
 
 // Chunks returns a receive-only channel of parsed chunk events.

--- a/api/event/commandoutput_listener.go
+++ b/api/event/commandoutput_listener.go
@@ -56,9 +56,10 @@ type commandOutputEnvelope struct {
 	} `json:"payload"`
 }
 
-// NewCommandOutputListener constructs a listener without connecting. ac may be
-// nil (empty header, for tests); the targets are set later via setTargets, because
-// SubmitCommand must run once the WS is already connected.
+// NewCommandOutputListener constructs a listener without connecting. ac may be nil
+// only for a test that never calls Start, because provisioning a session dereferences
+// it. The targets are set later via setTargets, because SubmitCommand must run once
+// the WS is already connected.
 func NewCommandOutputListener(ac *client.AlpaconClient) *CommandOutputListener {
 	l := &CommandOutputListener{
 		ac:       ac,

--- a/api/event/commandoutput_listener.go
+++ b/api/event/commandoutput_listener.go
@@ -84,10 +84,9 @@ func (l *CommandOutputListener) provisionSession() (string, error) {
 	if err != nil {
 		l.stateMu.Lock()
 		l.err = err
-		// Before the first subscribe a fatal 4xx means a bad request or an expired
-		// login, so retrying only burns the caller's connect budget before it falls
-		// back to polling anyway. Once the command is streaming, giving up would cost
-		// the rest of the run its live output, so every status is retried.
+		// Before the first subscribe a fatal 4xx only burns the caller's connect budget
+		// before it falls back to polling anyway. Once the command is streaming, giving
+		// up would cost the rest of the run its live output, so every status is retried.
 		fatal := !l.subscribed && isFatalRequestError(err)
 		l.stateMu.Unlock()
 
@@ -105,8 +104,7 @@ func (l *CommandOutputListener) provisionSession() (string, error) {
 	return session.WebsocketURL, nil
 }
 
-// subscribeTo issues the first subscription, once the command exists. Every later
-// connect re-issues it through onConnected.
+// subscribeTo issues the first subscription; every later connect re-issues it through onConnected.
 func (l *CommandOutputListener) subscribeTo(commandID, serverID string) error {
 	l.setTargets(commandID, serverID)
 	return l.subscribe()
@@ -184,8 +182,6 @@ func (l *CommandOutputListener) handleMessage(raw []byte) {
 	}
 }
 
-// setTargets names the command whose chunks to keep and the server whose fin event
-// ends the stream.
 func (l *CommandOutputListener) setTargets(commandID, serverID string) {
 	l.cmdMu.Lock()
 	l.commandID = commandID

--- a/api/event/commandoutput_listener.go
+++ b/api/event/commandoutput_listener.go
@@ -26,12 +26,17 @@ type ChunkEvent struct {
 // event WebSocket, exposing chunks on Chunks() and the command's fin on
 // Finished().
 //
-// Lifecycle: NewCommandOutputListener -> Start -> (consume Chunks) -> Stop.
-// Stop is idempotent and safe to call from any goroutine.
+// Lifecycle: NewCommandOutputListener -> Start -> subscribeTo -> (consume Chunks) -> Stop.
+// Stop is idempotent and safe to call from any goroutine. Event channel tokens are
+// single-use, so every dial provisions its own session and re-subscribes.
 type CommandOutputListener struct {
 	*wsListener
-	cmdMu     sync.Mutex // guards commandID
+	ac        *client.AlpaconClient
+	cmdMu     sync.Mutex // guards commandID, serverID
 	commandID string
+	serverID  string
+	chanMu    sync.Mutex // guards channelID
+	channelID string
 	chunks    chan ChunkEvent
 	finished  chan struct{}
 }
@@ -50,16 +55,66 @@ type commandOutputEnvelope struct {
 }
 
 // NewCommandOutputListener constructs a listener without connecting. ac may be
-// nil (empty header, for tests); commandID may be set later via setCommandID.
-func NewCommandOutputListener(ac *client.AlpaconClient, wsURL, commandID string) *CommandOutputListener {
+// nil (empty header, for tests); the targets are set later via setTargets, because
+// SubmitCommand must run once the WS is already connected.
+func NewCommandOutputListener(ac *client.AlpaconClient) *CommandOutputListener {
 	l := &CommandOutputListener{
-		wsListener: newWSListener(ac, wsURL, commandOutputConnectTimeout),
-		commandID:  commandID,
-		chunks:     make(chan ChunkEvent, commandOutputChunkBuffer),
-		finished:   make(chan struct{}, 1),
+		ac:       ac,
+		chunks:   make(chan ChunkEvent, commandOutputChunkBuffer),
+		finished: make(chan struct{}, 1),
 	}
+	l.wsListener = newProvisionedWSListener(ac, l.provisionSession, commandOutputConnectTimeout)
 	l.handleFrame = l.handleMessage
+	l.onConnected = l.subscribe
 	return l
+}
+
+func (l *CommandOutputListener) provisionSession() (string, error) {
+	session, err := CreateEventSession(l.ac)
+	if err != nil {
+		return "", err
+	}
+
+	l.chanMu.Lock()
+	l.channelID = session.ChannelID
+	l.chanMu.Unlock()
+
+	return session.WebsocketURL, nil
+}
+
+// subscribeTo issues the first subscription, once the command exists. Every later
+// connect re-issues it through onConnected.
+func (l *CommandOutputListener) subscribeTo(commandID, serverID string) error {
+	l.setTargets(commandID, serverID)
+	return l.subscribe()
+}
+
+func (l *CommandOutputListener) subscribe() error {
+	l.cmdMu.Lock()
+	commandID, serverID := l.commandID, l.serverID
+	l.cmdMu.Unlock()
+
+	// The command is submitted only after the WS is up, so the first connect has
+	// nothing to subscribe to yet.
+	if commandID == "" {
+		return nil
+	}
+
+	l.chanMu.Lock()
+	channelID := l.channelID
+	l.chanMu.Unlock()
+
+	if err := SubscribeEvent(l.ac, channelID, EventTypeCommandOutput, commandID); err != nil {
+		return err
+	}
+
+	// Chunks carry no end marker, so without this the exit waits for the poll to
+	// notice. Best effort: on failure that poll stays the only terminal signal.
+	if serverID != "" {
+		_ = SubscribeEvent(l.ac, channelID, EventTypeCommandFin, serverID)
+	}
+
+	return nil
 }
 
 // Chunks returns a receive-only channel of parsed chunk events.
@@ -102,10 +157,11 @@ func (l *CommandOutputListener) handleMessage(raw []byte) {
 	}
 }
 
-// setCommandID assigns the commandID after construction. Used because
-// SubmitCommand must run after the WS is already connected.
-func (l *CommandOutputListener) setCommandID(id string) {
+// setTargets names the command whose chunks to keep and the server whose fin event
+// ends the stream.
+func (l *CommandOutputListener) setTargets(commandID, serverID string) {
 	l.cmdMu.Lock()
-	l.commandID = id
+	l.commandID = commandID
+	l.serverID = serverID
 	l.cmdMu.Unlock()
 }

--- a/api/event/commandoutput_listener.go
+++ b/api/event/commandoutput_listener.go
@@ -31,15 +31,16 @@ type ChunkEvent struct {
 // single-use, so every dial provisions its own session and re-subscribes.
 type CommandOutputListener struct {
 	*wsListener
-	ac        *client.AlpaconClient
-	cmdMu     sync.Mutex // guards commandID, serverID
-	commandID string
-	serverID  string
-	stateMu   sync.Mutex // guards channelID, err
-	channelID string
-	err       error
-	chunks    chan ChunkEvent
-	finished  chan struct{}
+	ac         *client.AlpaconClient
+	cmdMu      sync.Mutex // guards commandID, serverID
+	commandID  string
+	serverID   string
+	stateMu    sync.Mutex // guards channelID, subscribed, err
+	channelID  string
+	subscribed bool
+	err        error
+	chunks     chan ChunkEvent
+	finished   chan struct{}
 }
 
 // commandOutputEnvelope is the WS message format emitted by alpacon-server. One
@@ -83,10 +84,14 @@ func (l *CommandOutputListener) provisionSession() (string, error) {
 	if err != nil {
 		l.stateMu.Lock()
 		l.err = err
+		// Before the first subscribe a 4xx means a bad request or an expired login,
+		// so retrying only burns the caller's connect budget before it falls back to
+		// polling anyway. Once the command is streaming, giving up would cost the
+		// rest of the run its live output, so every status is retried.
+		fatal := !l.subscribed && isFatalRequestError(err)
 		l.stateMu.Unlock()
-		// A 4xx means a bad request or an expired login, so retrying only burns the
-		// caller's connect budget before it falls back to polling anyway.
-		if isFatalRequestError(err) {
+
+		if fatal {
 			l.Stop()
 		}
 		return "", err
@@ -131,6 +136,10 @@ func (l *CommandOutputListener) subscribe() error {
 	if serverID != "" {
 		_ = SubscribeEvent(l.ac, channelID, EventTypeCommandFin, serverID)
 	}
+
+	l.stateMu.Lock()
+	l.subscribed = true
+	l.stateMu.Unlock()
 
 	return nil
 }

--- a/api/event/commandoutput_listener.go
+++ b/api/event/commandoutput_listener.go
@@ -2,6 +2,7 @@ package event
 
 import (
 	"encoding/json"
+	"errors"
 	"sync"
 	"time"
 
@@ -112,6 +113,15 @@ func (l *CommandOutputListener) subscribeTo(commandID, serverID string) error {
 }
 
 func (l *CommandOutputListener) subscribe() error {
+	// A fatal session failure can stop the listener between the caller's WaitConnected
+	// and its subscribeTo. Subscribing then succeeds against a channel nothing reads,
+	// so the caller would stream from a dead listener instead of falling back.
+	select {
+	case <-l.done:
+		return errors.New("event listener stopped before the subscription")
+	default:
+	}
+
 	l.cmdMu.Lock()
 	commandID, serverID := l.commandID, l.serverID
 	l.cmdMu.Unlock()

--- a/api/event/commandoutput_listener.go
+++ b/api/event/commandoutput_listener.go
@@ -35,8 +35,9 @@ type CommandOutputListener struct {
 	cmdMu     sync.Mutex // guards commandID, serverID
 	commandID string
 	serverID  string
-	chanMu    sync.Mutex // guards channelID
+	stateMu   sync.Mutex // guards channelID, err
 	channelID string
+	err       error
 	chunks    chan ChunkEvent
 	finished  chan struct{}
 }
@@ -69,15 +70,32 @@ func NewCommandOutputListener(ac *client.AlpaconClient) *CommandOutputListener {
 	return l
 }
 
+// Err returns why the listener could not connect, so a caller that only sees
+// WaitConnected time out can still report the server's own reason.
+func (l *CommandOutputListener) Err() error {
+	l.stateMu.Lock()
+	defer l.stateMu.Unlock()
+	return l.err
+}
+
 func (l *CommandOutputListener) provisionSession() (string, error) {
 	session, err := CreateEventSession(l.ac)
 	if err != nil {
+		l.stateMu.Lock()
+		l.err = err
+		l.stateMu.Unlock()
+		// A 4xx means a bad request or an expired login, so retrying only burns the
+		// caller's connect budget before it falls back to polling anyway.
+		if isFatalRequestError(err) {
+			l.Stop()
+		}
 		return "", err
 	}
 
-	l.chanMu.Lock()
+	l.stateMu.Lock()
 	l.channelID = session.ChannelID
-	l.chanMu.Unlock()
+	l.err = nil
+	l.stateMu.Unlock()
 
 	return session.WebsocketURL, nil
 }
@@ -100,9 +118,9 @@ func (l *CommandOutputListener) subscribe() error {
 		return nil
 	}
 
-	l.chanMu.Lock()
+	l.stateMu.Lock()
 	channelID := l.channelID
-	l.chanMu.Unlock()
+	l.stateMu.Unlock()
 
 	if err := SubscribeEvent(l.ac, channelID, EventTypeCommandOutput, commandID); err != nil {
 		return err

--- a/api/event/commandoutput_listener.go
+++ b/api/event/commandoutput_listener.go
@@ -84,10 +84,10 @@ func (l *CommandOutputListener) provisionSession() (string, error) {
 	if err != nil {
 		l.stateMu.Lock()
 		l.err = err
-		// Before the first subscribe a 4xx means a bad request or an expired login,
-		// so retrying only burns the caller's connect budget before it falls back to
-		// polling anyway. Once the command is streaming, giving up would cost the
-		// rest of the run its live output, so every status is retried.
+		// Before the first subscribe a fatal 4xx means a bad request or an expired
+		// login, so retrying only burns the caller's connect budget before it falls
+		// back to polling anyway. Once the command is streaming, giving up would cost
+		// the rest of the run its live output, so every status is retried.
 		fatal := !l.subscribed && isFatalRequestError(err)
 		l.stateMu.Unlock()
 

--- a/api/event/commandoutput_listener_test.go
+++ b/api/event/commandoutput_listener_test.go
@@ -2,13 +2,10 @@ package event
 
 import (
 	"encoding/json"
-	"net/http"
-	"net/http/httptest"
-	"strings"
-	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/alpacax/alpacon-cli/client"
 	"github.com/gorilla/websocket"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -45,7 +42,8 @@ func TestCommandOutputListener_HandleMessage_FiltersAndEmits(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			l := NewCommandOutputListener(nil, "", "cmd-1")
+			l := NewCommandOutputListener(nil)
+			l.setTargets("cmd-1", "")
 			l.handleMessage([]byte(tt.payload))
 
 			select {
@@ -87,7 +85,8 @@ func TestCommandOutputListener_HandleMessage_FinishedIsPerCommand(t *testing.T) 
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			l := NewCommandOutputListener(nil, "", "cmd-1")
+			l := NewCommandOutputListener(nil)
+			l.setTargets("cmd-1", "")
 			l.handleMessage([]byte(tt.payload))
 
 			select {
@@ -105,17 +104,11 @@ func TestCommandOutputListener_HandleMessage_FinishedIsPerCommand(t *testing.T) 
 }
 
 func TestCommandOutputListener_Start_DeliversChunks(t *testing.T) {
-	upgrader := websocket.Upgrader{}
 	cmdID := "cmd-uuid"
 
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		conn, err := upgrader.Upgrade(w, r, nil)
-		if err != nil {
-			return
-		}
+	ts, _, _ := newWatcherTestServer(t, alwaysCreated, alwaysUpgrade, alwaysCreated, func(conn *websocket.Conn, _ int32) {
 		defer func() { _ = conn.Close() }()
 
-		// Emit two chunks
 		for _, c := range []ChunkEvent{{Seq: 0, Content: "a"}, {Seq: 1, Content: "b"}} {
 			env := map[string]any{
 				"event_type": "command_output",
@@ -135,12 +128,11 @@ func TestCommandOutputListener_Start_DeliversChunks(t *testing.T) {
 				return
 			}
 		}
-	}))
-	defer ts.Close()
+	})
 
-	wsURL := "ws" + strings.TrimPrefix(ts.URL, "http")
-
-	l := NewCommandOutputListener(nil, wsURL, cmdID)
+	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
+	l := NewCommandOutputListener(ac)
+	l.setTargets(cmdID, "")
 	l.Start()
 	defer l.Stop()
 
@@ -161,17 +153,9 @@ func TestCommandOutputListener_Start_DeliversChunks(t *testing.T) {
 }
 
 func TestCommandOutputListener_Reconnects(t *testing.T) {
-	upgrader := websocket.Upgrader{}
-	var connectionCount atomic.Int32
 	cmdID := "cmd-uuid"
 
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		conn, err := upgrader.Upgrade(w, r, nil)
-		if err != nil {
-			return
-		}
-		n := connectionCount.Add(1)
-
+	ts, sessions, _ := newWatcherTestServer(t, alwaysCreated, alwaysUpgrade, alwaysCreated, func(conn *websocket.Conn, n int32) {
 		if n == 1 {
 			// First connection: emit one chunk and drop
 			env := `{"event_type":"command_output","payload":{"command_id":"` + cmdID + `","seq":0,"content":"first"}}`
@@ -187,11 +171,12 @@ func TestCommandOutputListener_Reconnects(t *testing.T) {
 				return
 			}
 		}
-	}))
-	defer ts.Close()
+	})
 
-	wsURL := "ws" + strings.TrimPrefix(ts.URL, "http")
-	l := NewCommandOutputListener(nil, wsURL, cmdID)
+	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
+	l := NewCommandOutputListener(ac)
+	l.setTargets(cmdID, "")
+	l.reconnectBaseDelay = testReconnectBaseDelay
 	l.Start()
 	defer l.Stop()
 
@@ -204,11 +189,59 @@ func TestCommandOutputListener_Reconnects(t *testing.T) {
 		case c := <-l.Chunks():
 			got = append(got, c)
 		case <-timeout:
-			t.Fatalf("timeout, got %+v (connections=%d)", got, connectionCount.Load())
+			t.Fatalf("timeout, got %+v (sessions=%d)", got, sessions.Load())
 		}
 	}
 
 	assert.Equal(t, ChunkEvent{Seq: 0, Content: "first"}, got[0])
 	assert.Equal(t, ChunkEvent{Seq: 1, Content: "second"}, got[1])
-	assert.GreaterOrEqual(t, connectionCount.Load(), int32(2))
+	assert.GreaterOrEqual(t, sessions.Load(), int32(2))
+}
+
+func TestCommandOutputListener_CreatesANewSessionAndResubscribesOnReconnect(t *testing.T) {
+	ts, sessions, subscribes := newWatcherTestServer(t, alwaysCreated, alwaysUpgrade, alwaysCreated, func(conn *websocket.Conn, n int32) {
+		if n == 1 {
+			// The token is single-use, so recovering means a whole new session.
+			_ = conn.Close()
+			return
+		}
+		for {
+			if _, _, err := conn.ReadMessage(); err != nil {
+				return
+			}
+		}
+	})
+
+	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
+	l := NewCommandOutputListener(ac)
+	l.reconnectBaseDelay = testReconnectBaseDelay
+	l.Start()
+	defer l.Stop()
+
+	require.True(t, l.WaitConnected(3*time.Second))
+	require.NoError(t, l.subscribeTo("cmd-1", "srv-1"))
+
+	assert.Eventually(t, func() bool {
+		return sessions.Load() >= 2 && subscribes.Load() >= 3
+	}, 5*time.Second, 10*time.Millisecond, "a reconnect must create a new session and re-issue both subscriptions")
+}
+
+func TestCommandOutputListener_FirstConnectSubscribesToNothing(t *testing.T) {
+	ts, _, subscribes := newWatcherTestServer(t, alwaysCreated, alwaysUpgrade, alwaysCreated, func(conn *websocket.Conn, _ int32) {
+		for {
+			if _, _, err := conn.ReadMessage(); err != nil {
+				return
+			}
+		}
+	})
+
+	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
+	l := NewCommandOutputListener(ac)
+	l.Start()
+	defer l.Stop()
+
+	// The command is submitted only after the WS is up, so there is nothing to
+	// subscribe to on the first connect.
+	require.True(t, l.WaitConnected(3*time.Second))
+	assert.Equal(t, int32(0), subscribes.Load())
 }

--- a/api/event/commandoutput_listener_test.go
+++ b/api/event/commandoutput_listener_test.go
@@ -241,8 +241,6 @@ func TestCommandOutputListener_FirstConnectSubscribesToNothing(t *testing.T) {
 	l.Start()
 	defer l.Stop()
 
-	// The command is submitted only after the WS is up, so there is nothing to
-	// subscribe to on the first connect.
 	require.True(t, l.WaitConnected(3*time.Second), "the first dial must connect even with nothing to subscribe to")
 	assert.Equal(t, int32(0), subscribes.Load())
 }
@@ -255,8 +253,8 @@ func TestCommandOutputListener_SurfacesAFatalSessionFailure(t *testing.T) {
 	l.Start()
 	defer l.Stop()
 
-	// A rejected session must end the wait immediately rather than burning the whole
-	// connect budget, and the caller needs the server's reason for its fallback.
+	// A rejected session ends the wait instead of retrying, and the caller needs the
+	// server's own reason for its fallback.
 	assert.False(t, l.WaitConnected(commandOutputConnectTimeout), "a rejected session must not report a connection")
 
 	err := l.Err()
@@ -269,8 +267,6 @@ func TestListenerFailureFallsBackToTheConnectBudget(t *testing.T) {
 }
 
 func TestCommandOutputListener_KeepsRetryingAfterTheFirstSubscribe(t *testing.T) {
-	// A 4xx on a later session create is not a dead end: the command is already
-	// streaming, so giving up would cost the rest of a long run its live output.
 	rejectSecond := func(attempt int32) int {
 		if attempt == 2 {
 			return http.StatusUnauthorized

--- a/api/event/commandoutput_listener_test.go
+++ b/api/event/commandoutput_listener_test.go
@@ -2,6 +2,7 @@ package event
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 	"testing"
 	"time"
@@ -315,4 +316,36 @@ func TestCommandOutputListener_SubscribeFailsOnAStoppedListener(t *testing.T) {
 	// A fatal session failure can stop the listener while the caller is still inside
 	// SubmitCommand, and the server would accept a subscription on the dead channel.
 	assert.Error(t, l.subscribeTo("command-1", "server-1"), "a stopped listener must not report a live subscription")
+}
+
+func TestCommandOutputListener_SubscribeCarriesWhyTheListenerStopped(t *testing.T) {
+	ts, _, _ := newWatcherTestServer(t, alwaysCreated, alwaysUpgrade, alwaysCreated, func(conn *websocket.Conn, _ int32) {})
+
+	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
+	l := NewCommandOutputListener(ac)
+
+	cause := errors.New("session create rejected")
+	l.stateMu.Lock()
+	l.err = cause
+	l.stateMu.Unlock()
+	l.Stop()
+
+	// The fallback warning prints this error, so dropping the cause would report the
+	// halt where the user needs the server's own refusal.
+	assert.ErrorIs(t, l.subscribeTo("command-1", "server-1"), cause)
+}
+
+func TestCommandOutputListener_SubscribeFailsWhenTheListenerStopsMidSubscription(t *testing.T) {
+	var l *CommandOutputListener
+	// Stop lands while SubscribeEvent is in flight, which is the window a single check
+	// before the request cannot see.
+	ts, _, _ := newWatcherTestServer(t, alwaysCreated, alwaysUpgrade, func(int32) int {
+		l.Stop()
+		return http.StatusCreated
+	}, func(conn *websocket.Conn, _ int32) {})
+
+	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
+	l = NewCommandOutputListener(ac)
+
+	assert.Error(t, l.subscribeTo("command-1", "server-1"), "a listener stopped mid-subscription must not report a live subscription")
 }

--- a/api/event/commandoutput_listener_test.go
+++ b/api/event/commandoutput_listener_test.go
@@ -2,6 +2,7 @@ package event
 
 import (
 	"encoding/json"
+	"net/http"
 	"testing"
 	"time"
 
@@ -136,7 +137,7 @@ func TestCommandOutputListener_Start_DeliversChunks(t *testing.T) {
 	l.Start()
 	defer l.Stop()
 
-	require.True(t, l.WaitConnected(2*time.Second), "should connect")
+	require.True(t, l.WaitConnected(2*time.Second), "the listener must connect before any chunk can arrive")
 
 	got := []ChunkEvent{}
 	timeout := time.After(2 * time.Second)
@@ -180,7 +181,7 @@ func TestCommandOutputListener_Reconnects(t *testing.T) {
 	l.Start()
 	defer l.Stop()
 
-	require.True(t, l.WaitConnected(2*time.Second))
+	require.True(t, l.WaitConnected(2*time.Second), "the first dial must connect before a reconnect can be observed")
 
 	got := []ChunkEvent{}
 	timeout := time.After(5 * time.Second)
@@ -218,7 +219,7 @@ func TestCommandOutputListener_CreatesANewSessionAndResubscribesOnReconnect(t *t
 	l.Start()
 	defer l.Stop()
 
-	require.True(t, l.WaitConnected(3*time.Second))
+	require.True(t, l.WaitConnected(3*time.Second), "the first dial must connect before the reconnect")
 	require.NoError(t, l.subscribeTo("cmd-1", "srv-1"))
 
 	assert.Eventually(t, func() bool {
@@ -242,7 +243,7 @@ func TestCommandOutputListener_FirstConnectSubscribesToNothing(t *testing.T) {
 
 	// The command is submitted only after the WS is up, so there is nothing to
 	// subscribe to on the first connect.
-	require.True(t, l.WaitConnected(3*time.Second))
+	require.True(t, l.WaitConnected(3*time.Second), "the first dial must connect even with nothing to subscribe to")
 	assert.Equal(t, int32(0), subscribes.Load())
 }
 
@@ -256,7 +257,7 @@ func TestCommandOutputListener_SurfacesAFatalSessionFailure(t *testing.T) {
 
 	// A rejected session must end the wait immediately rather than burning the whole
 	// connect budget, and the caller needs the server's reason for its fallback.
-	assert.False(t, l.WaitConnected(commandOutputConnectTimeout))
+	assert.False(t, l.WaitConnected(commandOutputConnectTimeout), "a rejected session must not report a connection")
 
 	err := l.Err()
 	require.Error(t, err)
@@ -265,4 +266,45 @@ func TestCommandOutputListener_SurfacesAFatalSessionFailure(t *testing.T) {
 
 func TestListenerFailureFallsBackToTheConnectBudget(t *testing.T) {
 	assert.Contains(t, listenerFailure(NewCommandOutputListener(nil)).Error(), "connect timeout")
+}
+
+func TestCommandOutputListener_KeepsRetryingAfterTheFirstSubscribe(t *testing.T) {
+	// A 4xx on a later session create is not a dead end: the command is already
+	// streaming, so giving up would cost the rest of a long run its live output.
+	rejectSecond := func(attempt int32) int {
+		if attempt == 2 {
+			return http.StatusUnauthorized
+		}
+		return http.StatusCreated
+	}
+
+	subscribed := make(chan struct{})
+	ts, sessions, _ := newWatcherTestServer(t, rejectSecond, alwaysUpgrade, alwaysCreated, func(conn *websocket.Conn, n int32) {
+		if n == 1 {
+			// Hold the first connection until the caller has subscribed, so the
+			// rejected reconnect lands on a listener that is already streaming.
+			<-subscribed
+			_ = conn.Close()
+			return
+		}
+		for {
+			if _, _, err := conn.ReadMessage(); err != nil {
+				return
+			}
+		}
+	})
+
+	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
+	l := NewCommandOutputListener(ac)
+	l.reconnectBaseDelay = testReconnectBaseDelay
+	l.Start()
+	defer l.Stop()
+
+	require.True(t, l.WaitConnected(3*time.Second), "the first dial must connect")
+	require.NoError(t, l.subscribeTo("cmd-1", "srv-1"))
+	close(subscribed)
+
+	assert.Eventually(t, func() bool {
+		return sessions.Load() >= 3
+	}, 5*time.Second, 10*time.Millisecond, "a rejected reconnect must not end a listener that already subscribed")
 }

--- a/api/event/commandoutput_listener_test.go
+++ b/api/event/commandoutput_listener_test.go
@@ -245,3 +245,24 @@ func TestCommandOutputListener_FirstConnectSubscribesToNothing(t *testing.T) {
 	require.True(t, l.WaitConnected(3*time.Second))
 	assert.Equal(t, int32(0), subscribes.Load())
 }
+
+func TestCommandOutputListener_SurfacesAFatalSessionFailure(t *testing.T) {
+	ts, _, _ := newWatcherTestServer(t, alwaysRejected, alwaysUpgrade, alwaysCreated, func(conn *websocket.Conn, _ int32) {})
+
+	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
+	l := NewCommandOutputListener(ac)
+	l.Start()
+	defer l.Stop()
+
+	// A rejected session must end the wait immediately rather than burning the whole
+	// connect budget, and the caller needs the server's reason for its fallback.
+	assert.False(t, l.WaitConnected(commandOutputConnectTimeout))
+
+	err := l.Err()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to create event session")
+}
+
+func TestListenerFailureFallsBackToTheConnectBudget(t *testing.T) {
+	assert.Contains(t, listenerFailure(NewCommandOutputListener(nil)).Error(), "connect timeout")
+}

--- a/api/event/commandoutput_listener_test.go
+++ b/api/event/commandoutput_listener_test.go
@@ -304,3 +304,15 @@ func TestCommandOutputListener_KeepsRetryingAfterTheFirstSubscribe(t *testing.T)
 		return sessions.Load() >= 3
 	}, 5*time.Second, 10*time.Millisecond, "a rejected reconnect must not end a listener that already subscribed")
 }
+
+func TestCommandOutputListener_SubscribeFailsOnAStoppedListener(t *testing.T) {
+	ts, _, _ := newWatcherTestServer(t, alwaysCreated, alwaysUpgrade, alwaysCreated, func(conn *websocket.Conn, _ int32) {})
+
+	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
+	l := NewCommandOutputListener(ac)
+	l.Stop()
+
+	// A fatal session failure can stop the listener while the caller is still inside
+	// SubmitCommand, and the server would accept a subscription on the dead channel.
+	assert.Error(t, l.subscribeTo("command-1", "server-1"), "a stopped listener must not report a live subscription")
+}

--- a/api/event/event.go
+++ b/api/event/event.go
@@ -380,7 +380,7 @@ func runCommandStreamingWithWriter(ac *client.AlpaconClient, serverName, command
 	listener.Start()
 	if !listener.WaitConnected(commandOutputConnectTimeout) {
 		listener.Stop()
-		return runCommandFallback(ac, serverName, command, username, groupname, env, workSessionID, out, fmt.Errorf("event websocket connect timeout"))
+		return runCommandFallback(ac, serverName, command, username, groupname, env, workSessionID, out, listenerFailure(listener))
 	}
 
 	cmdResp, err := SubmitCommand(ac, serverName, command, username, groupname, env, workSessionID)
@@ -402,7 +402,7 @@ func StreamApprovedCommand(ac *client.AlpaconClient, cmdID string, out io.Writer
 	listener.Start()
 	if !listener.WaitConnected(commandOutputConnectTimeout) {
 		listener.Stop()
-		return runCommandFallbackFromID(ac, cmdID, out, true, fmt.Errorf("event websocket connect timeout"))
+		return runCommandFallbackFromID(ac, cmdID, out, true, listenerFailure(listener))
 	}
 	// The fin event targets the server, which only the command itself names here.
 	// A failed read just skips the subscription; the poll still ends the run.
@@ -411,6 +411,15 @@ func StreamApprovedCommand(ac *client.AlpaconClient, cmdID string, out io.Writer
 		serverID = details.Server.ID
 	}
 	return streamSubscribed(ac, listener, cmdID, serverID, out, timeout, streamPollTick, true)
+}
+
+// listenerFailure names why the listener never connected: the server's own error
+// when it reached the server at all, the connect budget otherwise.
+func listenerFailure(listener *CommandOutputListener) error {
+	if err := listener.Err(); err != nil {
+		return err
+	}
+	return fmt.Errorf("event websocket connect timeout")
 }
 
 // streamSubscribed subscribes to cmdID's output channel and to serverID's fin

--- a/api/event/event.go
+++ b/api/event/event.go
@@ -376,12 +376,7 @@ func RunCommandStreaming(ac *client.AlpaconClient, serverName, command, username
 }
 
 func runCommandStreamingWithWriter(ac *client.AlpaconClient, serverName, command, username, groupname string, env map[string]string, workSessionID string, out io.Writer) error {
-	session, err := CreateEventSession(ac)
-	if err != nil {
-		return runCommandFallback(ac, serverName, command, username, groupname, env, workSessionID, out, err)
-	}
-
-	listener := NewCommandOutputListener(ac, session.WebsocketURL, "")
+	listener := NewCommandOutputListener(ac)
 	listener.Start()
 	if !listener.WaitConnected(commandOutputConnectTimeout) {
 		listener.Stop()
@@ -393,9 +388,8 @@ func runCommandStreamingWithWriter(ac *client.AlpaconClient, serverName, command
 		listener.Stop()
 		return err
 	}
-	listener.setCommandID(cmdResp.ID)
 
-	return streamSubscribed(ac, session, listener, cmdResp.ID, cmdResp.Server.ID, out, execTimeout(), streamPollTick, false)
+	return streamSubscribed(ac, listener, cmdResp.ID, cmdResp.Server.ID, out, execTimeout(), streamPollTick, false)
 }
 
 // StreamApprovedCommand resubscribes to an already-submitted command and streams
@@ -404,11 +398,7 @@ func runCommandStreamingWithWriter(ac *client.AlpaconClient, serverName, command
 // PendingApprovalError; the parked job produced no output yet, so resubscribing
 // loses nothing.
 func StreamApprovedCommand(ac *client.AlpaconClient, cmdID string, out io.Writer, timeout time.Duration) error {
-	session, err := CreateEventSession(ac)
-	if err != nil {
-		return runCommandFallbackFromID(ac, cmdID, out, true, err)
-	}
-	listener := NewCommandOutputListener(ac, session.WebsocketURL, cmdID)
+	listener := NewCommandOutputListener(ac)
 	listener.Start()
 	if !listener.WaitConnected(commandOutputConnectTimeout) {
 		listener.Stop()
@@ -420,23 +410,17 @@ func StreamApprovedCommand(ac *client.AlpaconClient, cmdID string, out io.Writer
 	if details, err := GetCommandByID(ac, cmdID); err == nil {
 		serverID = details.Server.ID
 	}
-	return streamSubscribed(ac, session, listener, cmdID, serverID, out, timeout, streamPollTick, true)
+	return streamSubscribed(ac, listener, cmdID, serverID, out, timeout, streamPollTick, true)
 }
 
 // streamSubscribed subscribes to cmdID's output channel and to serverID's fin
 // channel, warm-fires persisted chunks, then writes live chunks to out until the
 // fin event or the poll reports a terminal state. Shared by the fresh-submit and
 // approval-resume paths.
-func streamSubscribed(ac *client.AlpaconClient, session *EventSessionResponse, listener *CommandOutputListener, cmdID, serverID string, out io.Writer, timeout, tick time.Duration, waitApproval bool) error {
-	if err := SubscribeEvent(ac, session.ChannelID, EventTypeCommandOutput, cmdID); err != nil {
+func streamSubscribed(ac *client.AlpaconClient, listener *CommandOutputListener, cmdID, serverID string, out io.Writer, timeout, tick time.Duration, waitApproval bool) error {
+	if err := listener.subscribeTo(cmdID, serverID); err != nil {
 		listener.Stop()
 		return runCommandFallbackFromID(ac, cmdID, out, waitApproval, err)
-	}
-	// Chunks carry no end marker, so without this the exit waits for the poll below
-	// to notice—up to 10 ticks once the command is a minute old. Best effort: on
-	// failure that poll stays the only terminal signal, as before.
-	if serverID != "" {
-		_ = SubscribeEvent(ac, session.ChannelID, EventTypeCommandFin, serverID)
 	}
 
 	// Warm-fire: drain any chunks already persisted. Advance lastSeq only over

--- a/api/event/event.go
+++ b/api/event/event.go
@@ -413,8 +413,8 @@ func StreamApprovedCommand(ac *client.AlpaconClient, cmdID string, out io.Writer
 	return streamSubscribed(ac, listener, cmdID, serverID, out, timeout, streamPollTick, true)
 }
 
-// listenerFailure names why the listener never connected: the server's own error
-// when it reached the server at all, the connect budget otherwise.
+// listenerFailure names why the listener never connected: the last error a session
+// attempt recorded, or the connect budget when no attempt got that far.
 func listenerFailure(listener *CommandOutputListener) error {
 	if err := listener.Err(); err != nil {
 		return err

--- a/api/event/event_test.go
+++ b/api/event/event_test.go
@@ -856,15 +856,13 @@ func TestRunCommandStreaming_NormalFlow(t *testing.T) {
 // so a test can hand streamSubscribed a poll tick of its own choosing.
 func startStream(t *testing.T, ac *client.AlpaconClient, cmdID, serverID string, out io.Writer, tick time.Duration, waitApproval bool) <-chan error {
 	t.Helper()
-	session, err := CreateEventSession(ac)
-	require.NoError(t, err)
-	listener := NewCommandOutputListener(ac, session.WebsocketURL, cmdID)
+	listener := NewCommandOutputListener(ac)
 	listener.Start()
 	require.True(t, listener.WaitConnected(commandOutputConnectTimeout), "listener should connect")
 
 	done := make(chan error, 1)
 	go func() {
-		done <- streamSubscribed(ac, session, listener, cmdID, serverID, out, 30*time.Second, tick, waitApproval)
+		done <- streamSubscribed(ac, listener, cmdID, serverID, out, 30*time.Second, tick, waitApproval)
 	}()
 	return done
 }

--- a/api/event/subscribe_test.go
+++ b/api/event/subscribe_test.go
@@ -5,10 +5,10 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
-	"strings"
 	"testing"
 
 	"github.com/alpacax/alpacon-cli/client"
+	"github.com/alpacax/alpacon-cli/utils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -145,7 +145,7 @@ func TestSubscribeEvent_ServerError(t *testing.T) {
 	assert.Contains(t, err.Error(), "failed to subscribe to sudo events: ")
 }
 
-func TestSubscribeEvent_NotFoundKeepsServerMessageLast(t *testing.T) {
+func TestSubscribeEvent_NotFoundKeepsTheStatusReachable(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusNotFound)
@@ -160,7 +160,7 @@ func TestSubscribeEvent_NotFoundKeepsServerMessageLast(t *testing.T) {
 
 	err := SubscribeEvent(ac, "channel-456", EventTypeSudo, "session-123")
 	require.Error(t, err)
-	// websh's isNotFoundError matches a literal ": not found." suffix on the
-	// lowercased message, so the wrap must keep the server's detail last.
-	assert.True(t, strings.HasSuffix(strings.ToLower(err.Error()), ": not found."), "got %q", err.Error())
+	// websh reads the status off this error to stay quiet on an older server, so the
+	// wrap must keep it reachable.
+	assert.Equal(t, http.StatusNotFound, utils.HTTPStatusCode(err))
 }

--- a/api/event/sudolistener.go
+++ b/api/event/sudolistener.go
@@ -89,8 +89,7 @@ func (sl *SudoListener) Err() error {
 func (sl *SudoListener) provisionSession() (string, error) {
 	session, err := CreateEventSession(sl.ac)
 	if err != nil {
-		sl.announceOutage(err)
-		return "", sl.failIfFatal(err)
+		return "", sl.fail(err)
 	}
 
 	sl.stateMu.Lock()
@@ -106,8 +105,7 @@ func (sl *SudoListener) subscribe() error {
 	sl.stateMu.Unlock()
 
 	if err := SubscribeEvent(sl.ac, channelID, EventTypeSudo, sl.sessionID); err != nil {
-		sl.announceOutage(err)
-		return sl.failIfFatal(err)
+		return sl.fail(err)
 	}
 
 	sl.stateMu.Lock()
@@ -119,40 +117,37 @@ func (sl *SudoListener) subscribe() error {
 	return nil
 }
 
-// failIfFatal stops the listener when retrying cannot help: a 4xx before the first
-// subscribe means a bad session or an expired login, not an outage. Everything else
-// is left to the reconnect loop.
-func (sl *SudoListener) failIfFatal(cause error) error {
+// announceOutage is the dial-failure hook: a dial error reaches neither
+// provisionSession nor subscribe, so without it a transport outage is silent.
+func (sl *SudoListener) announceOutage(cause error) {
+	_ = sl.fail(cause)
+}
+
+// fail decides what a failed connect attempt means. A fatal 4xx before the first
+// subscribe is a bad session or an expired login, so the listener stops carrying the
+// reason; websh reports that one itself, which is why nothing is announced before then.
+// Once subscribed, the same failure is an outage: announced once, then left to the
+// reconnect loop, with its own CRLF because websh holds the terminal in raw mode.
+func (sl *SudoListener) fail(cause error) error {
 	sl.stateMu.Lock()
 	fatal := !sl.subscribed && isFatalRequestError(cause)
 	if fatal {
 		sl.err = cause
+	}
+	announce := sl.subscribed && !sl.warned
+	if announce {
+		sl.warned = true
 	}
 	sl.stateMu.Unlock()
 
 	if fatal {
 		sl.Stop()
 	}
+	if announce {
+		_, _ = fmt.Fprintf(os.Stderr, "\r\n%s\r\n", utils.Yellow("Sudo MFA listener disconnected; retrying..."))
+	}
 
 	return cause
-}
-
-// announceOutage reports a dropped event channel once per outage. Before the first
-// subscribe the caller (websh) already handles the failure, so this stays quiet.
-// The message is wrapped in CRLF because websh holds the terminal in raw mode.
-func (sl *SudoListener) announceOutage(error) {
-	sl.stateMu.Lock()
-	quiet := !sl.subscribed || sl.warned
-	if !quiet {
-		sl.warned = true
-	}
-	sl.stateMu.Unlock()
-
-	if quiet {
-		return
-	}
-
-	_, _ = fmt.Fprint(os.Stderr, "\r\n\033[33mSudo MFA listener disconnected; retrying...\033[0m\r\n")
 }
 
 func (sl *SudoListener) handleMessage(message []byte) {

--- a/api/event/sudolistener.go
+++ b/api/event/sudolistener.go
@@ -122,7 +122,7 @@ func (sl *SudoListener) subscribe() error {
 // is left to the reconnect loop.
 func (sl *SudoListener) failIfFatal(cause error) error {
 	sl.stateMu.Lock()
-	fatal := !sl.subscribed && utils.IsFatalClientError(utils.HTTPStatusCode(cause))
+	fatal := !sl.subscribed && isFatalRequestError(cause)
 	if fatal {
 		sl.err = cause
 	}

--- a/api/event/sudolistener.go
+++ b/api/event/sudolistener.go
@@ -47,23 +47,88 @@ type sudoMFAEvent struct {
 // The AlpaconClient (ac) is shared with the terminal WebSocket goroutines.
 // http.Client is concurrency-safe. Token refresh and grant verification are
 // serialized by mfaMu so only one MFA flow runs at a time.
+//
+// Event channel tokens are single-use, so every dial provisions its own session
+// and re-subscribes once connected.
 type SudoListener struct {
 	*wsListener
 	ac         *client.AlpaconClient
 	serverName string
+	sessionID  string
 	mfaMu      sync.Mutex // serializes handleSudoMFA so only one MFA flow runs at a time
+
+	stateMu    sync.Mutex // guards channelID, subscribed, err
+	channelID  string
+	subscribed bool
+	err        error
 }
 
 // NewSudoListener creates a SudoListener but does not connect yet. ac may be
 // nil in tests; MFA request frames are then dropped instead of dereferencing it.
-func NewSudoListener(ac *client.AlpaconClient, wsURL, serverName string) *SudoListener {
+func NewSudoListener(ac *client.AlpaconClient, serverName, sessionID string) *SudoListener {
 	sl := &SudoListener{
-		wsListener: newWSListener(ac, wsURL, sudoHandshakeTimeout),
 		ac:         ac,
 		serverName: serverName,
+		sessionID:  sessionID,
 	}
+	sl.wsListener = newProvisionedWSListener(ac, sl.provisionSession, sudoHandshakeTimeout)
 	sl.handleFrame = sl.handleMessage
+	sl.onConnected = sl.subscribe
 	return sl
+}
+
+// Err returns the error that stopped the listener before it ever subscribed.
+func (sl *SudoListener) Err() error {
+	sl.stateMu.Lock()
+	defer sl.stateMu.Unlock()
+	return sl.err
+}
+
+func (sl *SudoListener) provisionSession() (string, error) {
+	session, err := CreateEventSession(sl.ac)
+	if err != nil {
+		return "", sl.failIfFatal(err)
+	}
+
+	sl.stateMu.Lock()
+	sl.channelID = session.ChannelID
+	sl.stateMu.Unlock()
+
+	return session.WebsocketURL, nil
+}
+
+func (sl *SudoListener) subscribe() error {
+	sl.stateMu.Lock()
+	channelID := sl.channelID
+	sl.stateMu.Unlock()
+
+	if err := SubscribeEvent(sl.ac, channelID, EventTypeSudo, sl.sessionID); err != nil {
+		return sl.failIfFatal(err)
+	}
+
+	sl.stateMu.Lock()
+	sl.subscribed = true
+	sl.stateMu.Unlock()
+
+	return nil
+}
+
+// failIfFatal stops the listener when retrying cannot help: a 4xx before the first
+// subscribe means a bad session or an expired login, not an outage. Everything else
+// is left to the reconnect loop.
+func (sl *SudoListener) failIfFatal(cause error) error {
+	sl.stateMu.Lock()
+	fatal := !sl.subscribed && utils.IsFatalClientError(utils.HTTPStatusCode(cause))
+	if fatal {
+		sl.err = cause
+	}
+	sl.stateMu.Unlock()
+
+	if fatal {
+		sl.Stop()
+	}
+
+	return cause
 }
 
 func (sl *SudoListener) handleMessage(message []byte) {

--- a/api/event/sudolistener.go
+++ b/api/event/sudolistener.go
@@ -3,6 +3,7 @@ package event
 import (
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"net/url"
 	"os"
 	"sync"
@@ -56,6 +57,8 @@ type SudoListener struct {
 	serverName string
 	sessionID  string
 	mfaMu      sync.Mutex // serializes handleSudoMFA so only one MFA flow runs at a time
+	// refreshToken is ac.RefreshToken, or nil when ac is nil. Replaced in tests.
+	refreshToken func() error
 
 	stateMu    sync.Mutex // guards channelID, subscribed, warned, err
 	channelID  string
@@ -64,13 +67,17 @@ type SudoListener struct {
 	err        error
 }
 
-// NewSudoListener creates a SudoListener but does not connect yet. ac may be
-// nil in tests; MFA request frames are then dropped instead of dereferencing it.
+// NewSudoListener creates a SudoListener but does not connect yet. ac may be nil
+// only for a test that never calls Start: MFA request frames are then dropped, but
+// provisioning a session on the listen goroutine would dereference it.
 func NewSudoListener(ac *client.AlpaconClient, serverName, sessionID string) *SudoListener {
 	sl := &SudoListener{
 		ac:         ac,
 		serverName: serverName,
 		sessionID:  sessionID,
+	}
+	if ac != nil {
+		sl.refreshToken = ac.RefreshToken
 	}
 	sl.wsListener = newProvisionedWSListener(ac, sl.provisionSession, sudoHandshakeTimeout)
 	sl.handleFrame = sl.handleMessage
@@ -79,7 +86,8 @@ func NewSudoListener(ac *client.AlpaconClient, serverName, sessionID string) *Su
 	return sl
 }
 
-// Err returns the error that stopped the listener before it ever subscribed.
+// Err returns the last reason the listener could not connect, so a caller that only
+// sees WaitConnected time out can report that instead of a bare timeout.
 func (sl *SudoListener) Err() error {
 	sl.stateMu.Lock()
 	defer sl.stateMu.Unlock()
@@ -112,6 +120,7 @@ func (sl *SudoListener) subscribe() error {
 	sl.subscribed = true
 	// A recovered channel means the next outage is a new one, worth announcing again.
 	sl.warned = false
+	sl.err = nil
 	sl.stateMu.Unlock()
 
 	return nil
@@ -125,13 +134,12 @@ func (sl *SudoListener) announceOutage(cause error) {
 // 4xx is a bad session or an expired login: the listener stops, carrying the reason for
 // websh to report, and says nothing itself. After it, the same failure is an outage
 // announced once, in CRLF because websh holds the terminal in raw mode, then left to
-// the reconnect loop.
+// the reconnect loop. Every cause is recorded either way, so a caller reading Err()
+// after a timeout gets the transport's own words rather than nothing.
 func (sl *SudoListener) fail(cause error) error {
 	sl.stateMu.Lock()
+	sl.err = cause
 	fatal := !sl.subscribed && isFatalRequestError(cause)
-	if fatal {
-		sl.err = cause
-	}
 	announce := sl.subscribed && !sl.warned
 	if announce {
 		sl.warned = true
@@ -140,12 +148,40 @@ func (sl *SudoListener) fail(cause error) error {
 
 	if fatal {
 		sl.Stop()
-	}
-	if announce {
-		_, _ = fmt.Fprintf(os.Stderr, "\r\n%s\r\n", utils.Yellow("Sudo MFA listener disconnected; retrying..."))
+		return cause
 	}
 
+	if announce {
+		select {
+		case <-sl.done:
+			// Stop cancels neither an in-flight dial nor a session create, so a
+			// failure landing after it must not claim anything is still retrying.
+		default:
+			_, _ = fmt.Fprintf(os.Stderr, "\r\n%s\r\n", utils.Yellow("Sudo MFA listener disconnected; retrying..."))
+		}
+	}
+
+	sl.refreshExpiredToken(cause)
+
 	return cause
+}
+
+// refreshExpiredToken renews the access token when cause is a 401. Past the first
+// subscribe nothing is fatal, so without this an access token that expires mid-session
+// is re-presented on every dial until websh exits and sudo MFA never comes back.
+func (sl *SudoListener) refreshExpiredToken(cause error) {
+	if sl.refreshToken == nil || utils.HTTPStatusCode(cause) != http.StatusUnauthorized {
+		return
+	}
+	// An MFA flow holds mfaMu across its own refresh; a second one would race it.
+	if !sl.mfaMu.TryLock() {
+		return
+	}
+	defer sl.mfaMu.Unlock()
+
+	// A failed refresh leaves the next attempt to the reconnect loop, which is
+	// where a recovery would land anyway.
+	_ = sl.refreshToken()
 }
 
 func (sl *SudoListener) handleMessage(message []byte) {

--- a/api/event/sudolistener.go
+++ b/api/event/sudolistener.go
@@ -57,9 +57,10 @@ type SudoListener struct {
 	sessionID  string
 	mfaMu      sync.Mutex // serializes handleSudoMFA so only one MFA flow runs at a time
 
-	stateMu    sync.Mutex // guards channelID, subscribed, err
+	stateMu    sync.Mutex // guards channelID, subscribed, warned, err
 	channelID  string
 	subscribed bool
+	warned     bool
 	err        error
 }
 
@@ -74,6 +75,7 @@ func NewSudoListener(ac *client.AlpaconClient, serverName, sessionID string) *Su
 	sl.wsListener = newProvisionedWSListener(ac, sl.provisionSession, sudoHandshakeTimeout)
 	sl.handleFrame = sl.handleMessage
 	sl.onConnected = sl.subscribe
+	sl.onDialFailed = sl.announceOutage
 	return sl
 }
 
@@ -108,6 +110,8 @@ func (sl *SudoListener) subscribe() error {
 
 	sl.stateMu.Lock()
 	sl.subscribed = true
+	// A recovered channel means the next outage is a new one, worth announcing again.
+	sl.warned = false
 	sl.stateMu.Unlock()
 
 	return nil
@@ -129,6 +133,24 @@ func (sl *SudoListener) failIfFatal(cause error) error {
 	}
 
 	return cause
+}
+
+// announceOutage reports a dropped event channel once per outage. Before the first
+// subscribe the caller (websh) already handles the failure, so this stays quiet.
+// The message is wrapped in CRLF because websh holds the terminal in raw mode.
+func (sl *SudoListener) announceOutage(error) {
+	sl.stateMu.Lock()
+	quiet := !sl.subscribed || sl.warned
+	if !quiet {
+		sl.warned = true
+	}
+	sl.stateMu.Unlock()
+
+	if quiet {
+		return
+	}
+
+	_, _ = fmt.Fprint(os.Stderr, "\r\n\033[33mSudo MFA listener disconnected; retrying...\033[0m\r\n")
 }
 
 func (sl *SudoListener) handleMessage(message []byte) {

--- a/api/event/sudolistener.go
+++ b/api/event/sudolistener.go
@@ -89,6 +89,7 @@ func (sl *SudoListener) Err() error {
 func (sl *SudoListener) provisionSession() (string, error) {
 	session, err := CreateEventSession(sl.ac)
 	if err != nil {
+		sl.announceOutage(err)
 		return "", sl.failIfFatal(err)
 	}
 
@@ -105,6 +106,7 @@ func (sl *SudoListener) subscribe() error {
 	sl.stateMu.Unlock()
 
 	if err := SubscribeEvent(sl.ac, channelID, EventTypeSudo, sl.sessionID); err != nil {
+		sl.announceOutage(err)
 		return sl.failIfFatal(err)
 	}
 

--- a/api/event/sudolistener.go
+++ b/api/event/sudolistener.go
@@ -28,6 +28,10 @@ const (
 	mfaPollingTimeout = 60 * time.Second
 
 	sudoHandshakeTimeout = 10 * time.Second
+
+	// sudoOutageWarning is asserted on by the tests, so it lives here rather than
+	// inline at the one place that prints it.
+	sudoOutageWarning = "Sudo MFA listener disconnected; retrying..."
 )
 
 // sudoMFAEvent represents the MFA request payload from the event WebSocket.
@@ -60,10 +64,11 @@ type SudoListener struct {
 	// refreshToken is ac.RefreshToken, or nil when ac is nil. Replaced in tests.
 	refreshToken func() error
 
-	stateMu    sync.Mutex // guards channelID, subscribed, warned, err
+	stateMu    sync.Mutex // guards channelID, subscribed, warned, refreshed, err
 	channelID  string
 	subscribed bool
 	warned     bool
+	refreshed  bool
 	err        error
 }
 
@@ -137,9 +142,19 @@ func (sl *SudoListener) announceOutage(cause error) {
 // the reconnect loop. Every cause is recorded either way, so a caller reading Err()
 // after a timeout gets the transport's own words rather than nothing.
 func (sl *SudoListener) fail(cause error) error {
+	// refreshToken is assigned before Start and never reassigned, so no lock here.
+	expired := sl.refreshToken != nil && utils.HTTPStatusCode(cause) == http.StatusUnauthorized
+
 	sl.stateMu.Lock()
 	sl.err = cause
 	fatal := !sl.subscribed && isFatalRequestError(cause)
+	// websh created its own session on this token moments ago, so a 401 on the first
+	// attempt means it expired in between and a refresh would fix it. One is enough:
+	// a 401 answering a token this listener just renewed is a real refusal.
+	if fatal && expired && !sl.refreshed {
+		sl.refreshed = true
+		fatal = false
+	}
 	announce := sl.subscribed && !sl.warned
 	if announce {
 		sl.warned = true
@@ -157,22 +172,22 @@ func (sl *SudoListener) fail(cause error) error {
 			// Stop cancels neither an in-flight dial nor a session create, so a
 			// failure landing after it must not claim anything is still retrying.
 		default:
-			_, _ = fmt.Fprintf(os.Stderr, "\r\n%s\r\n", utils.Yellow("Sudo MFA listener disconnected; retrying..."))
+			_, _ = fmt.Fprintf(os.Stderr, "\r\n%s\r\n", utils.Yellow(sudoOutageWarning))
 		}
 	}
 
-	sl.refreshExpiredToken(cause)
+	if expired {
+		sl.refreshExpiredToken()
+	}
 
 	return cause
 }
 
-// refreshExpiredToken renews the access token when cause is a 401. Past the first
-// subscribe nothing is fatal, so without this an access token that expires mid-session
-// is re-presented on every dial until websh exits and sudo MFA never comes back.
-func (sl *SudoListener) refreshExpiredToken(cause error) {
-	if sl.refreshToken == nil || utils.HTTPStatusCode(cause) != http.StatusUnauthorized {
-		return
-	}
+// refreshExpiredToken renews the access token so the next dial stops presenting the one
+// that just came back 401. Past the first subscribe nothing else would: no status is
+// fatal there, so an access token that expires mid-session would be re-presented on
+// every dial until websh exits and sudo MFA would never come back.
+func (sl *SudoListener) refreshExpiredToken() {
 	// An MFA flow holds mfaMu across its own refresh; a second one would race it.
 	if !sl.mfaMu.TryLock() {
 		return

--- a/api/event/sudolistener.go
+++ b/api/event/sudolistener.go
@@ -117,17 +117,15 @@ func (sl *SudoListener) subscribe() error {
 	return nil
 }
 
-// announceOutage is the dial-failure hook: a dial error reaches neither
-// provisionSession nor subscribe, so without it a transport outage is silent.
 func (sl *SudoListener) announceOutage(cause error) {
 	_ = sl.fail(cause)
 }
 
-// fail decides what a failed connect attempt means. A fatal 4xx before the first
-// subscribe is a bad session or an expired login, so the listener stops carrying the
-// reason; websh reports that one itself, which is why nothing is announced before then.
-// Once subscribed, the same failure is an outage: announced once, then left to the
-// reconnect loop, with its own CRLF because websh holds the terminal in raw mode.
+// fail decides what a failed connect attempt means. Before the first subscribe a fatal
+// 4xx is a bad session or an expired login: the listener stops, carrying the reason for
+// websh to report, and says nothing itself. After it, the same failure is an outage
+// announced once, in CRLF because websh holds the terminal in raw mode, then left to
+// the reconnect loop.
 func (sl *SudoListener) fail(cause error) error {
 	sl.stateMu.Lock()
 	fatal := !sl.subscribed && isFatalRequestError(cause)

--- a/api/event/sudolistener.go
+++ b/api/event/sudolistener.go
@@ -149,8 +149,10 @@ func (sl *SudoListener) fail(cause error) error {
 	sl.err = cause
 	fatal := !sl.subscribed && isFatalRequestError(cause)
 	// websh created its own session on this token moments ago, so a 401 on the first
-	// attempt means it expired in between and a refresh would fix it. One is enough:
-	// a 401 answering a token this listener just renewed is a real refusal.
+	// attempt means it expired in between and a refresh would fix it. The allowance is
+	// spent here whether or not the refresh below lands, because what it bounds is the
+	// downgrade, not the refresh: a refresh that fails leaves the retry presenting the
+	// same token, and that second 401 is the one that has to stop us.
 	if fatal && expired && !sl.refreshed {
 		sl.refreshed = true
 		fatal = false

--- a/api/event/sudolistener_test.go
+++ b/api/event/sudolistener_test.go
@@ -93,7 +93,7 @@ func TestSudoListener_StopClosesConnection(t *testing.T) {
 	sl := NewSudoListener(ac, "my-server", "session-1")
 	sl.Start()
 
-	require.True(t, sl.WaitConnected(3*time.Second))
+	require.True(t, sl.WaitConnected(3*time.Second), "the listener must connect before Stop has a connection to close")
 
 	sl.Stop()
 
@@ -313,7 +313,7 @@ func TestSudoListener_AnnouncesOutageOncePerOutage(t *testing.T) {
 		sl.Start()
 		defer sl.Stop()
 
-		require.True(t, sl.WaitConnected(3*time.Second))
+		require.True(t, sl.WaitConnected(3*time.Second), "the first dial must subscribe before an outage counts")
 
 		// A third session means at least two dials failed after the first connect.
 		require.Eventually(t, func() bool {
@@ -340,7 +340,7 @@ func TestSudoListener_StaysQuietBeforeFirstSubscribe(t *testing.T) {
 		sl.Start()
 		defer sl.Stop()
 
-		assert.False(t, sl.WaitConnected(300*time.Millisecond))
+		assert.False(t, sl.WaitConnected(300*time.Millisecond), "a listener that never upgrades must not report a connection")
 	})
 
 	assert.NotContains(t, stderr, "Sudo MFA listener disconnected")
@@ -369,7 +369,7 @@ func TestSudoListener_AnnouncesOutageWhenSessionCreateFails(t *testing.T) {
 		sl.Start()
 		defer sl.Stop()
 
-		require.True(t, sl.WaitConnected(3*time.Second))
+		require.True(t, sl.WaitConnected(3*time.Second), "the first dial must subscribe before an outage counts")
 
 		require.Eventually(t, func() bool {
 			return sessions.Load() >= 3
@@ -402,7 +402,7 @@ func TestSudoListener_AnnouncesOutageWhenResubscribeFails(t *testing.T) {
 		sl.Start()
 		defer sl.Stop()
 
-		require.True(t, sl.WaitConnected(3*time.Second))
+		require.True(t, sl.WaitConnected(3*time.Second), "the first dial must subscribe before an outage counts")
 
 		require.Eventually(t, func() bool {
 			return subscribes.Load() >= 3
@@ -411,4 +411,52 @@ func TestSudoListener_AnnouncesOutageWhenResubscribeFails(t *testing.T) {
 
 	assert.Equal(t, 1, strings.Count(stderr, "Sudo MFA listener disconnected"),
 		"a resubscribe that keeps failing is an outage and must be announced once")
+}
+
+func TestSudoListener_AnnouncesTheNextOutageAfterRecovering(t *testing.T) {
+	// Upgrade the first and third dials: outage, recovery, outage. The second
+	// outage is a new one, so the recovery must clear the warned flag.
+	upgradeFirstAndThird := func(attempt int32) bool { return attempt == 1 || attempt == 3 }
+
+	ts, sessions, _ := newWatcherTestServer(t, alwaysCreated, upgradeFirstAndThird, alwaysCreated, func(conn *websocket.Conn, _ int32) {
+		_ = conn.Close()
+	})
+
+	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
+
+	_, stderr := testutil.CaptureOutput(t, func() {
+		sl := NewSudoListener(ac, "my-server", "session-1")
+		sl.reconnectBaseDelay = testReconnectBaseDelay
+		sl.Start()
+		defer sl.Stop()
+
+		require.True(t, sl.WaitConnected(3*time.Second), "the first dial must connect and subscribe")
+
+		// Six sessions means the fifth dial already failed, so the second outage
+		// has had its chance to speak.
+		require.Eventually(t, func() bool {
+			return sessions.Load() >= 6
+		}, 5*time.Second, 10*time.Millisecond)
+	})
+
+	assert.Equal(t, 2, strings.Count(stderr, "Sudo MFA listener disconnected"),
+		"a recovered channel makes the next outage a new one, worth announcing again")
+}
+
+func TestSudoListener_FirstSessionFailureStopsAndSurfaces(t *testing.T) {
+	ts, _, _ := newWatcherTestServer(t, alwaysRejected, alwaysUpgrade, alwaysCreated, func(conn *websocket.Conn, _ int32) {})
+
+	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
+	sl := NewSudoListener(ac, "my-server", "session-1")
+	sl.reconnectBaseDelay = testReconnectBaseDelay
+	sl.Start()
+	defer sl.Stop()
+
+	// A rejected session before the first subscribe must end the wait rather than
+	// retry, and websh needs the server's reason for its warning.
+	assert.False(t, sl.WaitConnected(3*time.Second), "a rejected session must not report a connection")
+
+	err := sl.Err()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to create event session")
 }

--- a/api/event/sudolistener_test.go
+++ b/api/event/sudolistener_test.go
@@ -5,8 +5,6 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
-	"strings"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -81,38 +79,24 @@ func TestSudoListener_HandleSudoMFA_DropsRequestWhenClientIsNil(t *testing.T) {
 }
 
 func TestSudoListener_StopClosesConnection(t *testing.T) {
-	upgrader := websocket.Upgrader{}
-
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		conn, err := upgrader.Upgrade(w, r, nil)
-		if err != nil {
-			return
-		}
+	ts, _, _ := newWatcherTestServer(t, alwaysCreated, alwaysUpgrade, alwaysCreated, func(conn *websocket.Conn, _ int32) {
 		for {
 			if _, _, err := conn.ReadMessage(); err != nil {
-				break
+				return
 			}
 		}
-	}))
-	defer server.Close()
+	})
 
-	wsURL := "ws" + strings.TrimPrefix(server.URL, "http")
-	sl := NewSudoListener(nil, wsURL, "")
+	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
+	sl := NewSudoListener(ac, "my-server", "session-1")
 	sl.Start()
 
-	// Wait for connection to establish by polling sl.conn
-	require.Eventually(t, func() bool {
-		sl.mu.Lock()
-		defer sl.mu.Unlock()
-		return sl.conn != nil
-	}, 2*time.Second, 10*time.Millisecond, "listener should connect")
+	require.True(t, sl.WaitConnected(3*time.Second))
 
 	sl.Stop()
 
-	// Wait for listenLoop goroutine to exit via stopped channel
 	select {
 	case <-sl.stopped:
-		// goroutine exited and cleanup ran
 	case <-time.After(2 * time.Second):
 		t.Fatal("timeout waiting for listener goroutine to exit")
 	}
@@ -123,27 +107,16 @@ func TestSudoListener_StopClosesConnection(t *testing.T) {
 }
 
 func TestSudoListener_ConnectAndListen_ExitsOnDisconnect(t *testing.T) {
-	upgrader := websocket.Upgrader{}
 	clientRead := make(chan struct{})
 
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		conn, err := upgrader.Upgrade(w, r, nil)
-		if err != nil {
-			return
-		}
+	ts, _, _ := newWatcherTestServer(t, alwaysCreated, alwaysUpgrade, alwaysCreated, func(conn *websocket.Conn, _ int32) {
 		defer func() { _ = conn.Close() }()
-
-		msg := `{"payload":{"type":"info","query":"status"}}`
-		_ = conn.WriteMessage(websocket.TextMessage, []byte(msg))
-
-		// Wait for client to read the message before closing
+		_ = conn.WriteMessage(websocket.TextMessage, []byte(`{"payload":{"type":"info","query":"status"}}`))
 		<-clientRead
-	}))
-	defer server.Close()
+	})
 
-	wsURL := "ws" + strings.TrimPrefix(server.URL, "http")
-
-	sl := NewSudoListener(nil, wsURL, "")
+	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
+	sl := NewSudoListener(ac, "my-server", "session-1")
 
 	// Local signal, so the test does not close the skeleton's stopped channel
 	readDone := make(chan struct{})
@@ -152,7 +125,6 @@ func TestSudoListener_ConnectAndListen_ExitsOnDisconnect(t *testing.T) {
 		_ = sl.connectAndListen()
 	}()
 
-	// Wait for connection, then signal server to close
 	require.Eventually(t, func() bool {
 		sl.mu.Lock()
 		defer sl.mu.Unlock()
@@ -163,7 +135,6 @@ func TestSudoListener_ConnectAndListen_ExitsOnDisconnect(t *testing.T) {
 
 	select {
 	case <-readDone:
-		// connectAndListen returned cleanly after server disconnect
 	case <-time.After(2 * time.Second):
 		t.Fatal("timeout waiting for connectAndListen to return")
 	}
@@ -211,39 +182,6 @@ func TestSudoListener_VerifySudoGrant_ServerError(t *testing.T) {
 	assert.Error(t, err)
 }
 
-func TestSudoListener_ReconnectsAfterDisconnect(t *testing.T) {
-	upgrader := websocket.Upgrader{}
-	var connectCount atomic.Int32
-
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		conn, err := upgrader.Upgrade(w, r, nil)
-		if err != nil {
-			return
-		}
-		connectCount.Add(1)
-		// Close immediately to trigger reconnect
-		_ = conn.Close()
-	}))
-	defer server.Close()
-
-	wsURL := "ws" + strings.TrimPrefix(server.URL, "http")
-	sl := NewSudoListener(nil, wsURL, "")
-	sl.Start()
-
-	// Wait for at least 2 connection attempts (initial + reconnect)
-	require.Eventually(t, func() bool {
-		return connectCount.Load() >= 2
-	}, 5*time.Second, 100*time.Millisecond, "should reconnect after disconnect")
-
-	sl.Stop()
-
-	select {
-	case <-sl.stopped:
-	case <-time.After(2 * time.Second):
-		t.Fatal("timeout waiting for listener to stop")
-	}
-}
-
 func TestSudoListener_PollMFACompletion_Timeout(t *testing.T) {
 	sl := NewSudoListener(nil, "", "")
 
@@ -258,4 +196,100 @@ func TestSudoListener_PollMFACompletion_Timeout(t *testing.T) {
 
 	assert.False(t, result, "should return false when stopped")
 	assert.Less(t, elapsed, 2*time.Second, "should exit quickly when stopped")
+}
+
+func TestSudoListener_CreatesANewSessionOnReconnect(t *testing.T) {
+	ts, sessions, _ := newWatcherTestServer(t, alwaysCreated, alwaysUpgrade, alwaysCreated, func(conn *websocket.Conn, n int32) {
+		if n == 1 {
+			// The token is single-use, so recovering means a whole new session.
+			_ = conn.Close()
+			return
+		}
+		for {
+			if _, _, err := conn.ReadMessage(); err != nil {
+				return
+			}
+		}
+	})
+
+	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
+	sl := NewSudoListener(ac, "my-server", "session-1")
+	sl.reconnectBaseDelay = testReconnectBaseDelay
+	sl.Start()
+	defer sl.Stop()
+
+	assert.Eventually(t, func() bool {
+		return sessions.Load() >= 2
+	}, 5*time.Second, 10*time.Millisecond, "each attempt must create its own event session")
+}
+
+func TestSudoListener_ResubscribesOnReconnect(t *testing.T) {
+	ts, _, subscribes := newWatcherTestServer(t, alwaysCreated, alwaysUpgrade, alwaysCreated, func(conn *websocket.Conn, n int32) {
+		if n == 1 {
+			_ = conn.Close()
+			return
+		}
+		for {
+			if _, _, err := conn.ReadMessage(); err != nil {
+				return
+			}
+		}
+	})
+
+	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
+	sl := NewSudoListener(ac, "my-server", "session-1")
+	sl.reconnectBaseDelay = testReconnectBaseDelay
+	sl.Start()
+	defer sl.Stop()
+
+	assert.Eventually(t, func() bool {
+		return subscribes.Load() >= 2
+	}, 5*time.Second, 10*time.Millisecond, "a reconnect must re-issue the sudo subscription")
+}
+
+func TestSudoListener_FirstSubscribeFailureStopsAndSurfaces(t *testing.T) {
+	ts, _, _ := newWatcherTestServer(t, alwaysCreated, alwaysUpgrade, alwaysRejected, func(conn *websocket.Conn, _ int32) {
+		for {
+			if _, _, err := conn.ReadMessage(); err != nil {
+				return
+			}
+		}
+	})
+
+	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
+	sl := NewSudoListener(ac, "my-server", "session-1")
+	sl.Start()
+	defer sl.Stop()
+
+	assert.False(t, sl.WaitConnected(3*time.Second), "a rejected subscription must not report connected")
+
+	err := sl.Err()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to subscribe to sudo events")
+}
+
+func TestSudoListener_SessionCreateRetryableStatusIsRetried(t *testing.T) {
+	failFirst := func(attempt int32) int {
+		if attempt == 1 {
+			return http.StatusServiceUnavailable
+		}
+		return http.StatusCreated
+	}
+
+	ts, _, _ := newWatcherTestServer(t, failFirst, alwaysUpgrade, alwaysCreated, func(conn *websocket.Conn, _ int32) {
+		for {
+			if _, _, err := conn.ReadMessage(); err != nil {
+				return
+			}
+		}
+	})
+
+	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
+	sl := NewSudoListener(ac, "my-server", "session-1")
+	sl.reconnectBaseDelay = testReconnectBaseDelay
+	sl.Start()
+	defer sl.Stop()
+
+	assert.True(t, sl.WaitConnected(3*time.Second), "a 503 before the first subscribe is not fatal; the next attempt must connect")
+	assert.NoError(t, sl.Err())
 }

--- a/api/event/sudolistener_test.go
+++ b/api/event/sudolistener_test.go
@@ -297,8 +297,7 @@ func TestSudoListener_SessionCreateRetryableStatusIsRetried(t *testing.T) {
 }
 
 func TestSudoListener_AnnouncesOutageOncePerOutage(t *testing.T) {
-	// Upgrade the first connection, then refuse: the listener is subscribed and every
-	// later dial fails, which is exactly one outage.
+	// Subscribed once, then every later dial fails: exactly one outage.
 	upgradeFirstOnly := func(attempt int32) bool { return attempt == 1 }
 
 	ts, sessions, _ := newWatcherTestServer(t, alwaysCreated, upgradeFirstOnly, alwaysCreated, func(conn *websocket.Conn, _ int32) {
@@ -326,8 +325,7 @@ func TestSudoListener_AnnouncesOutageOncePerOutage(t *testing.T) {
 }
 
 func TestSudoListener_StaysQuietBeforeFirstSubscribe(t *testing.T) {
-	// Never upgrade: the listener never subscribes, so websh's own WaitConnected
-	// failure is the only thing that should speak.
+	// It never subscribes, so websh's WaitConnected failure is the only thing that speaks.
 	neverUpgrade := func(int32) bool { return false }
 
 	ts, _, _ := newWatcherTestServer(t, alwaysCreated, neverUpgrade, alwaysCreated, func(conn *websocket.Conn, _ int32) {})
@@ -347,8 +345,7 @@ func TestSudoListener_StaysQuietBeforeFirstSubscribe(t *testing.T) {
 }
 
 func TestSudoListener_AnnouncesOutageWhenSessionCreateFails(t *testing.T) {
-	// The first attempt connects and subscribes, then every later session create
-	// fails: an outage that never reaches the dial, so onDialFailed never fires.
+	// This outage never reaches the dial, so onDialFailed is not what announces it.
 	createThenFail := func(attempt int32) int {
 		if attempt == 1 {
 			return http.StatusCreated
@@ -381,8 +378,7 @@ func TestSudoListener_AnnouncesOutageWhenSessionCreateFails(t *testing.T) {
 }
 
 func TestSudoListener_AnnouncesOutageWhenResubscribeFails(t *testing.T) {
-	// The dial keeps succeeding but every resubscribe after the first fails, so the
-	// channel is dead even though onDialFailed never fires.
+	// The dial succeeds every time; only the resubscribe fails, so onDialFailed never fires.
 	createThenFail := func(attempt int32) int {
 		if attempt == 1 {
 			return http.StatusCreated
@@ -414,8 +410,7 @@ func TestSudoListener_AnnouncesOutageWhenResubscribeFails(t *testing.T) {
 }
 
 func TestSudoListener_AnnouncesTheNextOutageAfterRecovering(t *testing.T) {
-	// Upgrade the first and third dials: outage, recovery, outage. The second
-	// outage is a new one, so the recovery must clear the warned flag.
+	// Outage, recovery, outage: the recovery must clear the warned flag.
 	upgradeFirstAndThird := func(attempt int32) bool { return attempt == 1 || attempt == 3 }
 
 	ts, sessions, _ := newWatcherTestServer(t, alwaysCreated, upgradeFirstAndThird, alwaysCreated, func(conn *websocket.Conn, _ int32) {
@@ -432,8 +427,7 @@ func TestSudoListener_AnnouncesTheNextOutageAfterRecovering(t *testing.T) {
 
 		require.True(t, sl.WaitConnected(3*time.Second), "the first dial must connect and subscribe")
 
-		// Six sessions means the fifth dial already failed, so the second outage
-		// has had its chance to speak.
+		// Six sessions means the fifth dial already failed, so the second outage has spoken.
 		require.Eventually(t, func() bool {
 			return sessions.Load() >= 6
 		}, 5*time.Second, 10*time.Millisecond)
@@ -452,8 +446,7 @@ func TestSudoListener_FirstSessionFailureStopsAndSurfaces(t *testing.T) {
 	sl.Start()
 	defer sl.Stop()
 
-	// A rejected session before the first subscribe must end the wait rather than
-	// retry, and websh needs the server's reason for its warning.
+	// It must end the wait rather than retry, and websh needs the server's reason.
 	assert.False(t, sl.WaitConnected(3*time.Second), "a rejected session must not report a connection")
 
 	err := sl.Err()

--- a/api/event/sudolistener_test.go
+++ b/api/event/sudolistener_test.go
@@ -2,10 +2,12 @@ package event
 
 import (
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -448,6 +450,112 @@ func TestSudoListener_FirstSessionFailureStopsAndSurfaces(t *testing.T) {
 
 	// It must end the wait rather than retry, and websh needs the server's reason.
 	assert.False(t, sl.WaitConnected(3*time.Second), "a rejected session must not report a connection")
+
+	err := sl.Err()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to create event session")
+}
+
+func TestSudoListener_RefreshesTheAccessTokenOnUnauthorized(t *testing.T) {
+	// The token expires only after the listener is subscribed, where nothing is fatal.
+	createThenUnauthorized := func(attempt int32) int {
+		if attempt == 1 {
+			return http.StatusCreated
+		}
+		return http.StatusUnauthorized
+	}
+
+	ts, sessions, _ := newWatcherTestServer(t, createThenUnauthorized, alwaysUpgrade, alwaysCreated, func(conn *websocket.Conn, _ int32) {
+		_ = conn.Close()
+	})
+
+	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
+
+	var refreshes atomic.Int32
+	testutil.CaptureOutput(t, func() {
+		sl := NewSudoListener(ac, "my-server", "session-1")
+		sl.reconnectBaseDelay = testReconnectBaseDelay
+		sl.refreshToken = func() error {
+			refreshes.Add(1)
+			return nil
+		}
+		sl.Start()
+		defer sl.Stop()
+
+		require.True(t, sl.WaitConnected(3*time.Second), "the first dial must subscribe before a 401 counts as post-subscribe")
+
+		require.Eventually(t, func() bool {
+			return refreshes.Load() >= 1
+		}, 3*time.Second, 10*time.Millisecond, "a 401 after the first subscribe must renew the token instead of re-presenting it")
+	})
+
+	assert.Greater(t, sessions.Load(), int32(1))
+}
+
+func TestSudoListener_LeavesTheTokenAloneOnOtherStatuses(t *testing.T) {
+	createThenServerError := func(attempt int32) int {
+		if attempt == 1 {
+			return http.StatusCreated
+		}
+		return http.StatusInternalServerError
+	}
+
+	ts, sessions, _ := newWatcherTestServer(t, createThenServerError, alwaysUpgrade, alwaysCreated, func(conn *websocket.Conn, _ int32) {
+		_ = conn.Close()
+	})
+
+	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
+
+	var refreshes atomic.Int32
+	testutil.CaptureOutput(t, func() {
+		sl := NewSudoListener(ac, "my-server", "session-1")
+		sl.reconnectBaseDelay = testReconnectBaseDelay
+		sl.refreshToken = func() error {
+			refreshes.Add(1)
+			return nil
+		}
+		sl.Start()
+		defer sl.Stop()
+
+		require.True(t, sl.WaitConnected(3*time.Second), "the first dial must subscribe")
+
+		require.Eventually(t, func() bool {
+			return sessions.Load() >= 3
+		}, 3*time.Second, 10*time.Millisecond)
+	})
+
+	assert.Zero(t, refreshes.Load(), "only a 401 says the token is the problem")
+}
+
+func TestSudoListener_StaysQuietWhenAFailureLandsAfterStop(t *testing.T) {
+	sl := NewSudoListener(nil, "my-server", "session-1")
+	sl.stateMu.Lock()
+	sl.subscribed = true
+	sl.stateMu.Unlock()
+
+	sl.Stop()
+
+	_, stderr := testutil.CaptureOutput(t, func() {
+		// Stop cancels no in-flight dial, so its failure still reaches fail afterwards.
+		_ = sl.fail(errors.New("dial failed after the stop"))
+	})
+
+	assert.NotContains(t, stderr, "Sudo MFA listener disconnected")
+}
+
+func TestSudoListener_SurfacesANonFatalCauseAfterTheWaitEnds(t *testing.T) {
+	alwaysServerError := func(int32) int { return http.StatusInternalServerError }
+
+	ts, _, _ := newWatcherTestServer(t, alwaysServerError, alwaysUpgrade, alwaysCreated, func(conn *websocket.Conn, _ int32) {})
+
+	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
+	sl := NewSudoListener(ac, "my-server", "session-1")
+	sl.reconnectBaseDelay = testReconnectBaseDelay
+	sl.Start()
+	defer sl.Stop()
+
+	// A 500 is retried, so the wait runs out; websh still has to name the reason.
+	assert.False(t, sl.WaitConnected(500*time.Millisecond), "a listener that never creates a session must not report connected")
 
 	err := sl.Err()
 	require.Error(t, err)

--- a/api/event/sudolistener_test.go
+++ b/api/event/sudolistener_test.go
@@ -322,7 +322,7 @@ func TestSudoListener_AnnouncesOutageOncePerOutage(t *testing.T) {
 		}, 3*time.Second, 10*time.Millisecond)
 	})
 
-	assert.Equal(t, 1, strings.Count(stderr, "Sudo MFA listener disconnected"),
+	assert.Equal(t, 1, strings.Count(stderr, sudoOutageWarning),
 		"one outage must produce exactly one warning, not one per retry")
 }
 
@@ -343,7 +343,7 @@ func TestSudoListener_StaysQuietBeforeFirstSubscribe(t *testing.T) {
 		assert.False(t, sl.WaitConnected(300*time.Millisecond), "a listener that never upgrades must not report a connection")
 	})
 
-	assert.NotContains(t, stderr, "Sudo MFA listener disconnected")
+	assert.NotContains(t, stderr, sudoOutageWarning)
 }
 
 func TestSudoListener_AnnouncesOutageWhenSessionCreateFails(t *testing.T) {
@@ -375,7 +375,7 @@ func TestSudoListener_AnnouncesOutageWhenSessionCreateFails(t *testing.T) {
 		}, 3*time.Second, 10*time.Millisecond)
 	})
 
-	assert.Equal(t, 1, strings.Count(stderr, "Sudo MFA listener disconnected"),
+	assert.Equal(t, 1, strings.Count(stderr, sudoOutageWarning),
 		"a session create that keeps failing is an outage and must be announced once")
 }
 
@@ -407,7 +407,7 @@ func TestSudoListener_AnnouncesOutageWhenResubscribeFails(t *testing.T) {
 		}, 3*time.Second, 10*time.Millisecond)
 	})
 
-	assert.Equal(t, 1, strings.Count(stderr, "Sudo MFA listener disconnected"),
+	assert.Equal(t, 1, strings.Count(stderr, sudoOutageWarning),
 		"a resubscribe that keeps failing is an outage and must be announced once")
 }
 
@@ -435,7 +435,7 @@ func TestSudoListener_AnnouncesTheNextOutageAfterRecovering(t *testing.T) {
 		}, 5*time.Second, 10*time.Millisecond)
 	})
 
-	assert.Equal(t, 2, strings.Count(stderr, "Sudo MFA listener disconnected"),
+	assert.Equal(t, 2, strings.Count(stderr, sudoOutageWarning),
 		"a recovered channel makes the next outage a new one, worth announcing again")
 }
 
@@ -540,7 +540,7 @@ func TestSudoListener_StaysQuietWhenAFailureLandsAfterStop(t *testing.T) {
 		_ = sl.fail(errors.New("dial failed after the stop"))
 	})
 
-	assert.NotContains(t, stderr, "Sudo MFA listener disconnected")
+	assert.NotContains(t, stderr, sudoOutageWarning)
 }
 
 func TestSudoListener_SurfacesANonFatalCauseAfterTheWaitEnds(t *testing.T) {
@@ -560,4 +560,32 @@ func TestSudoListener_SurfacesANonFatalCauseAfterTheWaitEnds(t *testing.T) {
 	err := sl.Err()
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to create event session")
+}
+
+func TestSudoListener_TriesOneRefreshBeforeGivingUpOnAnUnauthorizedFirstSession(t *testing.T) {
+	alwaysUnauthorized := func(int32) int { return http.StatusUnauthorized }
+
+	ts, sessions, _ := newWatcherTestServer(t, alwaysUnauthorized, alwaysUpgrade, alwaysCreated, func(conn *websocket.Conn, _ int32) {})
+
+	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
+	sl := NewSudoListener(ac, "my-server", "session-1")
+	sl.reconnectBaseDelay = testReconnectBaseDelay
+
+	var refreshes atomic.Int32
+	sl.refreshToken = func() error {
+		refreshes.Add(1)
+		return nil
+	}
+	sl.Start()
+	defer sl.Stop()
+
+	select {
+	case <-sl.stopped:
+	case <-time.After(3 * time.Second):
+		t.Fatal("a 401 answering a freshly renewed token must stop the listener")
+	}
+
+	assert.Equal(t, int32(1), refreshes.Load(), "the refusal is only worth one refresh")
+	assert.Equal(t, int32(2), sessions.Load(), "that refresh buys exactly one more attempt")
+	assert.Error(t, sl.Err(), "websh still needs the reason it gave up")
 }

--- a/api/event/sudolistener_test.go
+++ b/api/event/sudolistener_test.go
@@ -5,10 +5,12 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/alpacax/alpacon-cli/client"
+	"github.com/alpacax/alpacon-cli/pkg/testutil"
 	"github.com/gorilla/websocket"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -292,4 +294,54 @@ func TestSudoListener_SessionCreateRetryableStatusIsRetried(t *testing.T) {
 
 	assert.True(t, sl.WaitConnected(3*time.Second), "a 503 before the first subscribe is not fatal; the next attempt must connect")
 	assert.NoError(t, sl.Err())
+}
+
+func TestSudoListener_AnnouncesOutageOncePerOutage(t *testing.T) {
+	// Upgrade the first connection, then refuse: the listener is subscribed and every
+	// later dial fails, which is exactly one outage.
+	upgradeFirstOnly := func(attempt int32) bool { return attempt == 1 }
+
+	ts, sessions, _ := newWatcherTestServer(t, alwaysCreated, upgradeFirstOnly, alwaysCreated, func(conn *websocket.Conn, _ int32) {
+		_ = conn.Close()
+	})
+
+	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
+
+	_, stderr := testutil.CaptureOutput(t, func() {
+		sl := NewSudoListener(ac, "my-server", "session-1")
+		sl.reconnectBaseDelay = testReconnectBaseDelay
+		sl.Start()
+		defer sl.Stop()
+
+		require.True(t, sl.WaitConnected(3*time.Second))
+
+		// A third session means at least two dials failed after the first connect.
+		require.Eventually(t, func() bool {
+			return sessions.Load() >= 3
+		}, 3*time.Second, 10*time.Millisecond)
+	})
+
+	assert.Equal(t, 1, strings.Count(stderr, "Sudo MFA listener disconnected"),
+		"one outage must produce exactly one warning, not one per retry")
+}
+
+func TestSudoListener_StaysQuietBeforeFirstSubscribe(t *testing.T) {
+	// Never upgrade: the listener never subscribes, so websh's own WaitConnected
+	// failure is the only thing that should speak.
+	neverUpgrade := func(int32) bool { return false }
+
+	ts, _, _ := newWatcherTestServer(t, alwaysCreated, neverUpgrade, alwaysCreated, func(conn *websocket.Conn, _ int32) {})
+
+	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
+
+	_, stderr := testutil.CaptureOutput(t, func() {
+		sl := NewSudoListener(ac, "my-server", "session-1")
+		sl.reconnectBaseDelay = testReconnectBaseDelay
+		sl.Start()
+		defer sl.Stop()
+
+		assert.False(t, sl.WaitConnected(300*time.Millisecond))
+	})
+
+	assert.NotContains(t, stderr, "Sudo MFA listener disconnected")
 }

--- a/api/event/sudolistener_test.go
+++ b/api/event/sudolistener_test.go
@@ -345,3 +345,70 @@ func TestSudoListener_StaysQuietBeforeFirstSubscribe(t *testing.T) {
 
 	assert.NotContains(t, stderr, "Sudo MFA listener disconnected")
 }
+
+func TestSudoListener_AnnouncesOutageWhenSessionCreateFails(t *testing.T) {
+	// The first attempt connects and subscribes, then every later session create
+	// fails: an outage that never reaches the dial, so onDialFailed never fires.
+	createThenFail := func(attempt int32) int {
+		if attempt == 1 {
+			return http.StatusCreated
+		}
+		return http.StatusInternalServerError
+	}
+	upgradeFirstOnly := func(attempt int32) bool { return attempt == 1 }
+
+	ts, sessions, _ := newWatcherTestServer(t, createThenFail, upgradeFirstOnly, alwaysCreated, func(conn *websocket.Conn, _ int32) {
+		_ = conn.Close()
+	})
+
+	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
+
+	_, stderr := testutil.CaptureOutput(t, func() {
+		sl := NewSudoListener(ac, "my-server", "session-1")
+		sl.reconnectBaseDelay = testReconnectBaseDelay
+		sl.Start()
+		defer sl.Stop()
+
+		require.True(t, sl.WaitConnected(3*time.Second))
+
+		require.Eventually(t, func() bool {
+			return sessions.Load() >= 3
+		}, 3*time.Second, 10*time.Millisecond)
+	})
+
+	assert.Equal(t, 1, strings.Count(stderr, "Sudo MFA listener disconnected"),
+		"a session create that keeps failing is an outage and must be announced once")
+}
+
+func TestSudoListener_AnnouncesOutageWhenResubscribeFails(t *testing.T) {
+	// The dial keeps succeeding but every resubscribe after the first fails, so the
+	// channel is dead even though onDialFailed never fires.
+	createThenFail := func(attempt int32) int {
+		if attempt == 1 {
+			return http.StatusCreated
+		}
+		return http.StatusInternalServerError
+	}
+
+	ts, _, subscribes := newWatcherTestServer(t, alwaysCreated, alwaysUpgrade, createThenFail, func(conn *websocket.Conn, _ int32) {
+		_ = conn.Close()
+	})
+
+	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
+
+	_, stderr := testutil.CaptureOutput(t, func() {
+		sl := NewSudoListener(ac, "my-server", "session-1")
+		sl.reconnectBaseDelay = testReconnectBaseDelay
+		sl.Start()
+		defer sl.Stop()
+
+		require.True(t, sl.WaitConnected(3*time.Second))
+
+		require.Eventually(t, func() bool {
+			return subscribes.Load() >= 3
+		}, 3*time.Second, 10*time.Millisecond)
+	})
+
+	assert.Equal(t, 1, strings.Count(stderr, "Sudo MFA listener disconnected"),
+		"a resubscribe that keeps failing is an outage and must be announced once")
+}

--- a/api/event/watcher.go
+++ b/api/event/watcher.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/alpacax/alpacon-cli/client"
-	"github.com/alpacax/alpacon-cli/utils"
 )
 
 const (
@@ -87,7 +86,7 @@ func (w *Watcher) Err() error {
 // The session request carries neither --type nor --target, so only a fatal 4xx proves
 // retrying pointless. Anything else gets the retry window a dial failure already gets.
 func (w *Watcher) sessionCreateFailed(cause error) error {
-	if utils.IsFatalClientError(utils.HTTPStatusCode(cause)) {
+	if isFatalRequestError(cause) {
 		return w.fail(cause)
 	}
 

--- a/api/event/wslistener.go
+++ b/api/event/wslistener.go
@@ -192,9 +192,8 @@ func (w *wsListener) connectAndListen() (connected bool) {
 	}
 }
 
-// isFatalRequestError reports whether retrying cause is pointless: a 4xx that refuses
-// rather than asks to be retried names a bad request or an expired login, which the
-// next attempt would hit again.
+// isFatalRequestError reports whether retrying is pointless: a 4xx that refuses rather
+// than asks to be retried is a bad request or an expired login, unchanged by a retry.
 func isFatalRequestError(cause error) bool {
 	return utils.IsFatalClientError(utils.HTTPStatusCode(cause))
 }

--- a/api/event/wslistener.go
+++ b/api/event/wslistener.go
@@ -43,7 +43,8 @@ type wsListener struct {
 }
 
 // newProvisionedWSListener builds the skeleton for a listener that obtains a new
-// URL for every dial attempt. ac may be nil (empty header, for tests).
+// URL for every dial attempt. A nil ac only means an empty header here; whether it
+// is safe at all is provision's call, since every attempt runs it.
 func newProvisionedWSListener(ac *client.AlpaconClient, provision func() (string, error), handshakeTimeout time.Duration) *wsListener {
 	wsHeader := http.Header{}
 	if ac != nil {

--- a/api/event/wslistener.go
+++ b/api/event/wslistener.go
@@ -35,7 +35,7 @@ type wsListener struct {
 
 	done        chan struct{}
 	stopped     chan struct{} // closed when listenLoop exits
-	connected   chan struct{} // closed after the first successful connect and subscribe
+	connected   chan struct{} // closed once a dial connected and onConnected returned
 	connectOnce sync.Once
 	closeOnce   sync.Once
 	mu          sync.Mutex // guards conn
@@ -75,8 +75,9 @@ func (w *wsListener) Start() {
 	}()
 }
 
-// WaitConnected blocks until connected and subscribed, timeout, or shutdown;
-// returns whether it connected.
+// WaitConnected blocks until a dial has connected and its onConnected hook has
+// returned, until timeout, or until shutdown; returns whether it connected. A hook
+// with nothing to subscribe to still counts, so this promises no subscription.
 func (w *wsListener) WaitConnected(timeout time.Duration) bool {
 	select {
 	case <-w.connected:

--- a/api/event/wslistener.go
+++ b/api/event/wslistener.go
@@ -41,12 +41,6 @@ type wsListener struct {
 	conn        *websocket.Conn
 }
 
-// newWSListener builds the skeleton for a listener that always dials the same
-// URL. ac may be nil (empty header, for tests).
-func newWSListener(ac *client.AlpaconClient, wsURL string, handshakeTimeout time.Duration) *wsListener {
-	return newProvisionedWSListener(ac, func() (string, error) { return wsURL, nil }, handshakeTimeout)
-}
-
 // newProvisionedWSListener builds the skeleton for a listener that obtains a new
 // URL for every dial attempt. ac may be nil (empty header, for tests).
 func newProvisionedWSListener(ac *client.AlpaconClient, provision func() (string, error), handshakeTimeout time.Duration) *wsListener {

--- a/api/event/wslistener.go
+++ b/api/event/wslistener.go
@@ -192,8 +192,9 @@ func (w *wsListener) connectAndListen() (connected bool) {
 	}
 }
 
-// isFatalRequestError reports whether retrying cause is pointless: a 4xx names a
-// bad request or an expired login, which the next attempt would hit again.
+// isFatalRequestError reports whether retrying cause is pointless: a 4xx that refuses
+// rather than asks to be retried names a bad request or an expired login, which the
+// next attempt would hit again.
 func isFatalRequestError(cause error) bool {
 	return utils.IsFatalClientError(utils.HTTPStatusCode(cause))
 }

--- a/api/event/wslistener.go
+++ b/api/event/wslistener.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/alpacax/alpacon-cli/client"
+	"github.com/alpacax/alpacon-cli/utils"
 	"github.com/gorilla/websocket"
 )
 
@@ -39,6 +40,12 @@ type wsListener struct {
 	closeOnce   sync.Once
 	mu          sync.Mutex // guards conn
 	conn        *websocket.Conn
+}
+
+// isFatalRequestError reports whether retrying cause is pointless: a 4xx names a
+// bad request or an expired login, which the next attempt would hit again.
+func isFatalRequestError(cause error) bool {
+	return utils.IsFatalClientError(utils.HTTPStatusCode(cause))
 }
 
 // newProvisionedWSListener builds the skeleton for a listener that obtains a new

--- a/api/event/wslistener.go
+++ b/api/event/wslistener.go
@@ -42,12 +42,6 @@ type wsListener struct {
 	conn        *websocket.Conn
 }
 
-// isFatalRequestError reports whether retrying cause is pointless: a 4xx names a
-// bad request or an expired login, which the next attempt would hit again.
-func isFatalRequestError(cause error) bool {
-	return utils.IsFatalClientError(utils.HTTPStatusCode(cause))
-}
-
 // newProvisionedWSListener builds the skeleton for a listener that obtains a new
 // URL for every dial attempt. ac may be nil (empty header, for tests).
 func newProvisionedWSListener(ac *client.AlpaconClient, provision func() (string, error), handshakeTimeout time.Duration) *wsListener {
@@ -195,4 +189,10 @@ func (w *wsListener) connectAndListen() (connected bool) {
 
 		w.handleFrame(message)
 	}
+}
+
+// isFatalRequestError reports whether retrying cause is pointless: a 4xx names a
+// bad request or an expired login, which the next attempt would hit again.
+func isFatalRequestError(cause error) bool {
+	return utils.IsFatalClientError(utils.HTTPStatusCode(cause))
 }

--- a/api/event/wslistener_test.go
+++ b/api/event/wslistener_test.go
@@ -18,7 +18,7 @@ import (
 const testReconnectBaseDelay = 10 * time.Millisecond
 
 func TestWSListener_StartPanicsWithoutHandleFrame(t *testing.T) {
-	w := newWSListener(nil, "", 0)
+	w := newProvisionedWSListener(nil, func() (string, error) { return "", nil }, 0)
 
 	assert.PanicsWithValue(t, "event: wsListener.handleFrame must be assigned before Start", func() {
 		w.Start()
@@ -26,7 +26,7 @@ func TestWSListener_StartPanicsWithoutHandleFrame(t *testing.T) {
 }
 
 func TestWSListener_StopIsIdempotent(t *testing.T) {
-	w := newWSListener(nil, "", 0)
+	w := newProvisionedWSListener(nil, func() (string, error) { return "", nil }, 0)
 
 	w.Stop()
 	w.Stop()
@@ -34,7 +34,7 @@ func TestWSListener_StopIsIdempotent(t *testing.T) {
 }
 
 func TestWSListener_WaitConnected_Success(t *testing.T) {
-	w := newWSListener(nil, "", 0)
+	w := newProvisionedWSListener(nil, func() (string, error) { return "", nil }, 0)
 
 	// Simulate connection after short delay
 	go func() {
@@ -47,7 +47,7 @@ func TestWSListener_WaitConnected_Success(t *testing.T) {
 }
 
 func TestWSListener_WaitConnected_Timeout(t *testing.T) {
-	w := newWSListener(nil, "", 0)
+	w := newProvisionedWSListener(nil, func() (string, error) { return "", nil }, 0)
 
 	start := time.Now()
 	result := w.WaitConnected(100 * time.Millisecond)
@@ -82,7 +82,7 @@ func TestWSListener_ConnectAndListen_ReturnsFalseOnFailedHandshake(t *testing.T)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
 	defer server.Close()
 
-	w := newWSListener(nil, "ws"+strings.TrimPrefix(server.URL, "http"), time.Second)
+	w := newProvisionedWSListener(nil, func() (string, error) { return "ws" + strings.TrimPrefix(server.URL, "http"), nil }, time.Second)
 	w.handleFrame = func([]byte) {}
 
 	assert.False(t, w.connectAndListen(), "failed handshake should not count as connected")
@@ -98,7 +98,7 @@ func TestWSListener_ListenLoop_DoesNotDialWhenAlreadyStopped(t *testing.T) {
 	}))
 	defer server.Close()
 
-	w := newWSListener(nil, "ws"+strings.TrimPrefix(server.URL, "http"), time.Second)
+	w := newProvisionedWSListener(nil, func() (string, error) { return "ws" + strings.TrimPrefix(server.URL, "http"), nil }, time.Second)
 	w.handleFrame = func([]byte) {}
 	w.Stop()
 
@@ -118,7 +118,7 @@ func TestWSListener_ListenLoop_DoesNotDialWhenAlreadyStopped(t *testing.T) {
 }
 
 func TestWSListener_WaitConnected_Shutdown(t *testing.T) {
-	w := newWSListener(nil, "", 0)
+	w := newProvisionedWSListener(nil, func() (string, error) { return "", nil }, 0)
 
 	go func() {
 		time.Sleep(50 * time.Millisecond)

--- a/cmd/websh/websh.go
+++ b/cmd/websh/websh.go
@@ -308,7 +308,7 @@ Note: All flags must be placed before the server name.
 		// ready, the approval request will expire and they can retry.
 		listenerDone := make(chan *event.SudoListener, 1)
 		go func() {
-			listenerDone <- setupSudoListener(alpaconClient, session.ID, serverName)
+			listenerDone <- setupSudoListener(alpaconClient, serverName, session.ID)
 		}()
 		defer func() {
 			select {
@@ -351,7 +351,7 @@ func extractValue(args []string, i int) (string, int) {
 
 // setupSudoListener starts the sudo MFA listener for the given websh session.
 // Returns nil when it cannot connect.
-func setupSudoListener(ac *client.AlpaconClient, sessionID, serverName string) *event.SudoListener {
+func setupSudoListener(ac *client.AlpaconClient, serverName, sessionID string) *event.SudoListener {
 	listener := event.NewSudoListener(ac, serverName, sessionID)
 	listener.Start()
 

--- a/cmd/websh/websh.go
+++ b/cmd/websh/websh.go
@@ -369,7 +369,9 @@ func setupSudoListener(ac *client.AlpaconClient, sessionID, serverName string) *
 // sudoListenerWarning explains why the sudo MFA listener never connected, or
 // returns "" when the failure is not worth telling the user about. A 404 means an
 // older server without the events API; the websh session runs fine without them.
-// A nil cause means the listener kept retrying until the wait ran out.
+// A nil cause means the listener kept retrying until the wait ran out. The cause
+// carries the server's own text, which is sanitized before it reaches a terminal
+// this command is about to put into raw mode.
 func sudoListenerWarning(cause error) string {
 	if utils.HTTPStatusCode(cause) == http.StatusNotFound {
 		return ""
@@ -377,5 +379,5 @@ func sudoListenerWarning(cause error) string {
 	if cause == nil {
 		return "Sudo MFA listener unavailable: timed out connecting to the event channel"
 	}
-	return fmt.Sprintf("Sudo MFA listener unavailable: %s", cause)
+	return fmt.Sprintf("Sudo MFA listener unavailable: %s", utils.SanitizeTerminalText(cause.Error()))
 }

--- a/cmd/websh/websh.go
+++ b/cmd/websh/websh.go
@@ -356,6 +356,11 @@ func setupSudoListener(ac *client.AlpaconClient, sessionID, serverName string) *
 
 	if !listener.WaitConnected(5 * time.Second) {
 		listener.Stop()
+		// An older server without the events API answers 404; that is not worth a
+		// warning, and the session runs fine without sudo MFA events.
+		if err := listener.Err(); err != nil && !isNotFoundError(err) {
+			utils.CliWarning("Sudo MFA listener unavailable: %s", err)
+		}
 		return nil
 	}
 

--- a/cmd/websh/websh.go
+++ b/cmd/websh/websh.go
@@ -377,8 +377,9 @@ func sudoListenerWarning(cause error) string {
 	if utils.HTTPStatusCode(cause) == http.StatusNotFound {
 		return ""
 	}
-	if cause == nil {
-		return "Sudo MFA listener unavailable: timed out connecting to the event channel"
+	reason := "timed out connecting to the event channel"
+	if cause != nil {
+		reason = utils.SanitizeTerminalText(cause.Error())
 	}
-	return fmt.Sprintf("Sudo MFA listener unavailable: %s", utils.SanitizeTerminalText(cause.Error()))
+	return fmt.Sprintf("Sudo MFA listener unavailable: %s", reason)
 }

--- a/cmd/websh/websh.go
+++ b/cmd/websh/websh.go
@@ -347,35 +347,15 @@ func extractValue(args []string, i int) (string, int) {
 	return "", i
 }
 
-// setupSudoListener creates an event session, connects the event WebSocket,
-// then subscribes to sudo events for the given websh session. The server
-// requires the WebSocket to be connected before allowing subscriptions.
-// Returns nil if the events API is not available. Silently skips "not found"
-// errors (older servers); logs a warning for other failures.
+// setupSudoListener starts the sudo MFA listener for the given websh session.
+// The listener provisions its own event channel and re-subscribes on every
+// connect, so it survives a disconnect. Returns nil when it cannot connect.
 func setupSudoListener(ac *client.AlpaconClient, sessionID, serverName string) *event.SudoListener {
-	eventSession, err := event.CreateEventSession(ac)
-	if err != nil {
-		if !isNotFoundError(err) {
-			utils.CliWarning("Sudo MFA listener unavailable: %s", err)
-		}
-		return nil
-	}
-
-	// Start listener first — the server requires the WebSocket channel to be
-	// connected before it accepts event subscriptions.
-	listener := event.NewSudoListener(ac, eventSession.WebsocketURL, serverName)
+	listener := event.NewSudoListener(ac, serverName, sessionID)
 	listener.Start()
 
 	if !listener.WaitConnected(5 * time.Second) {
 		listener.Stop()
-		return nil
-	}
-
-	if err := event.SubscribeEvent(ac, eventSession.ChannelID, event.EventTypeSudo, sessionID); err != nil {
-		listener.Stop()
-		if !isNotFoundError(err) {
-			utils.CliWarning("Sudo MFA listener unavailable: %s", err)
-		}
 		return nil
 	}
 

--- a/cmd/websh/websh.go
+++ b/cmd/websh/websh.go
@@ -3,6 +3,7 @@ package websh
 import (
 	"errors"
 	"fmt"
+	"net/http"
 	"strings"
 	"time"
 
@@ -356,10 +357,8 @@ func setupSudoListener(ac *client.AlpaconClient, sessionID, serverName string) *
 
 	if !listener.WaitConnected(5 * time.Second) {
 		listener.Stop()
-		// An older server without the events API answers 404; that is not worth a
-		// warning, and the session runs fine without sudo MFA events.
-		if err := listener.Err(); err != nil && !isNotFoundError(err) {
-			utils.CliWarning("Sudo MFA listener unavailable: %s", err)
+		if warning := sudoListenerWarning(listener.Err()); warning != "" {
+			utils.CliWarning("%s", warning)
 		}
 		return nil
 	}
@@ -367,14 +366,16 @@ func setupSudoListener(ac *client.AlpaconClient, sessionID, serverName string) *
 	return listener
 }
 
-// isNotFoundError checks if an error message indicates a 404/not-found response.
-// AlpaconClient.SendPostRequest returns the server's error detail (e.g., "Not found.")
-// rather than the raw HTTP status code.
-func isNotFoundError(err error) bool {
-	if err == nil {
-		return false
+// sudoListenerWarning explains why the sudo MFA listener never connected, or
+// returns "" when the failure is not worth telling the user about. A 404 means an
+// older server without the events API; the websh session runs fine without them.
+// A nil cause means the listener kept retrying until the wait ran out.
+func sudoListenerWarning(cause error) string {
+	if utils.HTTPStatusCode(cause) == http.StatusNotFound {
+		return ""
 	}
-	msg := strings.TrimSpace(strings.ToLower(err.Error()))
-	return msg == "not found" || msg == "not found." ||
-		strings.HasSuffix(msg, ": not found") || strings.HasSuffix(msg, ": not found.")
+	if cause == nil {
+		return "Sudo MFA listener unavailable: timed out connecting to the event channel"
+	}
+	return fmt.Sprintf("Sudo MFA listener unavailable: %s", cause)
 }

--- a/cmd/websh/websh.go
+++ b/cmd/websh/websh.go
@@ -350,8 +350,7 @@ func extractValue(args []string, i int) (string, int) {
 }
 
 // setupSudoListener starts the sudo MFA listener for the given websh session.
-// The listener provisions its own event channel and re-subscribes on every
-// connect, so it survives a disconnect. Returns nil when it cannot connect.
+// Returns nil when it cannot connect.
 func setupSudoListener(ac *client.AlpaconClient, sessionID, serverName string) *event.SudoListener {
 	listener := event.NewSudoListener(ac, serverName, sessionID)
 	listener.Start()
@@ -370,12 +369,10 @@ func setupSudoListener(ac *client.AlpaconClient, sessionID, serverName string) *
 	return listener
 }
 
-// sudoListenerWarning explains why the sudo MFA listener never connected, or
-// returns "" when the failure is not worth telling the user about. A 404 means an
-// older server without the events API; the websh session runs fine without them.
-// A nil cause means the listener kept retrying until the wait ran out. The cause
-// carries the server's own text, which is sanitized before it reaches a terminal
-// this command is about to put into raw mode.
+// sudoListenerWarning explains why the sudo MFA listener never connected, or returns ""
+// when the failure is not worth telling the user about: a 404 is an older server without
+// the events API, and the websh session runs fine without it. The server's own text is
+// sanitized because this command is about to put the terminal into raw mode.
 func sudoListenerWarning(cause error) string {
 	if utils.HTTPStatusCode(cause) == http.StatusNotFound {
 		return ""

--- a/cmd/websh/websh.go
+++ b/cmd/websh/websh.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"os"
 	"strings"
 	"time"
 
@@ -358,7 +359,10 @@ func setupSudoListener(ac *client.AlpaconClient, sessionID, serverName string) *
 	if !listener.WaitConnected(5 * time.Second) {
 		listener.Stop()
 		if warning := sudoListenerWarning(listener.Err()); warning != "" {
-			utils.CliWarning("%s", warning)
+			// Not utils.CliWarning: this runs in a goroutine racing
+			// OpenNewTerminal, so the terminal may already be in raw mode,
+			// where a bare newline leaves the cursor where it stood.
+			_, _ = fmt.Fprintf(os.Stderr, "\r\n%s: %s\r\n", utils.Yellow("Warning"), warning)
 		}
 		return nil
 	}

--- a/cmd/websh/websh_test.go
+++ b/cmd/websh/websh_test.go
@@ -4,12 +4,17 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 
+	"github.com/alpacax/alpacon-cli/api/event"
 	"github.com/alpacax/alpacon-cli/api/types"
 	"github.com/alpacax/alpacon-cli/api/websh"
+	"github.com/alpacax/alpacon-cli/client"
 	execCmd "github.com/alpacax/alpacon-cli/cmd/exec"
+	"github.com/alpacax/alpacon-cli/pkg/testutil"
 	"github.com/alpacax/alpacon-cli/utils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -443,4 +448,47 @@ func TestBuildRemoteExecArgsPinsWebshInvocation(t *testing.T) {
 	assert.Equal(t, "prod", args.Server)
 	assert.Equal(t, "psql -h localhost", args.Command)
 	assert.Equal(t, parsed.Env, args.Env)
+}
+
+// newSudoListenerTestServer serves only the event session endpoint, with the status
+// and body the test wants, so setupSudoListener's failure path can be driven directly.
+func newSudoListenerTestServer(t *testing.T, status int, body string) *httptest.Server {
+	t.Helper()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/events/sessions/", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(status)
+		_, _ = w.Write([]byte(body))
+	})
+
+	ts := httptest.NewServer(mux)
+	t.Cleanup(ts.Close)
+	return ts
+}
+
+func TestSetupSudoListener_StaysSilentOnNotFound(t *testing.T) {
+	ts := newSudoListenerTestServer(t, http.StatusNotFound, `{"detail":"Not found."}`)
+	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
+
+	var listener *event.SudoListener
+	_, stderr := testutil.CaptureOutput(t, func() {
+		listener = setupSudoListener(ac, "session-1", "my-server")
+	})
+
+	assert.Nil(t, listener)
+	assert.Empty(t, stderr, "an older server without the events API must not warn")
+}
+
+func TestSetupSudoListener_WarnsOnOtherFailures(t *testing.T) {
+	ts := newSudoListenerTestServer(t, http.StatusBadRequest, `{"detail":"Invalid input."}`)
+	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
+
+	var listener *event.SudoListener
+	_, stderr := testutil.CaptureOutput(t, func() {
+		listener = setupSudoListener(ac, "session-1", "my-server")
+	})
+
+	assert.Nil(t, listener)
+	assert.Contains(t, stderr, "Sudo MFA listener unavailable")
 }

--- a/cmd/websh/websh_test.go
+++ b/cmd/websh/websh_test.go
@@ -270,52 +270,41 @@ func TestCommandParsing(t *testing.T) {
 	}
 }
 
-func TestIsNotFoundError(t *testing.T) {
+// statusErr carries an HTTP status the way client's own errors do, so the warning
+// decision can be tested without standing up a server.
+type statusErr struct {
+	status int
+}
+
+func (e statusErr) Error() string       { return fmt.Sprintf("server said %d", e.status) }
+func (e statusErr) HTTPStatusCode() int { return e.status }
+
+func TestSudoListenerWarning(t *testing.T) {
 	tests := []struct {
-		name     string
-		err      error
-		expected bool
+		name  string
+		cause error
+		want  string
 	}{
 		{
-			name:     "server returns Not found.",
-			err:      fmt.Errorf("Not found."),
-			expected: true,
+			name:  "an older server without the events API stays silent",
+			cause: fmt.Errorf("failed to create event session: %w", statusErr{status: http.StatusNotFound}),
+			want:  "",
 		},
 		{
-			name:     "exact not found without period",
-			err:      fmt.Errorf("Not found"),
-			expected: true,
+			name:  "a rejected request names the server's reason",
+			cause: fmt.Errorf("failed to create event session: %w", statusErr{status: http.StatusBadRequest}),
+			want:  "Sudo MFA listener unavailable: failed to create event session: server said 400",
 		},
 		{
-			name:     "case insensitive NOT FOUND",
-			err:      fmt.Errorf("NOT FOUND"),
-			expected: true,
-		},
-		{
-			name:     "wrapped not found error",
-			err:      fmt.Errorf("failed to create event session: Not found"),
-			expected: true,
-		},
-		{
-			name:     "wrapped with period",
-			err:      fmt.Errorf("failed to subscribe: Not found."),
-			expected: true,
-		},
-		{
-			name:     "unrelated error",
-			err:      fmt.Errorf("connection refused"),
-			expected: false,
-		},
-		{
-			name:     "api insufficient data",
-			err:      fmt.Errorf("code: api_insufficient_data"),
-			expected: false,
+			name:  "no cause at all means the wait ran out",
+			cause: nil,
+			want:  "Sudo MFA listener unavailable: timed out connecting to the event channel",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.expected, isNotFoundError(tt.err))
+			assert.Equal(t, tt.want, sudoListenerWarning(tt.cause))
 		})
 	}
 }

--- a/cmd/websh/websh_test.go
+++ b/cmd/websh/websh_test.go
@@ -462,7 +462,7 @@ func TestSetupSudoListener_StaysSilentOnNotFound(t *testing.T) {
 
 	var listener *event.SudoListener
 	_, stderr := testutil.CaptureOutput(t, func() {
-		listener = setupSudoListener(ac, "session-1", "my-server")
+		listener = setupSudoListener(ac, "my-server", "session-1")
 	})
 
 	assert.Nil(t, listener)
@@ -475,7 +475,7 @@ func TestSetupSudoListener_WarnsOnOtherFailures(t *testing.T) {
 
 	var listener *event.SudoListener
 	_, stderr := testutil.CaptureOutput(t, func() {
-		listener = setupSudoListener(ac, "session-1", "my-server")
+		listener = setupSudoListener(ac, "my-server", "session-1")
 	})
 
 	assert.Nil(t, listener)
@@ -494,7 +494,7 @@ func TestSetupSudoListener_WarningReturnsTheCursor(t *testing.T) {
 	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
 
 	_, stderr := testutil.CaptureOutput(t, func() {
-		_ = setupSudoListener(ac, "session-1", "my-server")
+		_ = setupSudoListener(ac, "my-server", "session-1")
 	})
 
 	require.NotEmpty(t, stderr, "a rejected request must warn, or there is nothing to check")

--- a/cmd/websh/websh_test.go
+++ b/cmd/websh/websh_test.go
@@ -488,3 +488,18 @@ func TestSudoListenerWarning_SanitizesTheServersText(t *testing.T) {
 	assert.NotContains(t, warning, "\x1b")
 	assert.Contains(t, warning, "boom")
 }
+
+func TestSetupSudoListener_WarningReturnsTheCursor(t *testing.T) {
+	ts := newSudoListenerTestServer(t, http.StatusBadRequest, `{"detail":"Invalid input."}`)
+	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
+
+	_, stderr := testutil.CaptureOutput(t, func() {
+		_ = setupSudoListener(ac, "session-1", "my-server")
+	})
+
+	require.NotEmpty(t, stderr, "a rejected request must warn, or there is nothing to check")
+	for _, line := range strings.Split(strings.TrimSuffix(stderr, "\n"), "\n") {
+		assert.True(t, strings.HasSuffix(line, "\r"),
+			"websh may already hold the terminal in raw mode, where a bare newline leaves the cursor mid-line: %q", line)
+	}
+}

--- a/cmd/websh/websh_test.go
+++ b/cmd/websh/websh_test.go
@@ -20,6 +20,15 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// statusErr carries an HTTP status the way client's own errors do, so the warning
+// decision can be tested without standing up a server.
+type statusErr struct {
+	status int
+}
+
+func (e statusErr) Error() string       { return fmt.Sprintf("server said %d", e.status) }
+func (e statusErr) HTTPStatusCode() int { return e.status }
+
 func TestCommandParsing(t *testing.T) {
 	tests := []struct {
 		testName          string
@@ -270,15 +279,6 @@ func TestCommandParsing(t *testing.T) {
 	}
 }
 
-// statusErr carries an HTTP status the way client's own errors do, so the warning
-// decision can be tested without standing up a server.
-type statusErr struct {
-	status int
-}
-
-func (e statusErr) Error() string       { return fmt.Sprintf("server said %d", e.status) }
-func (e statusErr) HTTPStatusCode() int { return e.status }
-
 func TestSudoListenerWarning(t *testing.T) {
 	tests := []struct {
 		name  string
@@ -480,4 +480,11 @@ func TestSetupSudoListener_WarnsOnOtherFailures(t *testing.T) {
 
 	assert.Nil(t, listener)
 	assert.Contains(t, stderr, "Sudo MFA listener unavailable")
+}
+
+func TestSudoListenerWarning_SanitizesTheServersText(t *testing.T) {
+	warning := sudoListenerWarning(errors.New("boom \x1b[31mred\x1b[0m"))
+
+	assert.NotContains(t, warning, "\x1b")
+	assert.Contains(t, warning, "boom")
 }


### PR DESCRIPTION
## Background

Event channel tokens are single-use, which `api/event/wslistener.go` has stated outright since #291: a reconnect needs a freshly provisioned URL. `SudoListener` predated that work and never moved onto it. It built its skeleton with `newWSListener(ac, wsURL, sudoHandshakeTimeout)`, which pinned one fixed URL for every dial, so after any disconnect it re-dialed a token that was already spent—and kept failing that way for the life of the process.

It also assigned only `handleFrame`. With `onConnected` nil, a dial that somehow did succeed came back unsubscribed and silently delivered nothing; the subscription was issued once, out of band, in `setupSudoListener`. With `onDialFailed` nil, the outage was never reported either. The user-visible result: an interactive `websh` session that lost the event channel stopped receiving sudo MFA events, and the next sudo prompt hung with no explanation, because the browser MFA flow never fired.

The issue flagged `CommandOutputListener` as possibly sharing the shape. It did. `NewCommandOutputListener(ac, session.WebsocketURL, cmdID)` took its URL from a session its caller had created, and `streamSubscribed` issued both subscriptions out of band, so the same two defects applied to `alpacon exec` streaming.

## Changes

### Both listeners provision their own session

`NewSudoListener(ac, serverName, sessionID)` drops the URL parameter and takes the websh session ID instead, since the listener now owns the subscription. It builds on `newProvisionedWSListener` with a `provisionSession` closure that calls `CreateEventSession` per dial, and assigns all three hooks: `handleFrame`, `onConnected` to re-subscribe, `onDialFailed` to announce the outage. `setupSudoListener` no longer creates a session or calls `SubscribeEvent`.

`NewCommandOutputListener(ac)` does the same. Its first connect has nothing to subscribe to—the command is submitted only after the WebSocket is up—so `subscribeTo(commandID, serverID)` issues the first subscription once the command exists, and every later connect re-issues it through `onConnected`. `streamSubscribed` lost its `session` parameter and both `SubscribeEvent` calls along with it.

`newWSListener` is gone. Every listener in the package provisions now, so a fixed-URL constructor is only a way to reintroduce this bug.

### An outage is announced once, and again after it recovers

`SudoListener.fail` is the one decision a failed connect attempt goes through. Once subscribed, the failure is an outage: it prints one warning, and a successful resubscribe clears the flag, so a second outage later in the same session speaks again rather than staying silent behind a latched flag. Before the first subscribe it stays quiet, because `setupSudoListener` is already reporting that case to the user itself. The notice goes through `utils.Yellow`, which emits ANSI only when stderr is a terminal, so a redirected session collects the text without escape codes. `Stop` cancels neither an in-flight dial nor an in-flight session create, so the announce checks `done` first and a failure that lands after shutdown says nothing.

`fail` is called from all three failure points—session create, dial, and resubscribe—not just wired to `onDialFailed`. `onDialFailed` fires only when the WebSocket handshake fails, so an outage that dies at `CreateEventSession` or at the resubscribe would otherwise drop the sudo MFA flow with nothing on screen. `announceOutage` survives as the thin dial hook over `fail`, the shape `Watcher` already had.

### One fatal judgment, shared by all three listeners

`isFatalRequestError` (`api/event/wslistener.go:198`) is the single rule: a 4xx that refuses rather than asks to be retried—so neither a 408 nor a 429—means a bad request or an expired login when it lands before the first subscribe, which the next attempt would hit again, so the listener stops and surfaces the reason. The one exception is a 401: websh created its own session on that token milliseconds earlier, so `SudoListener.fail` renews it once and lets the attempt count as non-fatal. A 401 answering a token it just renewed is a real refusal and still stops it. `Watcher.sessionCreateFailed` now calls it instead of carrying its own copy of the same expression.

After the first subscribe, no status is fatal for either new listener. A 401 arriving mid-stream on a long command would otherwise cost the rest of that run its live output, and the reconnect loop is exactly the right place to wait it out.

A 401 is still the one status a retry cannot fix by itself, so `SudoListener.fail` renews the access token before the next dial, holding `mfaMu` so it cannot race the refresh `handleSudoMFA` already does. Without it, an access token that expires during a long interactive `websh` session is re-presented on every dial until the session ends, and sudo MFA never comes back.

`CommandOutputListener.subscribe` refuses to subscribe once the listener is stopped. Its first connect has nothing to subscribe to, so the caller holds a connected listener while `SubmitCommand` runs; a drop plus a fatal session create in that window stops the listener behind the caller's back, and subscribing on the dead session's channel would have let `streamSubscribed` proceed as if output were streaming. It still would not lose output, since the poll goroutine runs regardless, but the run would degrade to polling with nothing saying why. The refusal carries the reason the listener stopped, wrapped from `Err()`, so the fallback warning names the server's own 401 or 403 rather than the halt. The check runs a second time once both subscriptions are in, which narrows the window to their round trips; closing it properly would mean `streamSubscribed` selecting on the listener's liveness in its main loop, which is more than this PR wants.

### The failure reaches the caller instead of a flat timeout

Both listeners expose `Err()`. `listenerFailure` hands `runCommandFallback` the server's own error when the listener reached the server at all, and the connect budget only when it did not, so a rejected session no longer reports itself as a timeout. `sudoListenerWarning` replaces the old `isNotFoundError` string matching with `utils.HTTPStatusCode(cause) == http.StatusNotFound`.

`SudoListener.fail` records every cause, not only the fatal one, and a successful subscribe clears it. Otherwise a 500, a refused connection, a TLS failure, or a proxy 502 all leave `Err()` nil and `websh` prints "timed out connecting to the event channel" where it used to print the server's own message. `Err()` now promises the last reason the listener could not connect rather than the reason it stopped; the `Stop` decision stays gated on the fatal rule.

## Safety

The warning interpolates the server's own `detail` text into a terminal that `websh` is about to put into raw mode, so it goes through `utils.SanitizeTerminalText` first, following the sibling precedent at `cmd/websh/websh_watch.go:53`.

It is printed with explicit CRLF rather than through `utils.CliWarning`. `cliMessage` strips `\r`, and `term.MakeRaw` clears OPOST, so a bare `\n` in raw mode drops a line without returning the cursor and the next line starts mid-screen. `setupSudoListener` runs in a goroutine racing `OpenNewTerminal`, so it cannot assume the terminal is still cooked.

A 404 stays silent, as before: it means an older server without the events API, and the websh session runs fine without sudo MFA events.

Two things are known and deliberately left:

`channelID` is read under `stateMu` and then used for a `SubscribeEvent` POST outside it, so a reconnect landing between the read and the POST can subscribe on the previous channel. Closing the window would mean holding a mutex across network I/O. The consequence is bounded and self-healing—the next reconnect resubscribes on the current channel, and for command output the poll still delivers every chunk, so a blip downgrades live streaming to polling rather than losing output.

The `stateMu` / `channelID` / `subscribed` / `err` block now appears in all three listeners. Extracting it would share the fields and the mutex but not the notification, which differs in every case: `Watcher` pushes to a channel, `SudoListener` writes to stderr, `CommandOutputListener` says nothing. The judgment that actually repeated was the 4xx test, and that is extracted.

## Testing

Twenty-four new tests in `api/event`, five in `cmd/websh`. The ones that pin this PR's behavior:

- `TestSudoListener_CreatesANewSessionOnReconnect` and `TestSudoListener_ResubscribesOnReconnect` cover the two defects the issue names.
- `TestCommandOutputListener_CreatesANewSessionAndResubscribesOnReconnect` covers the same pair for exec streaming, and `TestCommandOutputListener_FirstConnectSubscribesToNothing` pins the empty first connect.
- `TestSudoListener_AnnouncesOutageOncePerOutage`, `..._WhenSessionCreateFails`, `..._WhenResubscribeFails`, and `TestSudoListener_AnnouncesTheNextOutageAfterRecovering` cover the announcement, each failure point, and the flag reset.
- `TestSudoListener_FirstSubscribeFailureStopsAndSurfaces` and `TestCommandOutputListener_KeepsRetryingAfterTheFirstSubscribe` pin the two halves of the fatal rule.
- `TestSudoListener_RefreshesTheAccessTokenOnUnauthorized` and `TestSudoListener_LeavesTheTokenAloneOnOtherStatuses` pin both halves of the 401 rule.
- `TestSudoListener_StaysQuietWhenAFailureLandsAfterStop` and `TestSudoListener_SurfacesANonFatalCauseAfterTheWaitEnds` cover the shutdown window and the widened `Err()`.
- `TestSudoListener_TriesOneRefreshBeforeGivingUpOnAnUnauthorizedFirstSession` pins both halves of the pre-subscribe exception: one refresh, then the refusal stands.
- `TestCommandOutputListener_SubscribeFailsOnAStoppedListener` covers the stop-then-subscribe window, `..._SubscribeCarriesWhyTheListenerStopped` pins the wrapped reason, and `..._SubscribeFailsWhenTheListenerStopsMidSubscription` drives the narrower window by stopping the listener from inside the subscription handler.
- `TestSudoListenerWarning_SanitizesTheServersText` and `TestSetupSudoListener_WarningReturnsTheCursor` cover the two raw-mode concerns above.

Every test was seen red first, and the assertions that carry a judgment were proven by mutation. Deleting `sl.warned = false` turns `TestSudoListener_AnnouncesTheNextOutageAfterRecovering` into `expected: 2, actual: 1`. Dropping the refresh call, refreshing on every status but 401, dropping the `done` guard, and recording only the fatal cause each turn exactly one test red. So do dropping the pre-subscribe refresh, dropping its one-shot guard, removing the stopped-listener check, dropping the `%w` wrap around the halt reason, and removing the second check.

On the final diff:

- `go test -race -count=1 ./...`: 39 `ok`, no `FAIL`.
- `go vet ./...`: no output.
- `golangci-lint run ./...`: `0 issues.`

Closes #293





