### PR TITLE
feat(update): add alpacon update to self-update the CLI

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -15,9 +15,9 @@ permissions:
   contents: read
 
 jobs:
-  # No `name:` on purpose: the check context is then the job id, which the
-  # matrix splits in two where a flat `build-and-test` context expects one.
-  build-and-test:
+  # A matrix reports one check context per leg, and the org ruleset on main
+  # requires the flat `build-and-test`. The job below is what reports it.
+  test:
     runs-on: ${{ matrix.os }}
 
     # Windows is not a portability formality: the files that replace a running
@@ -60,3 +60,13 @@ jobs:
 
       - name: Run Tests
         run: go test -race -v ${{ matrix.packages }}
+
+  # success only if every leg was.
+  build-and-test:
+    needs: [test]
+    if: always()
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Fail unless every matrix leg passed
+        run: '[ "${{ needs.test.result }}" = "success" ]'

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -15,10 +15,27 @@ permissions:
   contents: read
 
 jobs:
-  # No `name:` on purpose. The check context is then the job id, which is the
-  # canonical single-segment `build-and-test` the other Go repos already emit.
+  # No `name:` on purpose: the check context is then the job id, which the
+  # matrix splits in two where a flat `build-and-test` context expects one.
   build-and-test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+
+    # Windows is not a portability formality: the files that replace a running
+    # executable are compiled out everywhere else and would ship untested without
+    # this runner. It runs only the packages that carry them—the rest of the
+    # suite asserts Unix file modes in tests that predate this job.
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            packages: ./...
+          - os: windows-latest
+            packages: ./pkg/selfupdate/... ./cmd
+
+    defaults:
+      run:
+        shell: bash
 
     steps:
       - name: Check out code
@@ -33,6 +50,7 @@ jobs:
         run: echo "GOTOOLCHAIN=auto" >> "$GITHUB_ENV"
 
       - name: Verify go.mod and go.sum are tidy
+        if: runner.os == 'Linux'
         run: |
           go mod tidy
           git diff --exit-code go.mod go.sum
@@ -41,4 +59,4 @@ jobs:
         run: go build -v .
 
       - name: Run Tests
-        run: go test -race -v ./...
+        run: go test -race -v ${{ matrix.packages }}

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -14,8 +14,18 @@ permissions:
 
 jobs:
   golangci-lint:
-    name: golangci-lint
+    name: golangci-lint (${{ matrix.goos }})
     runs-on: ubuntu-latest
+
+    # The self-update path has a file per platform; linting one GOOS leaves the
+    # other's unread.
+    strategy:
+      fail-fast: false
+      matrix:
+        goos: [linux, windows]
+
+    env:
+      GOOS: ${{ matrix.goos }}
 
     steps:
       - name: Check out code

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,7 +63,7 @@ cmd/                 # Cobra command definitions
 api/                 # API client functions per domain
 client/              # HTTP client wrapper for Alpacon API
 config/              # Configuration management (credentials, workspace)
-pkg/                 # Internal packages (cert, tunnel)
+pkg/                 # Internal packages (cert, selfupdate, tunnel)
 utils/               # Shared utilities (output, prompts, errors, SSH parsing)
 ```
 
@@ -193,5 +193,5 @@ _ = json.NewEncoder(w).Encode(resp)
 - **Config file**: `~/.alpacon/config.json` (dir `0700`, file `0600`). `saveConfig` writes a sibling temp file and renames it over the target—two alpacon processes can be saving a renewed access token at the same moment, and a plain truncate-and-write leaves a config the next command cannot parse. Any new writer must go through `saveConfig`
 - **Alias**: `alpacon` can also be invoked as `ac`
 - **File transfer**: The `cp` command lives in `cmd/ftp/` (package name `ftp`)
-- **Exit codes**: `0` success, `1` general error, `2` usage error (only `work-session`, `event wait`/`watch`, and `utils.RequirePositiveInt`; every other command's own validation and Cobra parse errors still exit `1`), `3` WorkSession gate denied, `4` pending approval with the outcome still open, `5` server busy, `6` approval not granted, `7` purpose required—an agent's command held while the gate asks what it is for, answerable by the caller rather than by an approver (constants in `utils/error.go`). Keep these stable—scripts, CI, and AI agents branch on them. See README "Exit codes".
+- **Exit codes**: `0` success, `1` general error, `2` usage error (only `work-session`, `event wait`/`watch`, and `utils.RequirePositiveInt`; every other command's own validation and Cobra parse errors still exit `1`), `3` WorkSession gate denied, `4` pending approval with the outcome still open, `5` server busy, `6` approval not granted, `7` purpose required—an agent's command held while the gate asks what it is for, answerable by the caller rather than by an approver, `8` a newer release exists (only `alpacon update --check`) (constants in `utils/error.go`). Keep these stable—scripts, CI, and AI agents branch on them. See README "Exit codes".
 - **IAM**: `user` and `group` commands both live in `cmd/iam/`

--- a/README.md
+++ b/README.md
@@ -64,9 +64,9 @@ go build && sudo mv alpacon-cli /usr/local/bin/alpacon
 
 ### Updating
 
-`alpacon update` brings the CLI to the latest release. A binary built from source carries the version `dev`, which matches no release, so the command refuses it and says so—build with GoReleaser or install a released build to use it. A binary you placed yourself is downloaded, verified against the release's SHA-256 checksums, and replaced in place; the old binary is kept beside it until the replacement succeeds—on Windows, where a running executable stays locked, it is kept as `alpacon.exe.old.<timestamp>` and removed by the next update. A binary a package manager or a version manager owns is never overwritten—the command prints how to update through that tool and exits `1`, leaving the upgrade to you. Homebrew, deb and rpm get the exact command; mise and asdf are named without one, since the command depends on how the tool was set up. While it runs it holds `.alpacon-update.lock` beside the binary, so two updates cannot replace the same file at once; the file stays there afterwards and is safe to leave alone. The command only moves forward: a build ahead of the latest release, such as a release candidate, is left alone rather than downgraded. `alpacon update --check` reports whether a newer release exists and installs nothing, exiting `8` when there is one.
+`alpacon update` brings the CLI to the latest release. A binary built from source carries the version `dev`, which matches no release, so the command refuses it and says so—build with GoReleaser or install a released build to use it. A binary you placed yourself is downloaded, verified against the release's SHA-256 checksums, and replaced in place; the old binary is kept beside it until the replacement succeeds—on Windows, where a running executable stays locked, it is kept as `alpacon.exe.old.<timestamp>` and removed by the next update. A binary a package manager or a version manager owns is never overwritten—the command prints how to update through that tool and exits `1`, leaving the upgrade to you. If the ownership question cannot be answered at all—`rpm -qf` takes a read lock on the rpm database, so it is killed when another package transaction holds it—the binary is left alone rather than assumed unowned, and the command says to retry once that transaction has finished. Homebrew, deb and rpm get the exact command; mise and asdf are named without one, since the command depends on how the tool was set up. While it runs it holds `.alpacon-update.lock` beside the binary, so two updates cannot replace the same file at once; the file stays there afterwards and is safe to leave alone. The command only moves forward: a build ahead of the latest release, such as a release candidate, is left alone rather than downgraded. `alpacon update --check` reports whether a newer release exists and installs nothing, exiting `8` when there is one.
 
-If the binary is group- or world-writable, the update keeps that mode and says so on stderr rather than narrowing it—re-permissioning a file you set up is your call. Close it with `chmod go-w`, since any local account can otherwise replace the binary you run.
+If the binary or its directory is group- or world-writable, the update says so on stderr rather than narrowing anything—re-permissioning what you set up is your call. The directory is the one that usually matters: replacing a file is a rename, which needs no permission on the file itself, so a `0755` root-owned `alpacon` inside a `0775` directory can still be swapped by anyone in that group. Close it with `chmod go-w`.
 
 #### What the checksum does and does not prove
 
@@ -75,6 +75,7 @@ Releases are checksum-verified but **unsigned**. The SHA-256 comparison proves t
 To check out of band, compare `alpacon version` against the [Releases](https://github.com/alpacax/alpacon-cli/releases) page, and verify the archive yourself before installing it:
 
 ```bash
+# The archive is .tar.gz everywhere but Windows, which ships .zip.
 curl -LO https://github.com/alpacax/alpacon-cli/releases/download/v<version>/alpacon-<version>-<os>-<arch>.tar.gz
 curl -LO https://github.com/alpacax/alpacon-cli/releases/download/v<version>/alpacon-<version>-checksums.sha256
 sha256sum --check --ignore-missing alpacon-<version>-checksums.sha256
@@ -82,11 +83,16 @@ sha256sum --check --ignore-missing alpacon-<version>-checksums.sha256
 
 #### If a Windows update is killed mid-replace
 
-Windows refuses to overwrite a running executable, so the update renames it aside and renames the new one into place. A process killed between those two renames leaves no `alpacon.exe`—only `alpacon.exe.old.<timestamp>` beside it. Nothing recovers automatically, because the binary that would run the next update is the one that went missing. Rename the preserved copy back:
+Windows refuses to overwrite a running executable, so the update copies the new binary in as `alpacon.exe.staged.<timestamp>`, renames the old one aside as `alpacon.exe.old.<timestamp>`, and renames the staged copy into place. A process killed between those two renames leaves no `alpacon.exe` and both of the others beside it. Nothing recovers automatically, because the binary that would run the next update is the one that went missing.
+
+The staged copy is the new release and was already checksum-verified, so finishing the update is usually what you want:
 
 ```powershell
-Rename-Item alpacon.exe.old.<timestamp> alpacon.exe
+Rename-Item alpacon.exe.staged.<timestamp> alpacon.exe
+Remove-Item alpacon.exe.old.<timestamp>
 ```
+
+To go back to the version you had instead, rename `alpacon.exe.old.<timestamp>` and delete the staged copy. Either way the next update sweeps whichever one you leave.
 
 ## Quick start
 

--- a/README.md
+++ b/README.md
@@ -66,6 +66,28 @@ go build && sudo mv alpacon-cli /usr/local/bin/alpacon
 
 `alpacon update` brings the CLI to the latest release. A binary built from source carries the version `dev`, which matches no release, so the command refuses it and says so—build with GoReleaser or install a released build to use it. A binary you placed yourself is downloaded, verified against the release's SHA-256 checksums, and replaced in place; the old binary is kept beside it until the replacement succeeds—on Windows, where a running executable stays locked, it is kept as `alpacon.exe.old.<timestamp>` and removed by the next update. A binary a package manager or a version manager owns is never overwritten—the command prints how to update through that tool and exits `1`, leaving the upgrade to you. Homebrew, deb and rpm get the exact command; mise and asdf are named without one, since the command depends on how the tool was set up. While it runs it holds `.alpacon-update.lock` beside the binary, so two updates cannot replace the same file at once; the file stays there afterwards and is safe to leave alone. The command only moves forward: a build ahead of the latest release, such as a release candidate, is left alone rather than downgraded. `alpacon update --check` reports whether a newer release exists and installs nothing, exiting `8` when there is one.
 
+If the binary is group- or world-writable, the update keeps that mode and says so on stderr rather than narrowing it—re-permissioning a file you set up is your call. Close it with `chmod go-w`, since any local account can otherwise replace the binary you run.
+
+#### What the checksum does and does not prove
+
+Releases are checksum-verified but **unsigned**. The SHA-256 comparison proves the archive arrived intact and matches the checksums file the release publishes; it proves nothing about who published either, because both come from the same release and no signature is attached. Anyone who could write to a release—a leaked token, a compromised account, a poisoned release workflow—could upload a trojaned archive together with a checksums file that matches it, and verification would pass.
+
+To check out of band, compare `alpacon version` against the [Releases](https://github.com/alpacax/alpacon-cli/releases) page, and verify the archive yourself before installing it:
+
+```bash
+curl -LO https://github.com/alpacax/alpacon-cli/releases/download/v<version>/alpacon-<version>-<os>-<arch>.tar.gz
+curl -LO https://github.com/alpacax/alpacon-cli/releases/download/v<version>/alpacon-<version>-checksums.sha256
+sha256sum --check --ignore-missing alpacon-<version>-checksums.sha256
+```
+
+#### If a Windows update is killed mid-replace
+
+Windows refuses to overwrite a running executable, so the update renames it aside and renames the new one into place. A process killed between those two renames leaves no `alpacon.exe`—only `alpacon.exe.old.<timestamp>` beside it. Nothing recovers automatically, because the binary that would run the next update is the one that went missing. Rename the preserved copy back:
+
+```powershell
+Rename-Item alpacon.exe.old.<timestamp> alpacon.exe
+```
+
 ## Quick start
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ If the binary or its directory is group- or world-writable, the update says so o
 
 #### What the checksum does and does not prove
 
-Releases are checksum-verified but **unsigned**. The SHA-256 comparison proves the archive arrived intact and matches the checksums file the release publishes; it proves nothing about who published either, because both come from the same release and no signature is attached. Anyone who could write to a release—a leaked token, a compromised account, a poisoned release workflow—could upload a trojaned archive together with a checksums file that matches it, and verification would pass.
+Releases are checksum-verified but **unsigned**. The SHA-256 comparison proves the archive arrived intact and matches the checksums file the release publishes; it proves nothing about who published either, because both come from the same release and no signature is attached. Anyone who could write to a release—a leaked token, a compromised account, a poisoned release workflow—could upload a trojaned archive together with a checksums file that matches it, and verification would pass. Signing the checksums against a pinned identity is tracked in [#412](https://github.com/alpacax/alpacon-cli/issues/412).
 
 To check out of band, compare `alpacon version` against the [Releases](https://github.com/alpacax/alpacon-cli/releases) page, and verify the archive yourself before installing it:
 

--- a/README.md
+++ b/README.md
@@ -30,22 +30,25 @@ For production usage, see the [official documentation](https://docs.alpacax.com/
 ### macOS (Homebrew)
 ```bash
 brew install alpacax/alpacon/alpacon-cli
+brew upgrade alpacon-cli   # update
 ```
 
 ### Linux (Debian / Ubuntu)
 ```bash
 curl -s https://packagecloud.io/install/repositories/alpacax/alpacon/script.deb.sh?any=true | sudo bash
 sudo apt-get install alpacon
+sudo apt-get update && sudo apt-get install --only-upgrade alpacon   # update
 ```
 
 ### Linux (RHEL / Rocky / AlmaLinux)
 ```bash
 curl -s https://packagecloud.io/install/repositories/alpacax/alpacon/script.rpm.sh?any=true | sudo bash
 sudo yum install alpacon
+sudo yum update alpacon   # update
 ```
 
 ### Windows
-Download the latest `.zip` from [Releases](https://github.com/alpacax/alpacon-cli/releases) and add the binary to your `PATH`.
+Download the latest `.zip` from [Releases](https://github.com/alpacax/alpacon-cli/releases) and add the binary to your `PATH`. Update it in place with `alpacon update`.
 
 ### Docker
 ```bash
@@ -58,6 +61,10 @@ git clone https://github.com/alpacax/alpacon-cli.git
 cd alpacon-cli
 go build && sudo mv alpacon-cli /usr/local/bin/alpacon
 ```
+
+### Updating
+
+`alpacon update` brings the CLI to the latest release. A binary built from source carries the version `dev`, which matches no release, so the command refuses it and says so—build with GoReleaser or install a released build to use it. A binary you placed yourself is downloaded, verified against the release's SHA-256 checksums, and replaced in place; the old binary is kept beside it until the replacement succeeds—on Windows, where a running executable stays locked, it is kept as `alpacon.exe.old.<timestamp>` and removed by the next update. A binary a package manager or a version manager owns is never overwritten—the command prints how to update through that tool and exits `1`, leaving the upgrade to you. Homebrew, deb and rpm get the exact command; mise and asdf are named without one, since the command depends on how the tool was set up. While it runs it holds `.alpacon-update.lock` beside the binary, so two updates cannot replace the same file at once; the file stays there afterwards and is safe to leave alone. The command only moves forward: a build ahead of the latest release, such as a release candidate, is left alone rather than downgraded. `alpacon update --check` reports whether a newer release exists and installs nothing, exiting `8` when there is one.
 
 ## Quick start
 
@@ -312,6 +319,7 @@ Also separate from the work session gate: when you authenticate with an API toke
 | `5`  | Server busy with active user work—a disruptive `server` action (`reboot`, `shutdown`, `upgrade`) was refused because the server has an open Websh/WebFTP session or in-flight command. Transient and retryable: retry when idle, or re-run with `--force` to override |
 | `6`  | Approval not granted—an awaited approval settled without being granted (rejected, expired, revoked, cancelled, or completed). Distinct from `4`: the outcome is final, so retrying the same request only generates another approval request. Returned by `alpacon event wait`, by `work-session create --wait`, and—when a reviewer rejected the command itself—by `exec`, by `websh` command mode, and by `alpacon exec logs`. Under `--output json` these paths emit an error envelope carrying the same `exit_code` |
 | `7`  | Purpose required—the verification gate held an agent's command and is asking what it is for, before any approval request exists (ADR 0052). Distinct from `4`: nothing is pending on a human, nobody has been notified, and the next move belongs to the caller that submitted the command. Answer with `alpacon exec purpose <JOB_ID> "..."` within about a minute; `--wait` does not apply, because the answer is yours to give rather than somebody else's to grant. Pass `--purpose` on the original `exec` to state it up front and skip the demand entirely. One demand per command: on silence the command takes the ordinary path, and a late or second answer is refused. Under `--output json`, a `{"status":"purpose_required", ...}` object is emitted carrying the command id, the seconds left (when the server reports the demand's expiry), and what makes a purpose useful. `alpacon exec purpose` answers on the same contract, emitting `purpose_recorded` on success and `purpose_refused` (exit `1`) when the demand is already settled or the credential is not the one that submitted the command. Returned by `exec`, by `websh` command mode (which reaches the same handler through `RunRemoteExec` but has no `--purpose`, so a demand there can only be answered with `alpacon exec purpose`), and by `alpacon exec logs` — the only sight `--detach` has of a demand, and worth knowing because a held command sits for the length of the window before taking the ordinary path |
+| `8`  | A newer release is available—returned only by `alpacon update --check`, which reports the newer version and installs nothing. Distinct from `1`: `1` means the check itself failed, `8` means it succeeded and found a newer version. The check prints what to run: `alpacon update` for a binary you placed yourself, and for one another tool owns, how to update through that tool |
 
 ## Contributing
 

--- a/cmd/helpers_test.go
+++ b/cmd/helpers_test.go
@@ -1,9 +1,22 @@
 package cmd
 
 import (
+	"bytes"
+	"context"
+	"os"
+	osexec "os/exec"
 	"runtime"
+	"slices"
 	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
 )
+
+// helperProcessTimeout bounds a child that blocks—on the network, or on a
+// prompt reading a stdin that never reaches EOF. Without it the whole suite
+// waits out go test's own timeout and the child outlives the test binary.
+const helperProcessTimeout = 60 * time.Second
 
 func homeEnvVar() string { // A test that sets only HOME points the Windows run at the real user's home, so the config it wrote under t.TempDir() is never the one being read.
 	if runtime.GOOS == "windows" {
@@ -17,11 +30,34 @@ func setTestHome(t *testing.T, dir string) {
 	t.Setenv(homeEnvVar(), dir)
 }
 
+// runHelperProcess re-executes this test binary as a child so an os.Exit the
+// command makes is observable, which no in-process test can see.
+func runHelperProcess(t *testing.T, helperTest, marker string, args []string, env ...string) (stdout, stderr string, exitCode int) {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(t.Context(), helperProcessTimeout)
+	defer cancel()
+
+	helperArgs := append([]string{"-test.run=^" + helperTest + "$", "--", marker}, args...)
+	helper := osexec.CommandContext(ctx, os.Args[0], helperArgs...)
+	helper.Env = append(os.Environ(), env...)
+
+	var stdoutBuf, stderrBuf bytes.Buffer
+	helper.Stdout = &stdoutBuf
+	helper.Stderr = &stderrBuf
+
+	if err := helper.Run(); err != nil {
+		require.NoError(t, ctx.Err(), "%s did not finish within %s", helperTest, helperProcessTimeout)
+		var exitErr *osexec.ExitError
+		require.ErrorAs(t, err, &exitErr)
+		exitCode = exitErr.ExitCode()
+	}
+	return stdoutBuf.String(), stderrBuf.String(), exitCode
+}
+
 func helperArgsAfter(args []string, marker string) ([]string, bool) { // Skips past the -test flags a re-executed test binary still carries in its own argv.
-	for i := 0; i < len(args); i++ {
-		if args[i] == marker {
-			return args[i+1:], true
-		}
+	if i := slices.Index(args, marker); i >= 0 {
+		return args[i+1:], true
 	}
 	return nil, false
 }

--- a/cmd/helpers_test.go
+++ b/cmd/helpers_test.go
@@ -1,0 +1,27 @@
+package cmd
+
+import (
+	"runtime"
+	"testing"
+)
+
+func homeEnvVar() string { // A test that sets only HOME points the Windows run at the real user's home, so the config it wrote under t.TempDir() is never the one being read.
+	if runtime.GOOS == "windows" {
+		return "USERPROFILE"
+	}
+	return "HOME"
+}
+
+func setTestHome(t *testing.T, dir string) {
+	t.Helper()
+	t.Setenv(homeEnvVar(), dir)
+}
+
+func helperArgsAfter(args []string, marker string) ([]string, bool) { // Skips past the -test flags a re-executed test binary still carries in its own argv.
+	for i := 0; i < len(args); i++ {
+		if args[i] == marker {
+			return args[i+1:], true
+		}
+	}
+	return nil, false
+}

--- a/cmd/login_test.go
+++ b/cmd/login_test.go
@@ -785,7 +785,7 @@ func runLoginCommandHelper(t *testing.T, args []string) (stdout, stderr string, 
 	helper := osexec.Command(os.Args[0], helperArgs...)
 	helper.Env = append(os.Environ(),
 		"GO_WANT_LOGIN_HELPER=1",
-		"HOME="+home,
+		homeEnvVar()+"="+home,
 	)
 
 	var stdoutBuf, stderrBuf bytes.Buffer
@@ -806,7 +806,7 @@ func TestLoginCommandHelperProcess(t *testing.T) {
 	if os.Getenv("GO_WANT_LOGIN_HELPER") != "1" {
 		return
 	}
-	args, ok := loginCommandHelperArgs(os.Args)
+	args, ok := helperArgsAfter(os.Args, "login-helper")
 	if !ok {
 		os.Exit(2)
 	}
@@ -815,15 +815,6 @@ func TestLoginCommandHelperProcess(t *testing.T) {
 		os.Exit(1)
 	}
 	os.Exit(0)
-}
-
-func loginCommandHelperArgs(args []string) ([]string, bool) {
-	for i := 0; i < len(args); i++ {
-		if args[i] == "login-helper" {
-			return args[i+1:], true
-		}
-	}
-	return nil, false
 }
 
 func writeLoginCommandTestConfig(t *testing.T, home string) {

--- a/cmd/login_test.go
+++ b/cmd/login_test.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"net/http"
 	"os"
-	osexec "os/exec"
 	"path/filepath"
 	"testing"
 	"time"
@@ -778,28 +777,10 @@ func runLoginCommandHelper(t *testing.T, args []string) (stdout, stderr string, 
 	home := t.TempDir()
 	writeLoginCommandTestConfig(t, home)
 
-	helperArgs := append(
-		[]string{"-test.run=^TestLoginCommandHelperProcess$", "--", "login-helper"},
-		args...,
-	)
-	helper := osexec.Command(os.Args[0], helperArgs...)
-	helper.Env = append(os.Environ(),
+	return runHelperProcess(t, "TestLoginCommandHelperProcess", "login-helper", args,
 		"GO_WANT_LOGIN_HELPER=1",
 		homeEnvVar()+"="+home,
 	)
-
-	var stdoutBuf, stderrBuf bytes.Buffer
-	helper.Stdout = &stdoutBuf
-	helper.Stderr = &stderrBuf
-
-	err := helper.Run()
-	exitCode = 0
-	if err != nil {
-		var exitErr *osexec.ExitError
-		require.ErrorAs(t, err, &exitErr)
-		exitCode = exitErr.ExitCode()
-	}
-	return stdoutBuf.String(), stderrBuf.String(), exitCode
 }
 
 func TestLoginCommandHelperProcess(t *testing.T) {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -85,6 +85,9 @@ func init() {
 	// version
 	RootCmd.AddCommand(versionCmd)
 
+	// update
+	RootCmd.AddCommand(updateCmd)
+
 	// login
 	RootCmd.AddCommand(loginCmd)
 

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestBuildWelcomeLines(t *testing.T) {
 	t.Run("not logged in (no config file)", func(t *testing.T) {
-		t.Setenv("HOME", t.TempDir())
+		setTestHome(t, t.TempDir())
 		lines := buildWelcomeLines()
 		require.Len(t, lines, 3)
 		assert.Contains(t, lines[0], "alpacon")
@@ -21,7 +21,7 @@ func TestBuildWelcomeLines(t *testing.T) {
 
 	t.Run("logged in via Auth0 — workspace host shown", func(t *testing.T) {
 		home := t.TempDir()
-		t.Setenv("HOME", home)
+		setTestHome(t, home)
 		cfgDir := filepath.Join(home, ".alpacon")
 		require.NoError(t, os.MkdirAll(cfgDir, 0700))
 		cfg := `{"workspace_url":"https://myws.us1.alpacon.io","workspace_name":"myws","access_token":"a"}`
@@ -34,7 +34,7 @@ func TestBuildWelcomeLines(t *testing.T) {
 
 	t.Run("logged in via legacy token — workspace host shown", func(t *testing.T) {
 		home := t.TempDir()
-		t.Setenv("HOME", home)
+		setTestHome(t, home)
 		cfgDir := filepath.Join(home, ".alpacon")
 		require.NoError(t, os.MkdirAll(cfgDir, 0700))
 		cfg := `{"workspace_url":"https://myws.alpacon.io","workspace_name":"myws","token":"t"}`
@@ -46,7 +46,7 @@ func TestBuildWelcomeLines(t *testing.T) {
 
 	t.Run("config malformed — surfaces config error, not 'not logged in'", func(t *testing.T) {
 		home := t.TempDir()
-		t.Setenv("HOME", home)
+		setTestHome(t, home)
 		cfgDir := filepath.Join(home, ".alpacon")
 		require.NoError(t, os.MkdirAll(cfgDir, 0700))
 		require.NoError(t, os.WriteFile(filepath.Join(cfgDir, "config.json"), []byte("{not-json"), 0600))
@@ -58,7 +58,7 @@ func TestBuildWelcomeLines(t *testing.T) {
 
 	t.Run("config exists but no tokens — treated as not logged in", func(t *testing.T) {
 		home := t.TempDir()
-		t.Setenv("HOME", home)
+		setTestHome(t, home)
 		cfgDir := filepath.Join(home, ".alpacon")
 		require.NoError(t, os.MkdirAll(cfgDir, 0700))
 		cfg := `{"workspace_url":"https://x.alpacon.io","workspace_name":"x"}`

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -68,11 +68,14 @@ never has to parse prose:
 		}
 
 		message, code := reportResult(result, utils.Version)
-		if code == 0 {
+		switch {
+		case code != 0:
+			utils.CliErrorWithExitCode(code, "%s", message)
+		case result.AlreadyCurrent:
 			utils.CliInfo("%s", message)
-			return
+		default:
+			utils.CliSuccess("%s", message) // The binary was replaced; Info would read exactly like the "already up to date" line above.
 		}
-		utils.CliErrorWithExitCode(code, "%s", message)
 	},
 }
 
@@ -91,24 +94,31 @@ func checkOutcome(current, latest string) (string, int) {
 	return fmt.Sprintf("A newer release is available: %s -> %s.", current, latest), utils.ExitCodeUpdateAvailable
 }
 
-func installKind() selfupdate.InstallKind { // The update itself would fail on a binary that cannot be found, so the check has nothing better to say than manual.
+func installKind() selfupdate.InstallKind { // --check installs nothing, so a binary it cannot find or place has nothing better to say than manual—'alpacon update' is where not knowing has to stop the work.
 	executable, err := selfupdate.ResolveExecutablePath()
 	if err != nil {
 		return selfupdate.InstallManual
 	}
-	return selfupdate.DetectInstallKind(selfupdate.ExecRunner, executable)
+	kind, err := selfupdate.DetectInstallKind(selfupdate.ExecRunner, executable)
+	if err != nil {
+		return selfupdate.InstallManual
+	}
+	return kind
 }
 
-func checkAction(kind selfupdate.InstallKind) string { // Never names 'alpacon update' for a binary a package manager owns: that command can only exit 1 on such a binary.
-	if guidance := selfupdate.UpgradeGuidance(kind); guidance != "" {
-		return guidance
+func checkAction(kind selfupdate.InstallKind) string { // Reads Kind rather than Guidance, for the reason reportResult gives below: an install kind whose wording nobody wrote must not be told to run 'alpacon update', which can only exit 1 on it.
+	if kind == selfupdate.InstallManual {
+		return "Run 'alpacon update' to install it."
 	}
-	return "Run 'alpacon update' to install it."
+	return selfupdate.UpgradeGuidance(kind)
 }
 
 func updateFailureMessage(err error) string {
 	if hint := permissionHint(err); hint != "" {
 		return fmt.Sprintf("%s (%s)", hint, err)
+	}
+	if errors.Is(err, selfupdate.ErrOwnerUnknown) {
+		return fmt.Sprintf("Could not tell whether a package manager owns this binary, so it was left alone. Try again once any package transaction has finished, or update through your package manager. (%s)", err)
 	}
 	return fmt.Sprintf("Update failed: %s", err)
 }
@@ -121,6 +131,10 @@ func permissionHint(err error) string {
 		return ""
 	}
 	if errors.Is(err, selfupdate.ErrWorkDirUnavailable) { // The temp directory is nobody's install location, so sudo is not the answer: the variable naming it belongs to the user who set it.
+		tempDirEnvVar := "TMPDIR"
+		if runtime.GOOS == "windows" { // os.TempDir calls GetTempPath there, which reads TMP, TEMP and USERPROFILE and never TMPDIR.
+			tempDirEnvVar = "TMP"
+		}
 		return fmt.Sprintf("The temporary directory is not writable by this user. Point %s at a writable directory and try again.", tempDirEnvVar)
 	}
 	if runtime.GOOS == "windows" {

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -1,0 +1,144 @@
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"runtime"
+
+	"github.com/alpacax/alpacon-cli/pkg/selfupdate"
+	"github.com/alpacax/alpacon-cli/utils"
+	"github.com/spf13/cobra"
+)
+
+var checkOnly bool
+
+var updateCmd = &cobra.Command{
+	Use:   "update [flags]",
+	Short: "Update the CLI to the latest release",
+	Args:  cobra.NoArgs, // Without this, 'alpacon update check'—the typo for --check—is an argument nobody reads, and the binary gets replaced instead.
+	Long: `Update the CLI to the latest release.
+
+A binary a package manager or a version manager installed is left to that tool:
+the command prints how to update through it instead of replacing the file. A
+binary built from source carries the version 'dev', which matches no release,
+and is refused.
+
+--check installs nothing and carries its answer in the exit code, so a script
+never has to parse prose:
+
+  0  already on the latest release
+  8  a newer release exists`,
+	Example: `  alpacon update
+  alpacon update --check`,
+	Run: func(cmd *cobra.Command, args []string) {
+		if selfupdate.IsUnknownVersion(utils.Version) {
+			utils.CliErrorWithExit("This build's version %q matches no release, so there is nothing to update from. Install a released build to use 'alpacon update'.", utils.Version)
+		}
+
+		if checkOnly {
+			release, err := selfupdate.LatestRelease(selfupdate.DefaultReleaseAPIURL)
+			if err != nil {
+				utils.CliErrorWithExit("Could not check for updates: %s", err)
+			}
+			message, code := checkOutcome(utils.Version, release.Version)
+			utils.CliInfo("%s", message)
+			if code != 0 {
+				utils.CliInfo("%s", checkAction(installKind())) // CliInfo, not CliError: the check succeeded, and "Error" would contradict the exit code the README tells scripts to branch on.
+				os.Exit(code)
+			}
+			return
+		}
+
+		executable, err := selfupdate.ResolveExecutablePath()
+		if err != nil {
+			utils.CliErrorWithExit("Could not find the running binary: %s", err)
+		}
+
+		result, err := selfupdate.Run(selfupdate.Options{
+			ReleaseAPIURL:  selfupdate.DefaultReleaseAPIURL,
+			CurrentVersion: utils.Version,
+			GOOS:           runtime.GOOS,
+			GOARCH:         runtime.GOARCH,
+			ExecutablePath: executable,
+			Runner:         selfupdate.ExecRunner,
+		})
+		if err != nil {
+			utils.CliErrorWithExit("%s", updateFailureMessage(err))
+		}
+
+		message, code := reportResult(result, utils.Version)
+		if code == 0 {
+			utils.CliInfo("%s", message)
+			return
+		}
+		utils.CliErrorWithExitCode(code, "%s", message)
+	},
+}
+
+func init() {
+	updateCmd.Flags().BoolVar(&checkOnly, "check", false, "Report whether a newer release exists without installing it")
+}
+
+func upToDateMessage(current string) string {
+	return fmt.Sprintf("alpacon %s is already up to date.", current)
+}
+
+func checkOutcome(current, latest string) (string, int) {
+	if !selfupdate.IsOutdated(current, latest) {
+		return upToDateMessage(current), 0
+	}
+	return fmt.Sprintf("A newer release is available: %s -> %s.", current, latest), utils.ExitCodeUpdateAvailable
+}
+
+func installKind() selfupdate.InstallKind { // The update itself would fail on a binary that cannot be found, so the check has nothing better to say than manual.
+	executable, err := selfupdate.ResolveExecutablePath()
+	if err != nil {
+		return selfupdate.InstallManual
+	}
+	return selfupdate.DetectInstallKind(selfupdate.ExecRunner, executable)
+}
+
+func checkAction(kind selfupdate.InstallKind) string { // Never names 'alpacon update' for a binary a package manager owns: that command can only exit 1 on such a binary.
+	if guidance := selfupdate.UpgradeGuidance(kind); guidance != "" {
+		return guidance
+	}
+	return "Run 'alpacon update' to install it."
+}
+
+func updateFailureMessage(err error) string {
+	if hint := permissionHint(err); hint != "" {
+		return fmt.Sprintf("%s (%s)", hint, err)
+	}
+	return fmt.Sprintf("Update failed: %s", err)
+}
+
+// permissionHint names sudo for the user to run, never for the CLI to re-run
+// itself: that would leave root-owned temp files and downloads in the user's own
+// directories.
+func permissionHint(err error) string {
+	if !errors.Is(err, os.ErrPermission) {
+		return ""
+	}
+	if errors.Is(err, selfupdate.ErrWorkDirUnavailable) { // The temp directory is nobody's install location, so sudo is not the answer: the variable naming it belongs to the user who set it.
+		return fmt.Sprintf("The temporary directory is not writable by this user. Point %s at a writable directory and try again.", tempDirEnvVar)
+	}
+	if runtime.GOOS == "windows" {
+		return "The install location is not writable by this user. Re-run 'alpacon update' from an administrator terminal."
+	}
+	return "The install location is not writable by this user. Re-run as 'sudo alpacon update'."
+}
+
+// reportResult reads Kind, not Guidance: an install kind whose wording nobody
+// wrote would otherwise be called a success and print "Successfully updated
+// to ." having replaced nothing.
+func reportResult(result selfupdate.Result, current string) (string, int) {
+	switch {
+	case result.AlreadyCurrent:
+		return upToDateMessage(current), 0
+	case result.Kind != selfupdate.InstallManual:
+		return result.Guidance, utils.ExitCodeGeneralError
+	default:
+		return fmt.Sprintf("Successfully updated to %s.", result.UpdatedTo), 0
+	}
+}

--- a/cmd/update_tempdir_unix.go
+++ b/cmd/update_tempdir_unix.go
@@ -1,0 +1,5 @@
+//go:build !windows
+
+package cmd
+
+const tempDirEnvVar = "TMPDIR"

--- a/cmd/update_tempdir_unix.go
+++ b/cmd/update_tempdir_unix.go
@@ -1,5 +1,0 @@
-//go:build !windows
-
-package cmd
-
-const tempDirEnvVar = "TMPDIR"

--- a/cmd/update_tempdir_windows.go
+++ b/cmd/update_tempdir_windows.go
@@ -1,0 +1,5 @@
+//go:build windows
+
+package cmd
+
+const tempDirEnvVar = "TMP" // os.TempDir calls GetTempPath here, which reads TMP, TEMP and USERPROFILE and never TMPDIR.

--- a/cmd/update_tempdir_windows.go
+++ b/cmd/update_tempdir_windows.go
@@ -1,5 +1,0 @@
-//go:build windows
-
-package cmd
-
-const tempDirEnvVar = "TMP" // os.TempDir calls GetTempPath here, which reads TMP, TEMP and USERPROFILE and never TMPDIR.

--- a/cmd/update_test.go
+++ b/cmd/update_test.go
@@ -185,7 +185,7 @@ func TestUpdateCommandRefusesADevBuild(t *testing.T) {
 	assert.NotContains(t, stderr, "Successfully updated")
 }
 
-func TestUpdateCommandCheckExitsSevenWhenANewerReleaseExists(t *testing.T) {
+func TestUpdateCommandCheckExitsEightWhenANewerReleaseExists(t *testing.T) {
 	stderr, exitCode := runUpdateCommandHelper(t, []string{"update", "--check"},
 		"ALPACON_TEST_CURRENT_VERSION=1.0.0",
 		"ALPACON_TEST_LATEST_RELEASE=9.9.9",

--- a/cmd/update_test.go
+++ b/cmd/update_test.go
@@ -1,0 +1,255 @@
+package cmd
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	osexec "os/exec"
+	"runtime"
+	"testing"
+
+	"github.com/alpacax/alpacon-cli/pkg/selfupdate"
+	"github.com/alpacax/alpacon-cli/utils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExitCodeUpdateAvailableIsEight(t *testing.T) {
+	assert.Equal(t, 8, utils.ExitCodeUpdateAvailable, "scripts branch on this value; it is a public contract")
+}
+
+func TestCheckOutcome(t *testing.T) {
+	tests := []struct {
+		name         string
+		current      string
+		latest       string
+		wantContains []string
+		wantCode     int
+	}{
+		{
+			name:         "already newest",
+			current:      "1.4.0",
+			latest:       "1.4.0",
+			wantContains: []string{"up to date", "1.4.0"},
+			wantCode:     0,
+		},
+		{
+			name:         "a newer release is out",
+			current:      "1.3.0",
+			latest:       "1.4.0",
+			wantContains: []string{"1.3.0", "1.4.0"},
+			wantCode:     utils.ExitCodeUpdateAvailable,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			message, code := checkOutcome(tt.current, tt.latest)
+
+			assert.Equal(t, tt.wantCode, code)
+			for _, want := range tt.wantContains {
+				assert.Contains(t, message, want)
+			}
+		})
+	}
+}
+
+func TestUpdateCommandIsRegistered(t *testing.T) {
+	var names []string
+	for _, command := range RootCmd.Commands() {
+		names = append(names, command.Name())
+	}
+
+	assert.Contains(t, names, "update")
+}
+
+func TestPermissionHint(t *testing.T) {
+	hint := permissionHint(os.ErrPermission)
+
+	assert.Contains(t, hint, "not writable")
+	if runtime.GOOS == "windows" {
+		assert.Contains(t, hint, "administrator terminal", "Windows has no sudo to send the user to")
+	} else {
+		assert.Contains(t, hint, "sudo alpacon update")
+	}
+	assert.Empty(t, permissionHint(errors.New("connection reset")), "only a refused write earns the hint")
+}
+
+func TestPermissionHintStillNamesSudoWhenTheLockIsWhatWasRefused(t *testing.T) {
+	hint := permissionHint(fmt.Errorf("%w: %w", selfupdate.ErrLockUnavailable, os.ErrPermission)) // The lock sits in the install directory, so this is that directory refusing a write—the first one the command attempts.
+
+	assert.Contains(t, hint, "install location")
+	if runtime.GOOS == "windows" {
+		assert.Contains(t, hint, "administrator terminal")
+	} else {
+		assert.Contains(t, hint, "sudo alpacon update")
+	}
+}
+
+func TestPermissionHintSendsATempDirectoryFailureSomewhereElse(t *testing.T) {
+	hint := permissionHint(fmt.Errorf("%w: %w", selfupdate.ErrWorkDirUnavailable, os.ErrPermission))
+
+	if runtime.GOOS == "windows" {
+		assert.Contains(t, hint, "Point TMP at")
+	} else {
+		assert.Contains(t, hint, "Point TMPDIR at")
+	}
+	assert.NotContains(t, hint, "sudo alpacon update", "the variable naming the temp directory belongs to the user who set it")
+}
+
+func TestUpdateFailureMessageKeepsTheCauseBesideTheHint(t *testing.T) {
+	refused := fmt.Errorf("%w: open /usr/local/bin/.alpacon-update.lock: %w", selfupdate.ErrLockUnavailable, os.ErrPermission)
+
+	message := updateFailureMessage(refused)
+
+	assert.Contains(t, message, "not writable", "the hint says what to do")
+	assert.Contains(t, message, "/usr/local/bin/.alpacon-update.lock", "only the cause says which file refused")
+	assert.Equal(t, "Update failed: connection reset", updateFailureMessage(errors.New("connection reset")))
+}
+
+func TestReportResultNeverReportsSuccessForAnInstallItLeftAlone(t *testing.T) {
+	message, code := reportResult(selfupdate.Result{Kind: selfupdate.InstallVersionManager}, "1.3.0")
+
+	assert.Equal(t, utils.ExitCodeGeneralError, code)
+	assert.NotContains(t, message, "Successfully")
+}
+
+func TestReportResult(t *testing.T) {
+	tests := []struct {
+		name         string
+		result       selfupdate.Result
+		wantContains string
+		wantCode     int
+	}{
+		{
+			name:         "replaced",
+			result:       selfupdate.Result{Kind: selfupdate.InstallManual, UpdatedTo: "1.4.0"},
+			wantContains: "1.4.0",
+			wantCode:     0,
+		},
+		{
+			name:         "already newest",
+			result:       selfupdate.Result{AlreadyCurrent: true},
+			wantContains: "up to date",
+			wantCode:     0,
+		},
+		{
+			name:         "handed back to homebrew",
+			result:       selfupdate.Result{Kind: selfupdate.InstallHomebrew, Guidance: "brew upgrade alpacon-cli"},
+			wantContains: "brew upgrade alpacon-cli",
+			wantCode:     utils.ExitCodeGeneralError,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			message, code := reportResult(tt.result, "1.3.0")
+
+			assert.Equal(t, tt.wantCode, code)
+			assert.Contains(t, message, tt.wantContains)
+		})
+	}
+}
+
+func TestCheckActionNeverSendsAPackageManagerInstallToTheUpdateCommand(t *testing.T) {
+	assert.Contains(t, checkAction(selfupdate.InstallManual), "alpacon update")
+
+	for _, kind := range []selfupdate.InstallKind{
+		selfupdate.InstallHomebrew,
+		selfupdate.InstallDeb,
+		selfupdate.InstallRPM,
+		selfupdate.InstallVersionManager,
+	} {
+		action := checkAction(kind)
+		assert.NotContains(t, action, "alpacon update", "%s: 'alpacon update' exits 1 on this install, so --check must not name it", kind)
+		assert.NotEmpty(t, action, "%s: exit 8 owes the caller something to do", kind)
+	}
+}
+
+func TestUpdateCommandRefusesAPositionalArgument(t *testing.T) {
+	require.NotNil(t, updateCmd.Args, "an unvalidated argument makes 'alpacon update check' replace the binary")
+
+	assert.Error(t, updateCmd.Args(updateCmd, []string{"check"}))
+	assert.NoError(t, updateCmd.Args(updateCmd, nil))
+}
+
+// The three tests below drive the real command in a child process: what Run
+// decides after its first branch is an os.Exit, so deleting the dev-build guard
+// or the os.Exit(8) leaves every in-process test green.
+func TestUpdateCommandRefusesADevBuild(t *testing.T) {
+	stderr, exitCode := runUpdateCommandHelper(t, []string{"update"})
+
+	assert.Equal(t, utils.ExitCodeGeneralError, exitCode)
+	assert.Contains(t, stderr, "matches no release")
+	assert.NotContains(t, stderr, "Successfully updated")
+}
+
+func TestUpdateCommandCheckExitsSevenWhenANewerReleaseExists(t *testing.T) {
+	stderr, exitCode := runUpdateCommandHelper(t, []string{"update", "--check"},
+		"ALPACON_TEST_CURRENT_VERSION=1.0.0",
+		"ALPACON_TEST_LATEST_RELEASE=9.9.9",
+	)
+
+	assert.Equal(t, utils.ExitCodeUpdateAvailable, exitCode, "scripts branch on 8; falling through to the end of Run would exit 0")
+	assert.Contains(t, stderr, "1.0.0 -> 9.9.9")
+}
+
+func TestUpdateCommandCheckExitsZeroWhenAlreadyCurrent(t *testing.T) {
+	stderr, exitCode := runUpdateCommandHelper(t, []string{"update", "--check"},
+		"ALPACON_TEST_CURRENT_VERSION=9.9.9",
+		"ALPACON_TEST_LATEST_RELEASE=9.9.9",
+	)
+
+	assert.Equal(t, 0, exitCode)
+	assert.Contains(t, stderr, "already up to date")
+}
+
+func runUpdateCommandHelper(t *testing.T, args []string, env ...string) (stderr string, exitCode int) {
+	t.Helper()
+
+	helperArgs := append(
+		[]string{"-test.run=^TestUpdateCommandHelperProcess$", "--", "update-helper"},
+		args...,
+	)
+	helper := osexec.Command(os.Args[0], helperArgs...)
+	helper.Env = append(os.Environ(), "GO_WANT_UPDATE_HELPER=1", homeEnvVar()+"="+t.TempDir())
+	helper.Env = append(helper.Env, env...)
+
+	var stdoutBuf, stderrBuf bytes.Buffer
+	helper.Stdout = &stdoutBuf
+	helper.Stderr = &stderrBuf
+
+	err := helper.Run()
+	exitCode = 0
+	if err != nil {
+		var exitErr *osexec.ExitError
+		require.ErrorAs(t, err, &exitErr)
+		exitCode = exitErr.ExitCode()
+	}
+	return stderrBuf.String(), exitCode
+}
+
+func TestUpdateCommandHelperProcess(t *testing.T) {
+	if os.Getenv("GO_WANT_UPDATE_HELPER") != "1" {
+		return
+	}
+	if latest := os.Getenv("ALPACON_TEST_LATEST_RELEASE"); latest != "" {
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_, _ = fmt.Fprintf(w, `{"tag_name":"v%s","html_url":"https://example.test/releases"}`, latest)
+		}))
+		defer ts.Close()
+		selfupdate.DefaultReleaseAPIURL = ts.URL
+		utils.Version = os.Getenv("ALPACON_TEST_CURRENT_VERSION")
+	}
+
+	args, ok := helperArgsAfter(os.Args, "update-helper")
+	if !ok {
+		os.Exit(2)
+	}
+	RootCmd.SetArgs(args)
+	if err := RootCmd.Execute(); err != nil {
+		os.Exit(1)
+	}
+	os.Exit(0)
+}

--- a/cmd/update_test.go
+++ b/cmd/update_test.go
@@ -1,13 +1,11 @@
 package cmd
 
 import (
-	"bytes"
 	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
-	osexec "os/exec"
 	"runtime"
 	"testing"
 
@@ -208,26 +206,9 @@ func TestUpdateCommandCheckExitsZeroWhenAlreadyCurrent(t *testing.T) {
 func runUpdateCommandHelper(t *testing.T, args []string, env ...string) (stderr string, exitCode int) {
 	t.Helper()
 
-	helperArgs := append(
-		[]string{"-test.run=^TestUpdateCommandHelperProcess$", "--", "update-helper"},
-		args...,
-	)
-	helper := osexec.Command(os.Args[0], helperArgs...)
-	helper.Env = append(os.Environ(), "GO_WANT_UPDATE_HELPER=1", homeEnvVar()+"="+t.TempDir())
-	helper.Env = append(helper.Env, env...)
-
-	var stdoutBuf, stderrBuf bytes.Buffer
-	helper.Stdout = &stdoutBuf
-	helper.Stderr = &stderrBuf
-
-	err := helper.Run()
-	exitCode = 0
-	if err != nil {
-		var exitErr *osexec.ExitError
-		require.ErrorAs(t, err, &exitErr)
-		exitCode = exitErr.ExitCode()
-	}
-	return stderrBuf.String(), exitCode
+	helperEnv := append([]string{"GO_WANT_UPDATE_HELPER=1", homeEnvVar() + "=" + t.TempDir()}, env...)
+	_, stderr, exitCode = runHelperProcess(t, "TestUpdateCommandHelperProcess", "update-helper", args, helperEnv...)
+	return stderr, exitCode
 }
 
 func TestUpdateCommandHelperProcess(t *testing.T) {
@@ -252,4 +233,12 @@ func TestUpdateCommandHelperProcess(t *testing.T) {
 		os.Exit(1)
 	}
 	os.Exit(0)
+}
+
+func TestUpdateFailureMessageSaysWhyTheBinaryWasLeftAlone(t *testing.T) {
+	message := updateFailureMessage(fmt.Errorf("%w: rpm: context deadline exceeded", selfupdate.ErrOwnerUnknown))
+
+	assert.Contains(t, message, "left alone")
+	assert.Contains(t, message, "package manager")
+	assert.NotContains(t, message, "sudo alpacon update", "a stalled rpm query is not a permission problem")
 }

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,13 +1,9 @@
 package cmd
 
 import (
-	"encoding/json"
 	"fmt"
-	"io"
-	"net/http"
-	"strings"
-	"time"
 
+	"github.com/alpacax/alpacon-cli/pkg/selfupdate"
 	"github.com/alpacax/alpacon-cli/utils"
 	"github.com/spf13/cobra"
 )
@@ -18,48 +14,26 @@ var versionCmd = &cobra.Command{
 	Long:  "Displays the current version of the CLI and checks if there is an available update.",
 	Run: func(cmd *cobra.Command, args []string) {
 		utils.CliInfo("Current version: %s", utils.Version)
-		tagName, htmlURL, err := getLatestRelease()
+		release, err := selfupdate.LatestRelease(selfupdate.DefaultReleaseAPIURL)
 		if err != nil {
 			utils.CliWarning("Could not check for updates: %s", err)
 			return
 		}
-		releaseVersion := strings.TrimPrefix(tagName, "v")
-		if releaseVersion != utils.Version {
-			utils.CliWarning("Upgrade available: %s -> %s\nVisit %s for release notes.", utils.Version, releaseVersion, htmlURL)
-		} else {
-			utils.CliInfo("You are up to date!")
+		if selfupdate.IsOutdated(utils.Version, release.Version) {
+			utils.CliWarning("%s", upgradeNotice(utils.Version, release.Version, release.HTMLURL))
+			return
 		}
+		utils.CliInfo("You are up to date!")
 	},
 }
 
-type githubRelease struct {
-	TagName string `json:"tag_name"`
-	HTMLURL string `json:"html_url"`
-}
-
-func getLatestRelease() (tagName, htmlURL string, err error) {
-	client := &http.Client{Timeout: 5 * time.Second}
-	req, err := http.NewRequest(http.MethodGet, "https://api.github.com/repos/alpacax/alpacon-cli/releases/latest", nil)
-	if err != nil {
-		return "", "", err
+// A released build is sent to 'alpacon update' whoever owns it: asking which
+// package manager does would spawn dpkg and rpm on every 'alpacon version', so
+// the caveat stands in for the answer.
+func upgradeNotice(current, latest, htmlURL string) string {
+	action := "Run 'alpacon update' to install it—on an install another tool owns it prints how to update through that tool instead."
+	if selfupdate.IsUnknownVersion(current) {
+		action = "Install a released build to update."
 	}
-	req.Header.Set("Accept", "application/vnd.github.v3+json")
-	req.Header.Set("User-Agent", utils.GetUserAgent())
-
-	resp, err := client.Do(req)
-	if err != nil {
-		return "", "", err
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	if resp.StatusCode != http.StatusOK {
-		return "", "", fmt.Errorf("GitHub API returned %s", resp.Status)
-	}
-
-	var release githubRelease
-	if err := json.NewDecoder(io.LimitReader(resp.Body, 1<<20)).Decode(&release); err != nil {
-		return "", "", err
-	}
-
-	return release.TagName, release.HTMLURL, nil
+	return fmt.Sprintf("Upgrade available: %s -> %s\n%s Release notes: %s", current, latest, action, htmlURL)
 }

--- a/cmd/version_test.go
+++ b/cmd/version_test.go
@@ -1,0 +1,30 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/alpacax/alpacon-cli/utils"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUpgradeNoticeNamesBothVersionsAndTheUpdateCommand(t *testing.T) {
+	notice := upgradeNotice("1.3.0", "1.4.0", "https://example.test/notes")
+
+	assert.Contains(t, notice, "1.3.0")
+	assert.Contains(t, notice, "1.4.0")
+	assert.Contains(t, notice, "https://example.test/notes")
+	assert.Contains(t, notice, "alpacon update")
+}
+
+func TestUpgradeNoticeDoesNotSendALocalBuildToTheUpdateCommand(t *testing.T) {
+	notice := upgradeNotice(utils.DevVersion, "1.4.0", "https://example.test/notes")
+
+	assert.NotContains(t, notice, "alpacon update", "'alpacon update' refuses a local build, so the notice must not name it")
+	assert.Contains(t, notice, "Install a released build")
+}
+
+func TestUpgradeNoticeSaysWhatAManagedInstallWillGetInstead(t *testing.T) {
+	notice := upgradeNotice("1.3.0", "1.4.0", "https://example.test/notes")
+
+	assert.Contains(t, notice, "an install another tool owns")
+}

--- a/pkg/selfupdate/archive.go
+++ b/pkg/selfupdate/archive.go
@@ -13,6 +13,10 @@ import (
 
 var maxReleaseFileSize int64 = 512 << 20 // Nothing in a release comes near it—it stops a malformed or endless stream, not anything real.
 
+// maxReleaseFileSize bounds the entry written and the archive downloaded, not
+// the bytes gzip inflates while the scan looks for that entry.
+var maxArchiveStreamSize int64 = 1 << 30
+
 func ExtractBinary(archivePath, binaryName, destDir string) (string, error) {
 	destPath := filepath.Join(destDir, binaryName+".new")
 	extract := extractFromTarGz
@@ -38,7 +42,7 @@ func extractFromTarGz(archivePath, binaryName, destPath string) error {
 	}
 	defer func() { _ = gzipReader.Close() }()
 
-	reader := tar.NewReader(gzipReader)
+	reader := tar.NewReader(io.LimitReader(gzipReader, maxArchiveStreamSize))
 	for {
 		header, err := reader.Next()
 		if err == io.EOF {

--- a/pkg/selfupdate/archive.go
+++ b/pkg/selfupdate/archive.go
@@ -1,0 +1,94 @@
+package selfupdate
+
+import (
+	"archive/tar"
+	"archive/zip"
+	"compress/gzip"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+var maxReleaseFileSize int64 = 512 << 20 // Nothing in a release comes near it—it stops a malformed or endless stream, not anything real.
+
+func ExtractBinary(archivePath, binaryName, destDir string) (string, error) {
+	destPath := filepath.Join(destDir, binaryName+".new")
+	extract := extractFromTarGz
+	if strings.HasSuffix(archivePath, ".zip") {
+		extract = extractFromZip
+	}
+	if err := extract(archivePath, binaryName, destPath); err != nil {
+		return "", err
+	}
+	return destPath, nil
+}
+
+func extractFromTarGz(archivePath, binaryName, destPath string) error {
+	file, err := os.Open(archivePath)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = file.Close() }()
+
+	gzipReader, err := gzip.NewReader(file)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = gzipReader.Close() }()
+
+	reader := tar.NewReader(gzipReader)
+	for {
+		header, err := reader.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return err
+		}
+		if header.Typeflag != tar.TypeReg || filepath.Base(header.Name) != binaryName {
+			continue
+		}
+		return writeExtracted(destPath, reader)
+	}
+	return fmt.Errorf("archive %s carries no entry named %s", filepath.Base(archivePath), binaryName)
+}
+
+func extractFromZip(archivePath, binaryName, destPath string) error {
+	reader, err := zip.OpenReader(archivePath)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = reader.Close() }()
+
+	for _, entry := range reader.File {
+		if filepath.Base(entry.Name) != binaryName || !entry.Mode().IsRegular() {
+			continue
+		}
+		opened, err := entry.Open()
+		if err != nil {
+			return err
+		}
+		writeErr := writeExtracted(destPath, opened)
+		_ = opened.Close()
+		return writeErr
+	}
+	return fmt.Errorf("archive %s carries no entry named %s", filepath.Base(archivePath), binaryName)
+}
+
+func writeExtracted(destPath string, src io.Reader) error {
+	out, err := os.OpenFile(destPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0755)
+	if err != nil {
+		return err
+	}
+	written, copyErr := io.Copy(out, io.LimitReader(src, maxReleaseFileSize+1))
+	closeErr := out.Close()
+	if copyErr != nil {
+		return copyErr
+	}
+	if written > maxReleaseFileSize {
+		return fmt.Errorf("archive entry %s exceeds %d bytes", filepath.Base(destPath), maxReleaseFileSize)
+	}
+	return closeErr
+}

--- a/pkg/selfupdate/archive.go
+++ b/pkg/selfupdate/archive.go
@@ -13,8 +13,9 @@ import (
 
 var maxReleaseFileSize int64 = 512 << 20 // Nothing in a release comes near it—it stops a malformed or endless stream, not anything real.
 
-// maxReleaseFileSize bounds the entry written and the archive downloaded, not
-// the bytes gzip inflates while the scan looks for that entry.
+// maxArchiveStreamSize bounds what gzip inflates while the scan looks for its
+// entry. maxReleaseFileSize bounds only the entry written and the archive
+// downloaded, neither of which counts decompressed bytes.
 var maxArchiveStreamSize int64 = 1 << 30
 
 func ExtractBinary(archivePath, binaryName, destDir string) (string, error) {
@@ -56,7 +57,7 @@ func extractFromTarGz(archivePath, binaryName, destPath string) error {
 		}
 		return writeExtracted(destPath, reader)
 	}
-	return fmt.Errorf("archive %s carries no entry named %s", filepath.Base(archivePath), binaryName)
+	return errNoSuchEntry(archivePath, binaryName)
 }
 
 func extractFromZip(archivePath, binaryName, destPath string) error {
@@ -78,6 +79,10 @@ func extractFromZip(archivePath, binaryName, destPath string) error {
 		_ = opened.Close()
 		return writeErr
 	}
+	return errNoSuchEntry(archivePath, binaryName)
+}
+
+func errNoSuchEntry(archivePath, binaryName string) error {
 	return fmt.Errorf("archive %s carries no entry named %s", filepath.Base(archivePath), binaryName)
 }
 
@@ -86,13 +91,12 @@ func writeExtracted(destPath string, src io.Reader) error {
 	if err != nil {
 		return err
 	}
-	written, copyErr := io.Copy(out, io.LimitReader(src, maxReleaseFileSize+1))
-	closeErr := out.Close()
-	if copyErr != nil {
-		return copyErr
+	overLimit, err := writeBounded(out, src, maxReleaseFileSize)
+	if err != nil {
+		return err
 	}
-	if written > maxReleaseFileSize {
+	if overLimit {
 		return fmt.Errorf("archive entry %s exceeds %d bytes", filepath.Base(destPath), maxReleaseFileSize)
 	}
-	return closeErr
+	return nil
 }

--- a/pkg/selfupdate/archive_test.go
+++ b/pkg/selfupdate/archive_test.go
@@ -1,0 +1,179 @@
+package selfupdate
+
+import (
+	"archive/tar"
+	"archive/zip"
+	"compress/gzip"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExtractBinaryFromTarGz(t *testing.T) {
+	dir := t.TempDir()
+	archivePath := filepath.Join(dir, "alpacon-1.4.0-linux-amd64.tar.gz")
+	writeTarGz(t, archivePath, map[string]string{
+		"LICENSE": "license text",
+		"alpacon": "binary content",
+	})
+
+	extracted, err := ExtractBinary(archivePath, "alpacon", dir)
+
+	require.NoError(t, err)
+	content, readErr := os.ReadFile(extracted)
+	require.NoError(t, readErr)
+	assert.Equal(t, "binary content", string(content))
+}
+
+func TestExtractBinaryFromZip(t *testing.T) {
+	dir := t.TempDir()
+	archivePath := filepath.Join(dir, "alpacon-1.4.0-windows-amd64.zip")
+	writeZip(t, archivePath, map[string]string{
+		"README.md":   "readme",
+		"alpacon.exe": "windows binary",
+	})
+
+	extracted, err := ExtractBinary(archivePath, "alpacon.exe", dir)
+
+	require.NoError(t, err)
+	content, readErr := os.ReadFile(extracted)
+	require.NoError(t, readErr)
+	assert.Equal(t, "windows binary", string(content))
+}
+
+func TestExtractBinaryFailsWhenTheEntryIsMissing(t *testing.T) {
+	dir := t.TempDir()
+	archivePath := filepath.Join(dir, "alpacon-1.4.0-linux-amd64.tar.gz")
+	writeTarGz(t, archivePath, map[string]string{"LICENSE": "license text"})
+
+	_, err := ExtractBinary(archivePath, "alpacon", dir)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no entry named alpacon")
+}
+
+func TestExtractBinaryFailsWhenTheZipEntryIsMissing(t *testing.T) {
+	dir := t.TempDir()
+	archivePath := filepath.Join(dir, "alpacon-1.4.0-windows-amd64.zip")
+	writeZip(t, archivePath, map[string]string{"LICENSE": "license text"})
+
+	_, err := ExtractBinary(archivePath, "alpacon.exe", dir)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no entry named alpacon.exe")
+}
+
+func writeTarGz(t *testing.T, path string, entries map[string]string) {
+	t.Helper()
+	file, err := os.Create(path)
+	require.NoError(t, err)
+	gzipWriter := gzip.NewWriter(file)
+	tarWriter := tar.NewWriter(gzipWriter)
+	for name, content := range entries {
+		require.NoError(t, tarWriter.WriteHeader(&tar.Header{
+			Name: name, Mode: 0755, Size: int64(len(content)), Typeflag: tar.TypeReg,
+		}))
+		_, writeErr := tarWriter.Write([]byte(content))
+		require.NoError(t, writeErr)
+	}
+	require.NoError(t, tarWriter.Close())
+	require.NoError(t, gzipWriter.Close())
+	require.NoError(t, file.Close())
+}
+
+func writeZip(t *testing.T, path string, entries map[string]string) {
+	t.Helper()
+	file, err := os.Create(path)
+	require.NoError(t, err)
+	zipWriter := zip.NewWriter(file)
+	for name, content := range entries {
+		entry, createErr := zipWriter.Create(name)
+		require.NoError(t, createErr)
+		_, writeErr := entry.Write([]byte(content))
+		require.NoError(t, writeErr)
+	}
+	require.NoError(t, zipWriter.Close())
+	require.NoError(t, file.Close())
+}
+
+func TestExtractBinaryReturnsNoPathWhenItFails(t *testing.T) {
+	dir := t.TempDir()
+	archivePath := filepath.Join(dir, "alpacon-1.4.0-linux-amd64.tar.gz")
+	writeTarGz(t, archivePath, map[string]string{"README": "not the binary"})
+
+	destPath, err := ExtractBinary(archivePath, "alpacon", dir)
+
+	require.Error(t, err)
+	assert.Empty(t, destPath, "a path the extraction never wrote must not be handed to the caller")
+}
+
+func TestExtractBinarySkipsAZipEntryThatIsNotAFile(t *testing.T) {
+	dir := t.TempDir()
+	archivePath := filepath.Join(dir, "alpacon-1.4.0-windows-amd64.zip")
+	file, err := os.Create(archivePath)
+	require.NoError(t, err)
+	writer := zip.NewWriter(file)
+	_, err = writer.Create("payload/alpacon.exe/")
+	require.NoError(t, err)
+	require.NoError(t, writer.Close())
+	require.NoError(t, file.Close())
+
+	_, err = ExtractBinary(archivePath, "alpacon.exe", dir)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no entry named alpacon.exe")
+}
+
+func TestExtractBinarySkipsATarEntryThatIsNotAFile(t *testing.T) {
+	dir := t.TempDir()
+	archivePath := filepath.Join(dir, "alpacon-1.4.0-linux-amd64.tar.gz")
+	file, err := os.Create(archivePath)
+	require.NoError(t, err)
+	gzipWriter := gzip.NewWriter(file)
+	tarWriter := tar.NewWriter(gzipWriter)
+	require.NoError(t, tarWriter.WriteHeader(&tar.Header{Name: "payload/alpacon/", Typeflag: tar.TypeDir, Mode: 0755}))
+	require.NoError(t, tarWriter.Close())
+	require.NoError(t, gzipWriter.Close())
+	require.NoError(t, file.Close())
+
+	_, err = ExtractBinary(archivePath, "alpacon", dir)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no entry named alpacon")
+}
+
+func TestExtractBinaryRefusesAnEntryPastTheSizeBound(t *testing.T) {
+	original := maxReleaseFileSize
+	t.Cleanup(func() { maxReleaseFileSize = original })
+	maxReleaseFileSize = 8
+
+	dir := t.TempDir()
+	archivePath := filepath.Join(dir, "alpacon-1.4.0-linux-amd64.tar.gz")
+	writeTarGz(t, archivePath, map[string]string{"alpacon": "far more than eight bytes"})
+
+	_, err := ExtractBinary(archivePath, "alpacon", dir)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "exceeds 8 bytes")
+}
+
+func TestExtractBinaryAcceptsAnEntryExactlyAtTheSizeBound(t *testing.T) {
+	content := "exactly8"
+	original := maxReleaseFileSize
+	t.Cleanup(func() { maxReleaseFileSize = original })
+	maxReleaseFileSize = int64(len(content))
+
+	dir := t.TempDir()
+	archivePath := filepath.Join(dir, "alpacon-1.4.0-linux-amd64.tar.gz")
+	writeTarGz(t, archivePath, map[string]string{"alpacon": content})
+
+	destPath, err := ExtractBinary(archivePath, "alpacon", dir)
+
+	require.NoError(t, err, "the bound is the largest size allowed, not the first refused")
+	extracted, readErr := os.ReadFile(destPath)
+	require.NoError(t, readErr)
+	assert.Equal(t, content, string(extracted))
+}

--- a/pkg/selfupdate/archive_test.go
+++ b/pkg/selfupdate/archive_test.go
@@ -177,3 +177,35 @@ func TestExtractBinaryAcceptsAnEntryExactlyAtTheSizeBound(t *testing.T) {
 	require.NoError(t, readErr)
 	assert.Equal(t, content, string(extracted))
 }
+
+// Structurally impossible today, which is why it is pinned: a refactor that
+// starts honoring header.Name would pass every other test in this file.
+func TestExtractBinaryNeverWritesOutsideTheDestinationDirectory(t *testing.T) {
+	parent := t.TempDir()
+	dir := filepath.Join(parent, "work")
+	require.NoError(t, os.Mkdir(dir, 0755))
+	archivePath := filepath.Join(dir, "alpacon-1.4.0-linux-amd64.tar.gz")
+	writeTarGz(t, archivePath, map[string]string{"../../evil/alpacon": "payload"})
+
+	extracted, err := ExtractBinary(archivePath, "alpacon", dir)
+
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join(dir, "alpacon.new"), extracted)
+	_, statErr := os.Stat(filepath.Join(parent, "evil"))
+	assert.ErrorIs(t, statErr, os.ErrNotExist, "an archive must not decide where its entry lands")
+}
+
+func TestExtractBinaryRefusesATarStreamThatKeepsInflating(t *testing.T) {
+	original := maxArchiveStreamSize
+	t.Cleanup(func() { maxArchiveStreamSize = original })
+	maxArchiveStreamSize = 64 // Smaller than one tar block, so the scan is cut off before it reaches any header.
+
+	dir := t.TempDir()
+	archivePath := filepath.Join(dir, "alpacon-1.4.0-linux-amd64.tar.gz")
+	writeTarGz(t, archivePath, map[string]string{"alpacon": "binary content"})
+
+	_, err := ExtractBinary(archivePath, "alpacon", dir)
+
+	require.Error(t, err, "the entry bound caps what is written, never what gzip inflates while scanning")
+	assert.NotContains(t, err.Error(), "no entry named", "a truncated scan must not read as an archive missing its binary")
+}

--- a/pkg/selfupdate/asset.go
+++ b/pkg/selfupdate/asset.go
@@ -1,0 +1,31 @@
+package selfupdate
+
+import "fmt"
+
+func ArchiveName(version, goos, goarch string) string { // Mirrors the archives name_template in .goreleaser.yaml.
+	extension := "tar.gz"
+	if goos == "windows" {
+		extension = "zip"
+	}
+	return fmt.Sprintf("alpacon-%s-%s-%s.%s", version, goos, goarch, extension)
+}
+
+func BinaryName(goos string) string { // Fixed by the build, so a binary renamed on disk—go install names it after the module, alpacon-cli—still finds its own file inside.
+	if goos == "windows" {
+		return "alpacon.exe"
+	}
+	return "alpacon"
+}
+
+func ChecksumsName(version string) string {
+	return fmt.Sprintf("alpacon-%s-checksums.sha256", version)
+}
+
+func SelectAsset(release *Release, name string) (Asset, error) {
+	for _, asset := range release.Assets {
+		if asset.Name == name {
+			return asset, nil
+		}
+	}
+	return Asset{}, fmt.Errorf("release %s carries no asset named %s", release.Version, name)
+}

--- a/pkg/selfupdate/asset_test.go
+++ b/pkg/selfupdate/asset_test.go
@@ -82,7 +82,7 @@ func TestAssetNamesStillMatchTheGoreleaserTemplates(t *testing.T) {
 func goreleaserSection(config, key string) []string {
 	var lines []string
 	inside := false
-	for _, raw := range strings.Split(config, "\n") {
+	for raw := range strings.SplitSeq(config, "\n") {
 		line := strings.TrimRight(raw, "\r")
 		trimmed := strings.TrimSpace(line)
 		switch {

--- a/pkg/selfupdate/asset_test.go
+++ b/pkg/selfupdate/asset_test.go
@@ -1,0 +1,98 @@
+package selfupdate
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestArchiveName(t *testing.T) {
+	tests := []struct {
+		name   string
+		goos   string
+		goarch string
+		want   string
+	}{
+		{name: "linux amd64", goos: "linux", goarch: "amd64", want: "alpacon-1.4.0-linux-amd64.tar.gz"},
+		{name: "darwin arm64", goos: "darwin", goarch: "arm64", want: "alpacon-1.4.0-darwin-arm64.tar.gz"},
+		{name: "windows amd64 is a zip", goos: "windows", goarch: "amd64", want: "alpacon-1.4.0-windows-amd64.zip"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, ArchiveName("1.4.0", tt.goos, tt.goarch))
+		})
+	}
+}
+
+func TestChecksumsName(t *testing.T) {
+	assert.Equal(t, "alpacon-1.4.0-checksums.sha256", ChecksumsName("1.4.0"))
+}
+
+func TestSelectAsset(t *testing.T) {
+	release := &Release{
+		Version: "1.4.0",
+		Assets: []Asset{
+			{Name: "alpacon-1.4.0-linux-amd64.tar.gz", DownloadURL: "https://example.test/a.tar.gz"},
+		},
+	}
+
+	found, err := SelectAsset(release, "alpacon-1.4.0-linux-amd64.tar.gz")
+	require.NoError(t, err)
+	assert.Equal(t, "https://example.test/a.tar.gz", found.DownloadURL)
+
+	_, err = SelectAsset(release, "alpacon-1.4.0-windows-arm64.zip")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "alpacon-1.4.0-windows-arm64.zip")
+}
+
+func TestBinaryNameIgnoresWhatTheUserRenamedTheBinaryTo(t *testing.T) {
+	assert.Equal(t, "alpacon", BinaryName("linux"))
+	assert.Equal(t, "alpacon", BinaryName("darwin"))
+	assert.Equal(t, "alpacon.exe", BinaryName("windows"))
+}
+
+func TestAssetNamesStillMatchTheGoreleaserTemplates(t *testing.T) {
+	config, err := os.ReadFile(filepath.Join("..", "..", ".goreleaser.yaml"))
+	require.NoError(t, err)
+
+	archives := goreleaserSection(string(config), "archives:")
+	checksum := goreleaserSection(string(config), "checksum:")
+
+	assert.Contains(t, archives, `- name_template: '{{ .ProjectName }}-{{ trimprefix .Version "v" }}-{{ .Os }}-{{ .Arch }}'`,
+		"ArchiveName in asset.go builds this name; change both together")
+	assert.Contains(t, checksum, `name_template: '{{ .ProjectName }}-{{ trimprefix .Version "v" }}-checksums.sha256'`,
+		"ChecksumsName in asset.go builds this name; change both together")
+	assert.Contains(t, archives, "- goos: windows",
+		"ArchiveName asks for a .zip on windows, and only this override builds one")
+
+	var formats []string
+	for _, line := range archives {
+		if strings.HasPrefix(line, "format:") {
+			formats = append(formats, line)
+		}
+	}
+	assert.Equal(t, []string{"format: zip"}, formats,
+		"ArchiveName builds .tar.gz everywhere but windows; an archives-level format would change that too")
+}
+
+func goreleaserSection(config, key string) []string {
+	var lines []string
+	inside := false
+	for _, raw := range strings.Split(config, "\n") {
+		line := strings.TrimRight(raw, "\r")
+		trimmed := strings.TrimSpace(line)
+		switch {
+		case !strings.HasPrefix(line, " ") && trimmed == key:
+			inside = true
+		case inside && trimmed != "" && !strings.HasPrefix(line, " "):
+			return lines
+		case inside && trimmed != "":
+			lines = append(lines, trimmed)
+		}
+	}
+	return lines
+}

--- a/pkg/selfupdate/checksum.go
+++ b/pkg/selfupdate/checksum.go
@@ -1,0 +1,46 @@
+package selfupdate
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"io"
+	"os"
+	"strings"
+)
+
+var ErrChecksumMismatch = errors.New("checksum mismatch")
+
+func ParseChecksums(data []byte) map[string]string { // Each line is "<sha256>  <file name>", the shape goreleaser writes.
+	sums := make(map[string]string)
+	for _, line := range strings.Split(string(data), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) != 2 {
+			continue
+		}
+		sums[fields[1]] = fields[0]
+	}
+	return sums
+}
+
+func VerifyChecksum(path, want string) error {
+	if want == "" { // An empty expectation is a checksum file that never named this archive—no weaker a reason to stop than a hash that disagrees.
+		return ErrChecksumMismatch
+	}
+
+	file, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = file.Close() }()
+
+	hash := sha256.New()
+	if _, err := io.Copy(hash, file); err != nil {
+		return err
+	}
+
+	if !strings.EqualFold(hex.EncodeToString(hash.Sum(nil)), want) {
+		return ErrChecksumMismatch
+	}
+	return nil
+}

--- a/pkg/selfupdate/checksum.go
+++ b/pkg/selfupdate/checksum.go
@@ -13,7 +13,7 @@ var ErrChecksumMismatch = errors.New("checksum mismatch")
 
 func ParseChecksums(data []byte) map[string]string { // Each line is "<sha256>  <file name>", the shape goreleaser writes.
 	sums := make(map[string]string)
-	for _, line := range strings.Split(string(data), "\n") {
+	for line := range strings.SplitSeq(string(data), "\n") {
 		fields := strings.Fields(line)
 		if len(fields) != 2 {
 			continue

--- a/pkg/selfupdate/checksum_test.go
+++ b/pkg/selfupdate/checksum_test.go
@@ -66,6 +66,7 @@ func TestFetchVerifiedBinaryRejectsAnArchiveTheChecksumsNeverName(t *testing.T) 
 		_, _ = w.Write([]byte("archive content"))
 	}))
 	defer server.Close()
+	allowAssetsFrom(t, server.URL)
 	release.Assets = []Asset{
 		{Name: archiveName, DownloadURL: server.URL + "/" + archiveName},
 		{Name: ChecksumsName("1.4.0"), DownloadURL: server.URL + "/" + ChecksumsName("1.4.0")},

--- a/pkg/selfupdate/checksum_test.go
+++ b/pkg/selfupdate/checksum_test.go
@@ -1,0 +1,84 @@
+package selfupdate
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"io/fs"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseChecksums(t *testing.T) {
+	data := []byte("" +
+		"9f2d1c0e6b3a4d5f8091a2b3c4d5e6f708192a3b4c5d6e7f8091a2b3c4d5e6f7  alpacon-1.4.0-linux-amd64.tar.gz\n" +
+		"1122334455667788990011223344556677889900112233445566778899001122  alpacon-1.4.0-windows-amd64.zip\n" +
+		"\n")
+
+	sums := ParseChecksums(data)
+
+	assert.Len(t, sums, 2)
+	assert.Equal(t, "9f2d1c0e6b3a4d5f8091a2b3c4d5e6f708192a3b4c5d6e7f8091a2b3c4d5e6f7", sums["alpacon-1.4.0-linux-amd64.tar.gz"])
+	assert.Equal(t, "1122334455667788990011223344556677889900112233445566778899001122", sums["alpacon-1.4.0-windows-amd64.zip"])
+}
+
+func TestVerifyChecksumAcceptsAMatch(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "archive.tar.gz")
+	content := []byte("archive content")
+	require.NoError(t, os.WriteFile(path, content, 0600))
+	sum := sha256.Sum256(content)
+
+	assert.NoError(t, VerifyChecksum(path, hex.EncodeToString(sum[:])))
+}
+
+func TestVerifyChecksumRejectsAMismatch(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "archive.tar.gz")
+	require.NoError(t, os.WriteFile(path, []byte("archive content"), 0600))
+
+	err := VerifyChecksum(path, "0000000000000000000000000000000000000000000000000000000000000000")
+
+	assert.ErrorIs(t, err, ErrChecksumMismatch)
+}
+
+func TestVerifyChecksumRejectsAnEmptyExpectation(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "archive.tar.gz")
+	require.NoError(t, os.WriteFile(path, []byte("archive content"), 0600))
+
+	err := VerifyChecksum(path, "")
+
+	assert.ErrorIs(t, err, ErrChecksumMismatch, "a checksums file that never named this archive proves nothing about it")
+}
+
+func TestFetchVerifiedBinaryRejectsAnArchiveTheChecksumsNeverName(t *testing.T) {
+	release := &Release{Version: "1.4.0"}
+	archiveName := ArchiveName("1.4.0", "linux", "amd64")
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "checksums.sha256") {
+			_, _ = w.Write([]byte("0000000000000000000000000000000000000000000000000000000000000000  alpacon-1.4.0-darwin-arm64.tar.gz\n"))
+			return
+		}
+		_, _ = w.Write([]byte("archive content"))
+	}))
+	defer server.Close()
+	release.Assets = []Asset{
+		{Name: archiveName, DownloadURL: server.URL + "/" + archiveName},
+		{Name: ChecksumsName("1.4.0"), DownloadURL: server.URL + "/" + ChecksumsName("1.4.0")},
+	}
+
+	_, err := FetchVerifiedBinary(release, "linux", "amd64", "alpacon", t.TempDir())
+
+	assert.ErrorIs(t, err, ErrChecksumMismatch)
+}
+
+func TestVerifyChecksumStopsBeforeItEvenOpensTheFile(t *testing.T) {
+	err := VerifyChecksum(filepath.Join(t.TempDir(), "never-downloaded.tar.gz"), "")
+
+	assert.ErrorIs(t, err, ErrChecksumMismatch)
+	assert.NotErrorIs(t, err, fs.ErrNotExist)
+}

--- a/pkg/selfupdate/download.go
+++ b/pkg/selfupdate/download.go
@@ -1,0 +1,99 @@
+package selfupdate
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/alpacax/alpacon-cli/utils"
+)
+
+// maxChecksumsSize bounds the checksums file, which is a few lines of text.
+// Nothing authenticates a download until those checksums are compared, so an
+// endless stream would otherwise fill the temp directory—memory, on tmpfs.
+const maxChecksumsSize = 1 << 20
+
+func FetchVerifiedBinary(release *Release, goos, goarch, binaryName, destDir string) (string, error) {
+	archiveName := ArchiveName(release.Version, goos, goarch)
+	archiveAsset, err := SelectAsset(release, archiveName)
+	if err != nil {
+		return "", err
+	}
+	checksumsAsset, err := SelectAsset(release, ChecksumsName(release.Version))
+	if err != nil {
+		return "", err
+	}
+
+	archivePath := filepath.Join(destDir, archiveName)
+	if err := downloadTo(archiveAsset.DownloadURL, archivePath, maxReleaseFileSize); err != nil {
+		return "", err
+	}
+
+	checksumsPath := filepath.Join(destDir, ChecksumsName(release.Version))
+	if err := downloadTo(checksumsAsset.DownloadURL, checksumsPath, maxChecksumsSize); err != nil {
+		return "", err
+	}
+	checksums, err := os.ReadFile(checksumsPath)
+	if err != nil {
+		return "", err
+	}
+
+	if err := VerifyChecksum(archivePath, ParseChecksums(checksums)[archiveName]); err != nil {
+		return "", err
+	}
+	return ExtractBinary(archivePath, binaryName, destDir)
+}
+
+func downloadTo(url, destPath string, maxBytes int64) error {
+	client := newHTTPClient(10 * time.Minute)
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("User-Agent", utils.GetUserAgent())
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("downloading %s returned %s", url, resp.Status)
+	}
+
+	file, err := os.Create(destPath)
+	if err != nil {
+		return err
+	}
+	written, copyErr := io.Copy(file, io.LimitReader(resp.Body, maxBytes+1))
+	closeErr := file.Close()
+	if copyErr != nil {
+		return copyErr
+	}
+	if written > maxBytes {
+		return fmt.Errorf("downloading %s exceeded %d bytes", url, maxBytes)
+	}
+	return closeErr
+}
+
+func newHTTPClient(timeout time.Duration) *http.Client {
+	return &http.Client{Timeout: timeout, CheckRedirect: refuseSchemeDowngrade}
+}
+
+// refuseSchemeDowngrade stops a redirect from https to http: the archive and
+// the checksums that vouch for it come down the same connection, so a redirect
+// into plain text would let whoever wrote it replace both together.
+func refuseSchemeDowngrade(req *http.Request, via []*http.Request) error {
+	if len(via) > 0 && via[0].URL.Scheme == "https" && req.URL.Scheme != "https" {
+		return fmt.Errorf("refusing redirect from https to %s", req.URL.Scheme)
+	}
+	if len(via) >= 10 {
+		return errors.New("stopped after 10 redirects")
+	}
+	return nil
+}

--- a/pkg/selfupdate/download.go
+++ b/pkg/selfupdate/download.go
@@ -1,7 +1,6 @@
 package selfupdate
 
 import (
-	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -9,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
+	"strings"
 	"time"
 
 	"github.com/alpacax/alpacon-cli/utils"
@@ -18,6 +18,15 @@ import (
 // Nothing authenticates a download until those checksums are compared, so an
 // endless stream would otherwise fill the temp directory—memory, on tmpfs.
 const maxChecksumsSize = 1 << 20
+
+// maxRedirects replaces the cap the default CheckRedirect carried, which
+// setting one of our own removed.
+const maxRedirects = 10
+
+// archiveDownloadTimeout covers a whole transfer rather than a stalled byte, so
+// it has to clear the largest release archive on a poor connection. It exists
+// to stop a hung download, not to pace a slow one.
+const archiveDownloadTimeout = 10 * time.Minute
 
 // The release JSON names both asset URLs, and refuseSchemeDowngrade only
 // inspects a redirect—so an http:// or off-GitHub URL would be fetched as
@@ -34,7 +43,8 @@ func FetchVerifiedBinary(release *Release, goos, goarch, binaryName, destDir str
 	if err != nil {
 		return "", err
 	}
-	checksumsAsset, err := SelectAsset(release, ChecksumsName(release.Version))
+	checksumsName := ChecksumsName(release.Version)
+	checksumsAsset, err := SelectAsset(release, checksumsName)
 	if err != nil {
 		return "", err
 	}
@@ -44,7 +54,7 @@ func FetchVerifiedBinary(release *Release, goos, goarch, binaryName, destDir str
 		return "", err
 	}
 
-	checksumsPath := filepath.Join(destDir, ChecksumsName(release.Version))
+	checksumsPath := filepath.Join(destDir, checksumsName)
 	if err := downloadTo(checksumsAsset.DownloadURL, checksumsPath, maxChecksumsSize); err != nil {
 		return "", err
 	}
@@ -59,12 +69,24 @@ func FetchVerifiedBinary(release *Release, goos, goarch, binaryName, destDir str
 	return ExtractBinary(archivePath, binaryName, destDir)
 }
 
+// assetOrigin normalizes what url.Parse leaves exactly as written: the host
+// keeps its case, and an explicit :443 stays on. Both name the same origin as
+// the pinned entry, and comparing them raw would refuse a release that is fine.
+func assetOrigin(parsed *url.URL) string {
+	scheme := strings.ToLower(parsed.Scheme)
+	host := strings.ToLower(parsed.Host)
+	if scheme == "https" {
+		host = strings.TrimSuffix(host, ":443")
+	}
+	return scheme + "://" + host
+}
+
 func checkAssetOrigin(rawURL string) error {
 	parsed, err := url.Parse(rawURL)
 	if err != nil {
 		return fmt.Errorf("release asset url %q cannot be read: %w", rawURL, err)
 	}
-	origin := parsed.Scheme + "://" + parsed.Host
+	origin := assetOrigin(parsed)
 	if !slices.Contains(allowedAssetOrigins, origin) {
 		return fmt.Errorf("refusing a release asset served from %s", origin)
 	}
@@ -76,7 +98,7 @@ func downloadTo(assetURL, destPath string, maxBytes int64) error {
 		return err
 	}
 
-	client := newHTTPClient(10 * time.Minute)
+	client := newHTTPClient(archiveDownloadTimeout)
 	req, err := http.NewRequest(http.MethodGet, assetURL, nil)
 	if err != nil {
 		return err
@@ -97,15 +119,30 @@ func downloadTo(assetURL, destPath string, maxBytes int64) error {
 	if err != nil {
 		return err
 	}
-	written, copyErr := io.Copy(file, io.LimitReader(resp.Body, maxBytes+1))
-	closeErr := file.Close()
-	if copyErr != nil {
-		return copyErr
+	overLimit, err := writeBounded(file, resp.Body, maxBytes)
+	if err != nil {
+		return err
 	}
-	if written > maxBytes {
+	if overLimit {
 		return fmt.Errorf("downloading %s exceeded %d bytes", assetURL, maxBytes)
 	}
-	return closeErr
+	return nil
+}
+
+// writeBounded copies src into file, closes it, and reports whether the stream
+// ran past maxBytes. Reading one byte more than the bound is what separates a
+// stream that overran it from one landing exactly on it, so the +1 and the >
+// are a single decision and belong in a single place.
+func writeBounded(file *os.File, src io.Reader, maxBytes int64) (bool, error) {
+	written, copyErr := io.Copy(file, io.LimitReader(src, maxBytes+1))
+	closeErr := file.Close()
+	if copyErr != nil {
+		return false, copyErr
+	}
+	if written > maxBytes {
+		return true, nil
+	}
+	return false, closeErr
 }
 
 func newHTTPClient(timeout time.Duration) *http.Client {
@@ -119,8 +156,8 @@ func refuseSchemeDowngrade(req *http.Request, via []*http.Request) error {
 	if len(via) > 0 && via[0].URL.Scheme == "https" && req.URL.Scheme != "https" {
 		return fmt.Errorf("refusing redirect from https to %s", req.URL.Scheme)
 	}
-	if len(via) >= 10 {
-		return errors.New("stopped after 10 redirects")
+	if len(via) >= maxRedirects {
+		return fmt.Errorf("stopped after %d redirects", maxRedirects)
 	}
 	return nil
 }

--- a/pkg/selfupdate/download.go
+++ b/pkg/selfupdate/download.go
@@ -5,8 +5,10 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
+	"slices"
 	"time"
 
 	"github.com/alpacax/alpacon-cli/utils"
@@ -16,6 +18,15 @@ import (
 // Nothing authenticates a download until those checksums are compared, so an
 // endless stream would otherwise fill the temp directory—memory, on tmpfs.
 const maxChecksumsSize = 1 << 20
+
+// The release JSON names both asset URLs, and refuseSchemeDowngrade only
+// inspects a redirect—so an http:// or off-GitHub URL would be fetched as
+// given. Later hops stay unpinned: GitHub's CDN host changes.
+var allowedAssetOrigins = []string{
+	"https://github.com",
+	"https://objects.githubusercontent.com",
+	"https://release-assets.githubusercontent.com",
+}
 
 func FetchVerifiedBinary(release *Release, goos, goarch, binaryName, destDir string) (string, error) {
 	archiveName := ArchiveName(release.Version, goos, goarch)
@@ -48,9 +59,25 @@ func FetchVerifiedBinary(release *Release, goos, goarch, binaryName, destDir str
 	return ExtractBinary(archivePath, binaryName, destDir)
 }
 
-func downloadTo(url, destPath string, maxBytes int64) error {
+func checkAssetOrigin(rawURL string) error {
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return fmt.Errorf("release asset url %q cannot be read: %w", rawURL, err)
+	}
+	origin := parsed.Scheme + "://" + parsed.Host
+	if !slices.Contains(allowedAssetOrigins, origin) {
+		return fmt.Errorf("refusing a release asset served from %s", origin)
+	}
+	return nil
+}
+
+func downloadTo(assetURL, destPath string, maxBytes int64) error {
+	if err := checkAssetOrigin(assetURL); err != nil {
+		return err
+	}
+
 	client := newHTTPClient(10 * time.Minute)
-	req, err := http.NewRequest(http.MethodGet, url, nil)
+	req, err := http.NewRequest(http.MethodGet, assetURL, nil)
 	if err != nil {
 		return err
 	}
@@ -63,7 +90,7 @@ func downloadTo(url, destPath string, maxBytes int64) error {
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("downloading %s returned %s", url, resp.Status)
+		return fmt.Errorf("downloading %s returned %s", assetURL, resp.Status)
 	}
 
 	file, err := os.Create(destPath)
@@ -76,7 +103,7 @@ func downloadTo(url, destPath string, maxBytes int64) error {
 		return copyErr
 	}
 	if written > maxBytes {
-		return fmt.Errorf("downloading %s exceeded %d bytes", url, maxBytes)
+		return fmt.Errorf("downloading %s exceeded %d bytes", assetURL, maxBytes)
 	}
 	return closeErr
 }

--- a/pkg/selfupdate/download_test.go
+++ b/pkg/selfupdate/download_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"path/filepath"
 	"testing"
@@ -14,6 +15,18 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// allowAssetsFrom points the origin pin at a test server, which it would
+// otherwise refuse.
+func allowAssetsFrom(t *testing.T, rawURL string) {
+	t.Helper()
+
+	parsed, err := url.Parse(rawURL)
+	require.NoError(t, err)
+	original := allowedAssetOrigins
+	t.Cleanup(func() { allowedAssetOrigins = original })
+	allowedAssetOrigins = []string{parsed.Scheme + "://" + parsed.Host}
+}
 
 func releaseServer(t *testing.T, dir string, corrupt bool) (*httptest.Server, *Release) {
 	t.Helper()
@@ -35,6 +48,7 @@ func releaseServer(t *testing.T, dir string, corrupt bool) (*httptest.Server, *R
 	mux.HandleFunc("/checksums", func(w http.ResponseWriter, r *http.Request) { _, _ = w.Write([]byte(checksums)) })
 	ts := httptest.NewServer(mux)
 	t.Cleanup(ts.Close)
+	allowAssetsFrom(t, ts.URL)
 
 	return ts, &Release{
 		Version: "1.4.0",
@@ -64,6 +78,8 @@ func TestFetchVerifiedBinaryRefusesAMismatchedChecksum(t *testing.T) {
 	_, err := FetchVerifiedBinary(release, "linux", "amd64", "alpacon", dir)
 
 	assert.ErrorIs(t, err, ErrChecksumMismatch)
+	_, statErr := os.Stat(filepath.Join(dir, "alpacon.new"))
+	assert.ErrorIs(t, statErr, os.ErrNotExist, "verification runs before extraction, and only the missing file proves that order")
 }
 
 func TestFetchVerifiedBinaryFailsWhenThePlatformHasNoAsset(t *testing.T) {
@@ -81,6 +97,7 @@ func TestDownloadToRefusesAResponseThatRunsPastTheLimit(t *testing.T) {
 		_, _ = w.Write(make([]byte, 64))
 	}))
 	defer ts.Close()
+	allowAssetsFrom(t, ts.URL)
 	destPath := filepath.Join(t.TempDir(), "archive.tar.gz")
 
 	err := downloadTo(ts.URL, destPath, 16)
@@ -114,6 +131,7 @@ func TestDownloadToAcceptsAResponseExactlyAtTheLimit(t *testing.T) {
 		_, _ = w.Write(body)
 	}))
 	defer ts.Close()
+	allowAssetsFrom(t, ts.URL)
 	destPath := filepath.Join(t.TempDir(), "archive.tar.gz")
 
 	require.NoError(t, downloadTo(ts.URL, destPath, int64(len(body))), "the limit is the largest size allowed, not the first refused")
@@ -132,4 +150,33 @@ func TestRefuseSchemeDowngradeStopsAnEndlessRedirectChain(t *testing.T) {
 
 	assert.Error(t, refuseSchemeDowngrade(secure, via))
 	assert.NoError(t, refuseSchemeDowngrade(secure, via[:9]))
+}
+
+func TestDownloadToRefusesAnAssetOutsideThePinnedOrigins(t *testing.T) {
+	tests := []struct {
+		name     string
+		assetURL string
+	}{
+		{name: "plain text", assetURL: "http://github.com/alpacax/alpacon-cli/releases/download/v1.4.0/alpacon.tar.gz"},
+		{name: "another host entirely", assetURL: "https://evil.test/alpacon.tar.gz"},
+		{name: "the pinned host as a subdomain of another", assetURL: "https://github.com.evil.test/alpacon.tar.gz"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			destPath := filepath.Join(t.TempDir(), "archive.tar.gz")
+
+			err := downloadTo(tt.assetURL, destPath, 1<<20)
+
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "refusing a release asset")
+			_, statErr := os.Stat(destPath)
+			assert.ErrorIs(t, statErr, os.ErrNotExist, "a refused asset must not reach disk")
+		})
+	}
+}
+
+func TestCheckAssetOriginAcceptsThePinnedGitHubOrigins(t *testing.T) {
+	for _, origin := range allowedAssetOrigins {
+		assert.NoError(t, checkAssetOrigin(origin+"/alpacax/alpacon-cli/releases/download/v1.4.0/alpacon.tar.gz"), "%s is where releases actually come from", origin)
+	}
 }

--- a/pkg/selfupdate/download_test.go
+++ b/pkg/selfupdate/download_test.go
@@ -25,10 +25,10 @@ func allowAssetsFrom(t *testing.T, rawURL string) {
 	require.NoError(t, err)
 	original := allowedAssetOrigins
 	t.Cleanup(func() { allowedAssetOrigins = original })
-	allowedAssetOrigins = []string{parsed.Scheme + "://" + parsed.Host}
+	allowedAssetOrigins = []string{assetOrigin(parsed)}
 }
 
-func releaseServer(t *testing.T, dir string, corrupt bool) (*httptest.Server, *Release) {
+func releaseServer(t *testing.T, dir string, corrupt bool) *Release {
 	t.Helper()
 
 	archivePath := filepath.Join(dir, "source.tar.gz")
@@ -50,7 +50,7 @@ func releaseServer(t *testing.T, dir string, corrupt bool) (*httptest.Server, *R
 	t.Cleanup(ts.Close)
 	allowAssetsFrom(t, ts.URL)
 
-	return ts, &Release{
+	return &Release{
 		Version: "1.4.0",
 		Assets: []Asset{
 			{Name: ArchiveName("1.4.0", "linux", "amd64"), DownloadURL: ts.URL + "/archive"},
@@ -61,7 +61,7 @@ func releaseServer(t *testing.T, dir string, corrupt bool) (*httptest.Server, *R
 
 func TestFetchVerifiedBinaryExtractsAVerifiedArchive(t *testing.T) {
 	dir := t.TempDir()
-	_, release := releaseServer(t, dir, false)
+	release := releaseServer(t, dir, false)
 
 	path, err := FetchVerifiedBinary(release, "linux", "amd64", "alpacon", dir)
 
@@ -73,7 +73,7 @@ func TestFetchVerifiedBinaryExtractsAVerifiedArchive(t *testing.T) {
 
 func TestFetchVerifiedBinaryRefusesAMismatchedChecksum(t *testing.T) {
 	dir := t.TempDir()
-	_, release := releaseServer(t, dir, true)
+	release := releaseServer(t, dir, true)
 
 	_, err := FetchVerifiedBinary(release, "linux", "amd64", "alpacon", dir)
 
@@ -84,7 +84,7 @@ func TestFetchVerifiedBinaryRefusesAMismatchedChecksum(t *testing.T) {
 
 func TestFetchVerifiedBinaryFailsWhenThePlatformHasNoAsset(t *testing.T) {
 	dir := t.TempDir()
-	_, release := releaseServer(t, dir, false)
+	release := releaseServer(t, dir, false)
 
 	_, err := FetchVerifiedBinary(release, "windows", "arm64", "alpacon.exe", dir)
 
@@ -179,4 +179,17 @@ func TestCheckAssetOriginAcceptsThePinnedGitHubOrigins(t *testing.T) {
 	for _, origin := range allowedAssetOrigins {
 		assert.NoError(t, checkAssetOrigin(origin+"/alpacax/alpacon-cli/releases/download/v1.4.0/alpacon.tar.gz"), "%s is where releases actually come from", origin)
 	}
+}
+
+// url.Parse hands back the host as written, so a pin comparing it raw would
+// refuse a release that is fine.
+func TestCheckAssetOriginAcceptsAPinnedOriginSpelledDifferently(t *testing.T) {
+	for _, rawURL := range []string{
+		"https://GitHub.com/alpacax/alpacon-cli/releases/download/v1.4.0/alpacon.tar.gz",
+		"https://github.com:443/alpacax/alpacon-cli/releases/download/v1.4.0/alpacon.tar.gz",
+		"HTTPS://github.com/alpacax/alpacon-cli/releases/download/v1.4.0/alpacon.tar.gz",
+	} {
+		assert.NoError(t, checkAssetOrigin(rawURL), rawURL)
+	}
+	assert.Error(t, checkAssetOrigin("https://github.com:8443/alpacax/alpacon-cli/releases/download/v1.4.0/alpacon.tar.gz"), "a non-default port is a different endpoint, not a spelling")
 }

--- a/pkg/selfupdate/download_test.go
+++ b/pkg/selfupdate/download_test.go
@@ -1,0 +1,135 @@
+package selfupdate
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func releaseServer(t *testing.T, dir string, corrupt bool) (*httptest.Server, *Release) {
+	t.Helper()
+
+	archivePath := filepath.Join(dir, "source.tar.gz")
+	writeTarGz(t, archivePath, map[string]string{"alpacon": "new binary"})
+	archive, err := os.ReadFile(archivePath)
+	require.NoError(t, err)
+
+	sum := sha256.Sum256(archive)
+	stated := hex.EncodeToString(sum[:])
+	if corrupt {
+		stated = "0000000000000000000000000000000000000000000000000000000000000000"
+	}
+	checksums := fmt.Sprintf("%s  %s\n", stated, ArchiveName("1.4.0", "linux", "amd64"))
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/archive", func(w http.ResponseWriter, r *http.Request) { _, _ = w.Write(archive) })
+	mux.HandleFunc("/checksums", func(w http.ResponseWriter, r *http.Request) { _, _ = w.Write([]byte(checksums)) })
+	ts := httptest.NewServer(mux)
+	t.Cleanup(ts.Close)
+
+	return ts, &Release{
+		Version: "1.4.0",
+		Assets: []Asset{
+			{Name: ArchiveName("1.4.0", "linux", "amd64"), DownloadURL: ts.URL + "/archive"},
+			{Name: ChecksumsName("1.4.0"), DownloadURL: ts.URL + "/checksums"},
+		},
+	}
+}
+
+func TestFetchVerifiedBinaryExtractsAVerifiedArchive(t *testing.T) {
+	dir := t.TempDir()
+	_, release := releaseServer(t, dir, false)
+
+	path, err := FetchVerifiedBinary(release, "linux", "amd64", "alpacon", dir)
+
+	require.NoError(t, err)
+	content, readErr := os.ReadFile(path)
+	require.NoError(t, readErr)
+	assert.Equal(t, "new binary", string(content))
+}
+
+func TestFetchVerifiedBinaryRefusesAMismatchedChecksum(t *testing.T) {
+	dir := t.TempDir()
+	_, release := releaseServer(t, dir, true)
+
+	_, err := FetchVerifiedBinary(release, "linux", "amd64", "alpacon", dir)
+
+	assert.ErrorIs(t, err, ErrChecksumMismatch)
+}
+
+func TestFetchVerifiedBinaryFailsWhenThePlatformHasNoAsset(t *testing.T) {
+	dir := t.TempDir()
+	_, release := releaseServer(t, dir, false)
+
+	_, err := FetchVerifiedBinary(release, "windows", "arm64", "alpacon.exe", dir)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "alpacon-1.4.0-windows-arm64.zip")
+}
+
+func TestDownloadToRefusesAResponseThatRunsPastTheLimit(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(make([]byte, 64))
+	}))
+	defer ts.Close()
+	destPath := filepath.Join(t.TempDir(), "archive.tar.gz")
+
+	err := downloadTo(ts.URL, destPath, 16)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "exceeded 16 bytes")
+}
+
+func TestRefuseSchemeDowngrade(t *testing.T) {
+	secure := httptest.NewRequest(http.MethodGet, "https://example.test/archive.tar.gz", nil)
+	plain := httptest.NewRequest(http.MethodGet, "http://example.test/archive.tar.gz", nil)
+
+	assert.Error(t, refuseSchemeDowngrade(plain, []*http.Request{secure}))
+	assert.NoError(t, refuseSchemeDowngrade(secure, []*http.Request{secure}))
+	assert.NoError(t, refuseSchemeDowngrade(plain, []*http.Request{plain}), "a plain-text start was never a promise to keep")
+}
+
+func TestReleaseHTTPClientRefusesToLeaveHTTPS(t *testing.T) {
+	client := newHTTPClient(time.Second)
+	require.NotNil(t, client.CheckRedirect, "both release requests build their client here")
+
+	secure := httptest.NewRequest(http.MethodGet, "https://example.test/archive.tar.gz", nil)
+	plain := httptest.NewRequest(http.MethodGet, "http://example.test/archive.tar.gz", nil)
+
+	assert.Error(t, client.CheckRedirect(plain, []*http.Request{secure}))
+}
+
+func TestDownloadToAcceptsAResponseExactlyAtTheLimit(t *testing.T) {
+	body := make([]byte, 16)
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(body)
+	}))
+	defer ts.Close()
+	destPath := filepath.Join(t.TempDir(), "archive.tar.gz")
+
+	require.NoError(t, downloadTo(ts.URL, destPath, int64(len(body))), "the limit is the largest size allowed, not the first refused")
+
+	written, err := os.ReadFile(destPath)
+	require.NoError(t, err)
+	assert.Len(t, written, len(body))
+}
+
+func TestRefuseSchemeDowngradeStopsAnEndlessRedirectChain(t *testing.T) {
+	secure := httptest.NewRequest(http.MethodGet, "https://example.test/archive.tar.gz", nil) // Replacing the default policy replaced its redirect cap too, so this one has to carry it.
+	via := make([]*http.Request, 10)
+	for i := range via {
+		via[i] = secure
+	}
+
+	assert.Error(t, refuseSchemeDowngrade(secure, via))
+	assert.NoError(t, refuseSchemeDowngrade(secure, via[:9]))
+}

--- a/pkg/selfupdate/guidance.go
+++ b/pkg/selfupdate/guidance.go
@@ -1,0 +1,22 @@
+package selfupdate
+
+import "fmt"
+
+// UpgradeGuidance returns text only, never a command: overwriting a file dpkg,
+// rpm, or Homebrew owns desyncs that manager, and running it for the user would
+// spend their root password on a command they never read.
+func UpgradeGuidance(kind InstallKind) string {
+	switch kind {
+	case InstallHomebrew:
+		return "This binary was installed by Homebrew. Update it with:\n    brew upgrade alpacon-cli"
+	case InstallDeb:
+		return "This binary was installed from a deb package. Update it with:\n    sudo apt-get update && sudo apt-get install --only-upgrade alpacon"
+	case InstallRPM:
+		return "This binary was installed from an rpm package. Update it with:\n    sudo yum update alpacon"
+	case InstallVersionManager:
+		return "This binary is managed by a version manager (mise or asdf). Update it through that tool."
+	case InstallManual:
+		return ""
+	}
+	return fmt.Sprintf("This binary is managed by its installer (%s). Update it through that tool.", kind) // A kind added without its wording. Saying nothing would read as "no guidance was needed", which is how a caller decides an update happened.
+}

--- a/pkg/selfupdate/guidance_test.go
+++ b/pkg/selfupdate/guidance_test.go
@@ -1,0 +1,37 @@
+package selfupdate
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUpgradeGuidance(t *testing.T) {
+	tests := []struct {
+		name         string
+		kind         InstallKind
+		wantContains string
+	}{
+		{name: "homebrew", kind: InstallHomebrew, wantContains: "brew upgrade alpacon-cli"},
+		{name: "deb", kind: InstallDeb, wantContains: "sudo apt-get install --only-upgrade alpacon"},
+		{name: "rpm", kind: InstallRPM, wantContains: "sudo yum update alpacon"},
+		{name: "version manager", kind: InstallVersionManager, wantContains: "version manager"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Contains(t, UpgradeGuidance(tt.kind), tt.wantContains)
+		})
+	}
+}
+
+func TestUpgradeGuidanceIsEmptyForAManualInstall(t *testing.T) {
+	assert.Empty(t, UpgradeGuidance(InstallManual), "a manual install is replaced by the CLI, so there is nothing to tell the user to run")
+}
+
+func TestUpgradeGuidanceAlwaysAnswersForANonManualInstall(t *testing.T) {
+	guidance := UpgradeGuidance(InstallKind("snap"))
+
+	assert.NotEmpty(t, guidance)
+	assert.Contains(t, guidance, "snap")
+	assert.Empty(t, UpgradeGuidance(InstallManual), "a manual install is the one this command does replace")
+}

--- a/pkg/selfupdate/location.go
+++ b/pkg/selfupdate/location.go
@@ -1,0 +1,53 @@
+package selfupdate
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const (
+	InstallManual         InstallKind = "manual"
+	InstallHomebrew       InstallKind = "homebrew"
+	InstallDeb            InstallKind = "deb"
+	InstallRPM            InstallKind = "rpm"
+	InstallVersionManager InstallKind = "version-manager"
+)
+
+var osExecutable = os.Executable
+
+type InstallKind string
+
+// ClassifyPath reads the path before the ownership answer: a Homebrew Cellar
+// path is unambiguous, while /usr/local/bin is shared by the deb, the rpm, and
+// a hand-placed binary, which only the ownership query separates.
+func ClassifyPath(realPath, packageOwner string) InstallKind {
+	for _, segment := range strings.Split(filepath.ToSlash(realPath), "/") {
+		switch segment {
+		case "Cellar":
+			return InstallHomebrew
+		case "mise", ".asdf":
+			return InstallVersionManager
+		}
+	}
+
+	switch {
+	case strings.HasPrefix(packageOwner, "deb:"):
+		return InstallDeb
+	case strings.HasPrefix(packageOwner, "rpm:"):
+		return InstallRPM
+	}
+	return InstallManual
+}
+
+func DetectInstallKind(run CommandRunner, realPath string) InstallKind { // Keeps the two halves together: a caller that asks only one of them gets a different verdict from the other's.
+	return ClassifyPath(realPath, PackageOwner(run, realPath))
+}
+
+func ResolveExecutablePath() (string, error) {
+	executable, err := osExecutable()
+	if err != nil {
+		return "", err
+	}
+	return filepath.EvalSymlinks(executable)
+}

--- a/pkg/selfupdate/location.go
+++ b/pkg/selfupdate/location.go
@@ -21,14 +21,9 @@ type InstallKind string
 // ClassifyPath reads the path before the ownership answer: a Homebrew Cellar
 // path is unambiguous, while /usr/local/bin is shared by the deb, the rpm, and
 // a hand-placed binary, which only the ownership query separates.
-func ClassifyPath(realPath, packageOwner string) InstallKind {
-	for _, segment := range strings.Split(filepath.ToSlash(realPath), "/") {
-		switch segment {
-		case "Cellar":
-			return InstallHomebrew
-		case "mise", ".asdf":
-			return InstallVersionManager
-		}
+func ClassifyPath(executablePath, packageOwner string) InstallKind {
+	if kind := classifyByPath(executablePath); kind != "" {
+		return kind
 	}
 
 	switch {
@@ -40,8 +35,30 @@ func ClassifyPath(realPath, packageOwner string) InstallKind {
 	return InstallManual
 }
 
-func DetectInstallKind(run CommandRunner, realPath string) InstallKind { // Keeps the two halves together: a caller that asks only one of them gets a different verdict from the other's.
-	return ClassifyPath(realPath, PackageOwner(run, realPath))
+// classifyByPath answers only where the path settles it on its own, and "" when
+// it does not.
+func classifyByPath(executablePath string) InstallKind {
+	for segment := range strings.SplitSeq(filepath.ToSlash(executablePath), "/") {
+		switch segment {
+		case "Cellar":
+			return InstallHomebrew
+		case "mise", ".asdf":
+			return InstallVersionManager
+		}
+	}
+	return ""
+}
+
+func DetectInstallKind(run CommandRunner, executablePath string) (InstallKind, error) { // Keeps the two halves together: a caller that asks only one of them gets a different verdict from the other's.
+	if kind := classifyByPath(executablePath); kind != "" { // Two subprocess spawns, up to packageQueryTimeout each, for an answer the path already gave.
+		return kind, nil
+	}
+
+	owner, err := PackageOwner(run, executablePath)
+	if err != nil {
+		return "", err
+	}
+	return ClassifyPath(executablePath, owner), nil
 }
 
 func ResolveExecutablePath() (string, error) {

--- a/pkg/selfupdate/location_test.go
+++ b/pkg/selfupdate/location_test.go
@@ -12,23 +12,23 @@ import (
 
 func TestClassifyPath(t *testing.T) {
 	tests := []struct {
-		name         string
-		realPath     string
-		packageOwner string
-		want         InstallKind
+		name           string
+		executablePath string
+		packageOwner   string
+		want           InstallKind
 	}{
-		{name: "homebrew cellar", realPath: "/opt/homebrew/Cellar/alpacon-cli/1.4.0/bin/alpacon", packageOwner: "", want: InstallHomebrew},
-		{name: "intel homebrew cellar", realPath: "/usr/local/Cellar/alpacon-cli/1.4.0/bin/alpacon", packageOwner: "", want: InstallHomebrew},
-		{name: "mise shim", realPath: "/home/dev/.local/share/mise/installs/alpacon/1.4.0/alpacon", packageOwner: "", want: InstallVersionManager},
-		{name: "asdf install", realPath: "/home/dev/.asdf/installs/alpacon/1.4.0/bin/alpacon", packageOwner: "", want: InstallVersionManager},
-		{name: "owned by a deb package", realPath: "/usr/local/bin/alpacon", packageOwner: "deb:alpacon", want: InstallDeb},
-		{name: "owned by an rpm package", realPath: "/usr/local/bin/alpacon", packageOwner: "rpm:alpacon", want: InstallRPM},
-		{name: "same path with no owner is manual", realPath: "/usr/local/bin/alpacon", packageOwner: "", want: InstallManual},
-		{name: "home directory install is manual", realPath: "/home/dev/.local/bin/alpacon", packageOwner: "", want: InstallManual},
+		{name: "homebrew cellar", executablePath: "/opt/homebrew/Cellar/alpacon-cli/1.4.0/bin/alpacon", packageOwner: "", want: InstallHomebrew},
+		{name: "intel homebrew cellar", executablePath: "/usr/local/Cellar/alpacon-cli/1.4.0/bin/alpacon", packageOwner: "", want: InstallHomebrew},
+		{name: "mise shim", executablePath: "/home/dev/.local/share/mise/installs/alpacon/1.4.0/alpacon", packageOwner: "", want: InstallVersionManager},
+		{name: "asdf install", executablePath: "/home/dev/.asdf/installs/alpacon/1.4.0/bin/alpacon", packageOwner: "", want: InstallVersionManager},
+		{name: "owned by a deb package", executablePath: "/usr/local/bin/alpacon", packageOwner: "deb:alpacon", want: InstallDeb},
+		{name: "owned by an rpm package", executablePath: "/usr/local/bin/alpacon", packageOwner: "rpm:alpacon", want: InstallRPM},
+		{name: "same path with no owner is manual", executablePath: "/usr/local/bin/alpacon", packageOwner: "", want: InstallManual},
+		{name: "home directory install is manual", executablePath: "/home/dev/.local/bin/alpacon", packageOwner: "", want: InstallManual},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.want, ClassifyPath(tt.realPath, tt.packageOwner))
+			assert.Equal(t, tt.want, ClassifyPath(tt.executablePath, tt.packageOwner))
 		})
 	}
 }

--- a/pkg/selfupdate/location_test.go
+++ b/pkg/selfupdate/location_test.go
@@ -1,0 +1,61 @@
+package selfupdate
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestClassifyPath(t *testing.T) {
+	tests := []struct {
+		name         string
+		realPath     string
+		packageOwner string
+		want         InstallKind
+	}{
+		{name: "homebrew cellar", realPath: "/opt/homebrew/Cellar/alpacon-cli/1.4.0/bin/alpacon", packageOwner: "", want: InstallHomebrew},
+		{name: "intel homebrew cellar", realPath: "/usr/local/Cellar/alpacon-cli/1.4.0/bin/alpacon", packageOwner: "", want: InstallHomebrew},
+		{name: "mise shim", realPath: "/home/dev/.local/share/mise/installs/alpacon/1.4.0/alpacon", packageOwner: "", want: InstallVersionManager},
+		{name: "asdf install", realPath: "/home/dev/.asdf/installs/alpacon/1.4.0/bin/alpacon", packageOwner: "", want: InstallVersionManager},
+		{name: "owned by a deb package", realPath: "/usr/local/bin/alpacon", packageOwner: "deb:alpacon", want: InstallDeb},
+		{name: "owned by an rpm package", realPath: "/usr/local/bin/alpacon", packageOwner: "rpm:alpacon", want: InstallRPM},
+		{name: "same path with no owner is manual", realPath: "/usr/local/bin/alpacon", packageOwner: "", want: InstallManual},
+		{name: "home directory install is manual", realPath: "/home/dev/.local/bin/alpacon", packageOwner: "", want: InstallManual},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, ClassifyPath(tt.realPath, tt.packageOwner))
+		})
+	}
+}
+
+func TestResolveExecutablePathFollowsSymlinks(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation requires elevated privileges on some Windows environments")
+	}
+	dir := t.TempDir()
+	target := filepath.Join(dir, "real-alpacon")
+	require.NoError(t, os.WriteFile(target, []byte("binary"), 0755))
+	link := filepath.Join(dir, "alpacon")
+	require.NoError(t, os.Symlink(target, link))
+
+	original := osExecutable
+	t.Cleanup(func() { osExecutable = original })
+	osExecutable = func() (string, error) { return link, nil }
+
+	resolved, err := ResolveExecutablePath()
+
+	require.NoError(t, err)
+	assert.Equal(t, mustEvalSymlinks(t, target), resolved)
+}
+
+func mustEvalSymlinks(t *testing.T, path string) string {
+	t.Helper()
+	resolved, err := filepath.EvalSymlinks(path)
+	require.NoError(t, err)
+	return resolved
+}

--- a/pkg/selfupdate/lock.go
+++ b/pkg/selfupdate/lock.go
@@ -1,0 +1,62 @@
+package selfupdate
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+var (
+	ErrUpdateInProgress = errors.New("another alpacon update is already running")
+
+	ErrLockUnavailable = errors.New("cannot open the update lock") // One shape for both ways the lock can fail to open, and it names the lock, which neither underlying message does.
+)
+
+// Lock is an advisory lock the kernel drops when this process exits, however it
+// exits. A lock named only by the file's own contents would need an age rule to
+// survive a killed process, and no age works: shorter than a slow download and
+// it evicts a live update, longer and a killed one strands the next run.
+type Lock struct {
+	file *os.File
+}
+
+// LockPath puts the lock beside the binary it guards. In the home directory it
+// would guard nothing: sudo moves HOME to /root on Linux, so the root run and
+// the user run would take two different locks over one install path—and where
+// sudo keeps HOME, root would leave a lock file the user can no longer open.
+func LockPath(executablePath string) string {
+	return filepath.Join(filepath.Dir(executablePath), ".alpacon-update.lock")
+}
+
+func AcquireLock(path string) (*Lock, error) {
+	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrLockUnavailable, err)
+	}
+
+	// 0666, not 0600: the file holds nothing and the kernel is what makes the
+	// lock exclusive. A mode only its creator can open would shut every other
+	// account out of a group-writable install directory, and one
+	// 'sudo alpacon update' would leave a root-owned lock behind for good.
+	file, err := os.OpenFile(path, lockOpenFlags, 0666)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrLockUnavailable, err)
+	}
+	if err := lockFile(file); err != nil {
+		_ = file.Close()
+		return nil, err
+	}
+	return &Lock{file: file}, nil
+}
+
+// Release drops the lock and leaves the file behind. Unlinking it would let a
+// process that opened it before the unlink and one that creates it after hold
+// locks on two different files at one path, which is the race the lock exists
+// to prevent.
+func (l *Lock) Release() error {
+	err := unlockFile(l.file)
+	if closeErr := l.file.Close(); err == nil {
+		err = closeErr
+	}
+	return err
+}

--- a/pkg/selfupdate/lock_test.go
+++ b/pkg/selfupdate/lock_test.go
@@ -58,10 +58,8 @@ func TestAcquireLockGivesAnUnheldLockToExactlyOneClaimant(t *testing.T) {
 	var held sync.Mutex
 	var locks []*Lock
 	start.Add(1)
-	for i := 0; i < claimants; i++ {
-		done.Add(1)
-		go func() {
-			defer done.Done()
+	for range claimants {
+		done.Go(func() {
 			start.Wait()
 			lock, err := AcquireLock(path)
 			if err != nil {
@@ -70,7 +68,7 @@ func TestAcquireLockGivesAnUnheldLockToExactlyOneClaimant(t *testing.T) {
 			held.Lock()
 			locks = append(locks, lock)
 			held.Unlock()
-		}()
+		})
 	}
 	start.Done()
 	done.Wait()

--- a/pkg/selfupdate/lock_test.go
+++ b/pkg/selfupdate/lock_test.go
@@ -1,0 +1,95 @@
+package selfupdate
+
+import (
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAcquireLockRefusesASecondHolder(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "update.lock")
+
+	first, err := AcquireLock(path)
+	require.NoError(t, err)
+
+	_, err = AcquireLock(path)
+	assert.ErrorIs(t, err, ErrUpdateInProgress)
+
+	require.NoError(t, first.Release())
+
+	second, err := AcquireLock(path)
+	require.NoError(t, err)
+	require.NoError(t, second.Release())
+}
+
+func TestAcquireLockTakesALockFileNoProcessHolds(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "update.lock")
+	require.NoError(t, os.WriteFile(path, []byte("4242"), 0600))
+
+	lock, err := AcquireLock(path)
+
+	require.NoError(t, err, "a lock file left behind by a process that died must not block the next update")
+	require.NoError(t, lock.Release())
+}
+
+func TestReleaseLetsTheNextHolderIn(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "update.lock")
+	lock, err := AcquireLock(path)
+	require.NoError(t, err)
+
+	require.NoError(t, lock.Release())
+
+	next, err := AcquireLock(path)
+	require.NoError(t, err)
+	require.NoError(t, next.Release())
+}
+
+func TestAcquireLockGivesAnUnheldLockToExactlyOneClaimant(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "update.lock")
+	require.NoError(t, os.WriteFile(path, []byte("4242"), 0600))
+
+	const claimants = 16
+	var start sync.WaitGroup
+	var done sync.WaitGroup
+	var held sync.Mutex
+	var locks []*Lock
+	start.Add(1)
+	for i := 0; i < claimants; i++ {
+		done.Add(1)
+		go func() {
+			defer done.Done()
+			start.Wait()
+			lock, err := AcquireLock(path)
+			if err != nil {
+				return
+			}
+			held.Lock()
+			locks = append(locks, lock)
+			held.Unlock()
+		}()
+	}
+	start.Done()
+	done.Wait()
+
+	assert.Len(t, locks, 1, "an unheld lock file that several processes reach at once must go to exactly one")
+	for _, lock := range locks {
+		_ = lock.Release()
+	}
+}
+
+func TestLockPathSitsBesideTheBinaryItGuards(t *testing.T) {
+	assert.Equal(t, filepath.Join("/usr/local/bin", ".alpacon-update.lock"), LockPath("/usr/local/bin/alpacon"))
+}
+
+func TestAcquireLockNamesItselfWhicheverWayTheLockCannotBeMade(t *testing.T) {
+	blocked := filepath.Join(t.TempDir(), "bin")
+	require.NoError(t, os.WriteFile(blocked, []byte("not a directory"), 0600))
+
+	_, err := AcquireLock(filepath.Join(blocked, ".alpacon-update.lock"))
+
+	assert.ErrorIs(t, err, ErrLockUnavailable)
+}

--- a/pkg/selfupdate/lock_unix.go
+++ b/pkg/selfupdate/lock_unix.go
@@ -1,0 +1,29 @@
+//go:build !windows
+
+package selfupdate
+
+import (
+	"errors"
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+// lockOpenFlags asks for no more access than the lock needs. flock takes an
+// exclusive lock on a read-only descriptor all the same, and asking for write
+// access would be refused on a lock file another account created under its own
+// umask. O_NOFOLLOW is the sudo guard: root opening this path would otherwise
+// follow a link an unprivileged process planted there.
+const lockOpenFlags = os.O_RDONLY | os.O_CREATE | unix.O_NOFOLLOW
+
+func lockFile(file *os.File) error {
+	err := unix.Flock(int(file.Fd()), unix.LOCK_EX|unix.LOCK_NB)
+	if errors.Is(err, unix.EWOULDBLOCK) {
+		return ErrUpdateInProgress
+	}
+	return err
+}
+
+func unlockFile(file *os.File) error {
+	return unix.Flock(int(file.Fd()), unix.LOCK_UN)
+}

--- a/pkg/selfupdate/lock_unix_test.go
+++ b/pkg/selfupdate/lock_unix_test.go
@@ -1,0 +1,35 @@
+//go:build !windows
+
+package selfupdate
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestAcquireLockRefusesToFollowASymlink(t *testing.T) {
+	dir := t.TempDir()
+	victim := filepath.Join(dir, "victim")
+	require.NoError(t, os.WriteFile(victim, nil, 0600))
+	path := filepath.Join(dir, ".alpacon-update.lock")
+	require.NoError(t, os.Symlink(victim, path))
+
+	_, err := AcquireLock(path)
+
+	require.Error(t, err, "root is told to run this command, so a planted link must not decide what it opens")
+}
+
+func TestAcquireLockOpensALockFileThisUserCannotWrite(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("root opens a file whatever its mode says")
+	}
+	path := filepath.Join(t.TempDir(), ".alpacon-update.lock")
+	require.NoError(t, os.WriteFile(path, nil, 0444))
+
+	lock, err := AcquireLock(path)
+	require.NoError(t, err, "a lock file another account left behind must not end updates for everyone else")
+	require.NoError(t, lock.Release())
+}

--- a/pkg/selfupdate/lock_windows.go
+++ b/pkg/selfupdate/lock_windows.go
@@ -1,0 +1,27 @@
+//go:build windows
+
+package selfupdate
+
+import (
+	"errors"
+	"os"
+
+	"golang.org/x/sys/windows"
+)
+
+const lockOpenFlags = os.O_RDWR | os.O_CREATE
+
+const lockFileBytes = 1 // The byte range LockFileEx takes: Windows has no whole-file form, and a range every caller names identically is exclusive all the same.
+
+func lockFile(file *os.File) error {
+	flags := uint32(windows.LOCKFILE_EXCLUSIVE_LOCK | windows.LOCKFILE_FAIL_IMMEDIATELY)
+	err := windows.LockFileEx(windows.Handle(file.Fd()), flags, 0, lockFileBytes, 0, new(windows.Overlapped))
+	if errors.Is(err, windows.ERROR_LOCK_VIOLATION) {
+		return ErrUpdateInProgress
+	}
+	return err
+}
+
+func unlockFile(file *os.File) error {
+	return windows.UnlockFileEx(windows.Handle(file.Fd()), 0, lockFileBytes, 0, new(windows.Overlapped))
+}

--- a/pkg/selfupdate/owner.go
+++ b/pkg/selfupdate/owner.go
@@ -2,41 +2,113 @@ package selfupdate
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"os"
 	"os/exec"
 	"strings"
 	"time"
 )
 
-const packageQueryTimeout = 5 * time.Second // rpm takes a read lock on its database, so a package transaction running elsewhere would otherwise stall the update for as long as it lasts.
+// ErrOwnerUnknown separates "no package owns this" from "the query could not
+// answer". Both used to arrive as the empty string, which ClassifyPath reads as
+// a manual install and Run reads as permission to overwrite the file.
+var ErrOwnerUnknown = errors.New("cannot tell which package owns the binary")
 
+var packageQueryTimeout = 5 * time.Second // rpm takes a read lock on its database, so a package transaction running elsewhere would otherwise stall the update for as long as it lasts.
+
+// packageManagerPaths pins where a manager may live. $PATH would otherwise name
+// it, and 'sudo alpacon update'—the command this CLI prints itself—carries the
+// operator's own PATH wherever sudoers has no secure_path.
+var packageManagerPaths = map[string][]string{
+	"dpkg": {"/usr/bin/dpkg", "/bin/dpkg"},
+	"rpm":  {"/usr/bin/rpm", "/bin/rpm"},
+}
+
+// CommandRunner answers who owns a path. A nil error is an answer; so is an
+// ordinary error, which means this manager does not claim the file. Only an
+// error wrapping ErrOwnerUnknown says the question went unanswered.
 type CommandRunner func(name string, args ...string) ([]byte, error)
 
 // ExecRunner reads stdout alone: dpkg-query warns on stderr and still exits
 // zero, and CombinedOutput would hand the parser "dpkg-query: warning" as the
 // package that owns the file.
 func ExecRunner(name string, args ...string) ([]byte, error) {
+	path, installed := resolvePackageManager(name)
+	if !installed {
+		return nil, fmt.Errorf("%s is not installed at a trusted path", name) // An answer, not uncertainty: this manager does not run on this host.
+	}
+
 	ctx, cancel := context.WithTimeout(context.Background(), packageQueryTimeout)
 	defer cancel()
-	return exec.CommandContext(ctx, name, args...).Output()
+
+	out, err := exec.CommandContext(ctx, path, args...).Output()
+	if err == nil {
+		return out, nil
+	}
+
+	// The deadline first: a killed process reports an ExitError like any other
+	// non-zero exit, and rpm is killed mid-query exactly when another
+	// transaction holds its database.
+	if ctx.Err() != nil {
+		return nil, fmt.Errorf("%w: %s: %w", ErrOwnerUnknown, name, ctx.Err())
+	}
+
+	// A non-zero exit is an answer, and so is a manager not installed on this host.
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) || errors.Is(err, exec.ErrNotFound) {
+		return nil, err
+	}
+	return nil, fmt.Errorf("%w: %s: %w", ErrOwnerUnknown, name, err)
 }
 
-func PackageOwner(run CommandRunner, realPath string) string {
+func resolvePackageManager(name string) (string, bool) {
+	candidates, pinned := packageManagerPaths[name]
+	if !pinned {
+		return name, true
+	}
+	for _, path := range candidates {
+		if info, err := os.Stat(path); err == nil && !info.IsDir() {
+			return path, true
+		}
+	}
+	return "", false
+}
+
+func PackageOwner(run CommandRunner, executablePath string) (string, error) {
 	if run == nil {
-		return ""
+		return "", fmt.Errorf("%w: no package-manager query was supplied", ErrOwnerUnknown)
 	}
 
-	if out, err := run("dpkg", "-S", realPath); err == nil {
-		if name, _, found := strings.Cut(string(out), ":"); found { // dpkg -S answers "<package>: <path>".
-			if name = strings.TrimSpace(name); name != "" {
-				return "deb:" + name
-			}
+	out, err := queryOwner(run, "dpkg", "-S", executablePath)
+	if err != nil {
+		return "", err
+	}
+	if name, _, found := strings.Cut(out, ":"); found { // dpkg -S answers "<package>: <path>".
+		if name = strings.TrimSpace(name); name != "" {
+			return "deb:" + name, nil
 		}
 	}
 
-	if out, err := run("rpm", "-qf", realPath); err == nil {
-		if name := strings.TrimSpace(string(out)); name != "" {
-			return "rpm:" + name
-		}
+	out, err = queryOwner(run, "rpm", "-qf", executablePath)
+	if err != nil {
+		return "", err
 	}
-	return ""
+	if name := strings.TrimSpace(out); name != "" {
+		return "rpm:" + name, nil
+	}
+	return "", nil
+}
+
+// queryOwner returns empty output for a manager that answered without claiming
+// the file, and an error only when the query could not answer at all.
+func queryOwner(run CommandRunner, tool string, args ...string) (string, error) {
+	out, err := run(tool, args...)
+	if err == nil {
+		return string(out), nil
+	}
+	if errors.Is(err, ErrOwnerUnknown) {
+		return "", err
+	}
+	return "", nil
 }

--- a/pkg/selfupdate/owner.go
+++ b/pkg/selfupdate/owner.go
@@ -1,0 +1,42 @@
+package selfupdate
+
+import (
+	"context"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const packageQueryTimeout = 5 * time.Second // rpm takes a read lock on its database, so a package transaction running elsewhere would otherwise stall the update for as long as it lasts.
+
+type CommandRunner func(name string, args ...string) ([]byte, error)
+
+// ExecRunner reads stdout alone: dpkg-query warns on stderr and still exits
+// zero, and CombinedOutput would hand the parser "dpkg-query: warning" as the
+// package that owns the file.
+func ExecRunner(name string, args ...string) ([]byte, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), packageQueryTimeout)
+	defer cancel()
+	return exec.CommandContext(ctx, name, args...).Output()
+}
+
+func PackageOwner(run CommandRunner, realPath string) string {
+	if run == nil {
+		return ""
+	}
+
+	if out, err := run("dpkg", "-S", realPath); err == nil {
+		if name, _, found := strings.Cut(string(out), ":"); found { // dpkg -S answers "<package>: <path>".
+			if name = strings.TrimSpace(name); name != "" {
+				return "deb:" + name
+			}
+		}
+	}
+
+	if out, err := run("rpm", "-qf", realPath); err == nil {
+		if name := strings.TrimSpace(string(out)); name != "" {
+			return "rpm:" + name
+		}
+	}
+	return ""
+}

--- a/pkg/selfupdate/owner_test.go
+++ b/pkg/selfupdate/owner_test.go
@@ -1,0 +1,72 @@
+package selfupdate
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPackageOwner(t *testing.T) {
+	notFound := errors.New("exit status 1")
+
+	tests := []struct {
+		name string
+		run  CommandRunner
+		want string
+	}{
+		{
+			name: "dpkg claims the file",
+			run: func(name string, args ...string) ([]byte, error) {
+				if name == "dpkg" {
+					return []byte("alpacon: /usr/local/bin/alpacon\n"), nil
+				}
+				return nil, notFound
+			},
+			want: "deb:alpacon",
+		},
+		{
+			name: "rpm claims the file",
+			run: func(name string, args ...string) ([]byte, error) {
+				if name == "rpm" {
+					return []byte("alpacon-1.4.0-1.x86_64\n"), nil
+				}
+				return nil, notFound
+			},
+			want: "rpm:alpacon-1.4.0-1.x86_64",
+		},
+		{
+			name: "no tool claims the file",
+			run: func(name string, args ...string) ([]byte, error) {
+				return nil, notFound
+			},
+			want: "",
+		},
+		{
+			name: "dpkg exits zero with a line carrying no colon",
+			run: func(name string, args ...string) ([]byte, error) {
+				if name == "dpkg" {
+					return []byte("no path found matching pattern\n"), nil
+				}
+				return nil, notFound
+			},
+			want: "",
+		},
+		{
+			name: "a tool exits zero with no output",
+			run: func(name string, args ...string) ([]byte, error) {
+				return []byte("   \n"), nil
+			},
+			want: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, PackageOwner(tt.run, "/usr/local/bin/alpacon"))
+		})
+	}
+}
+
+func TestPackageOwnerTreatsANilRunnerAsNoOwner(t *testing.T) {
+	assert.Empty(t, PackageOwner(nil, "/usr/local/bin/alpacon"), "a caller with no way to ask has a manual install")
+}

--- a/pkg/selfupdate/owner_test.go
+++ b/pkg/selfupdate/owner_test.go
@@ -2,9 +2,12 @@ package selfupdate
 
 import (
 	"errors"
+	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestPackageOwner(t *testing.T) {
@@ -62,11 +65,59 @@ func TestPackageOwner(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.want, PackageOwner(tt.run, "/usr/local/bin/alpacon"))
+			owner, err := PackageOwner(tt.run, "/usr/local/bin/alpacon")
+
+			assert.NoError(t, err)
+			assert.Equal(t, tt.want, owner)
 		})
 	}
 }
 
-func TestPackageOwnerTreatsANilRunnerAsNoOwner(t *testing.T) {
-	assert.Empty(t, PackageOwner(nil, "/usr/local/bin/alpacon"), "a caller with no way to ask has a manual install")
+// No querier is the strongest form of "the query could not answer", and
+// answering "" would have ClassifyPath call it a manual install.
+func TestPackageOwnerRefusesAnAnswerWithNoWayToAsk(t *testing.T) {
+	owner, err := PackageOwner(nil, "/usr/local/bin/alpacon")
+
+	require.ErrorIs(t, err, ErrOwnerUnknown)
+	assert.Empty(t, owner)
+}
+
+// A query that could not answer must not read as "nobody owns it": ClassifyPath
+// turns that into a manual install, which is permission to overwrite the file.
+func TestPackageOwnerRefusesToGuessWhenTheQueryCannotAnswer(t *testing.T) {
+	for _, stalled := range []string{"dpkg", "rpm"} {
+		t.Run(stalled, func(t *testing.T) {
+			run := func(name string, args ...string) ([]byte, error) {
+				if name == stalled {
+					return nil, fmt.Errorf("%w: %s: signal: killed", ErrOwnerUnknown, name)
+				}
+				return nil, errors.New("exit status 1")
+			}
+
+			owner, err := PackageOwner(run, "/usr/local/bin/alpacon")
+
+			require.ErrorIs(t, err, ErrOwnerUnknown)
+			assert.Empty(t, owner)
+
+			_, kindErr := DetectInstallKind(run, "/usr/local/bin/alpacon")
+			assert.ErrorIs(t, kindErr, ErrOwnerUnknown)
+		})
+	}
+}
+
+// $PATH must never name the manager: 'sudo alpacon update' carries the
+// operator's PATH wherever sudoers has no secure_path.
+func TestResolvePackageManagerNeverLeavesTheNameToThePath(t *testing.T) {
+	for _, name := range []string{"dpkg", "rpm"} {
+		path, installed := resolvePackageManager(name)
+		if installed {
+			assert.True(t, strings.HasPrefix(path, "/"), "%s must resolve to an absolute path, got %q", name, path)
+		} else {
+			assert.Empty(t, path)
+		}
+	}
+
+	path, installed := resolvePackageManager("/bin/sh")
+	assert.True(t, installed, "a name this map does not pin is passed through for the tests that use one")
+	assert.Equal(t, "/bin/sh", path)
 }

--- a/pkg/selfupdate/owner_unix_test.go
+++ b/pkg/selfupdate/owner_unix_test.go
@@ -1,0 +1,17 @@
+//go:build !windows
+
+package selfupdate
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExecRunnerLeavesStderrOutOfTheAnswer(t *testing.T) {
+	out, err := ExecRunner("/bin/sh", "-c", `echo "dpkg-query: warning: parsing file" >&2; echo "alpacon: /usr/local/bin/alpacon"`)
+
+	require.NoError(t, err)
+	assert.Equal(t, "alpacon: /usr/local/bin/alpacon\n", string(out))
+}

--- a/pkg/selfupdate/owner_unix_test.go
+++ b/pkg/selfupdate/owner_unix_test.go
@@ -4,6 +4,7 @@ package selfupdate
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -14,4 +15,21 @@ func TestExecRunnerLeavesStderrOutOfTheAnswer(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.Equal(t, "alpacon: /usr/local/bin/alpacon\n", string(out))
+}
+
+func TestExecRunnerSeparatesAnAnswerFromAQueryThatCouldNotAnswer(t *testing.T) {
+	original := packageQueryTimeout
+	t.Cleanup(func() { packageQueryTimeout = original })
+	packageQueryTimeout = 100 * time.Millisecond
+
+	_, stalled := ExecRunner("/bin/sh", "-c", "sleep 5")
+	require.ErrorIs(t, stalled, ErrOwnerUnknown, "rpm is killed mid-query exactly when another transaction holds its database")
+
+	_, notOwned := ExecRunner("/bin/sh", "-c", "exit 1")
+	require.Error(t, notOwned)
+	assert.NotErrorIs(t, notOwned, ErrOwnerUnknown, "a non-zero exit is the answer 'this manager does not own it'")
+
+	_, missing := ExecRunner("alpacon-no-such-package-manager", "-qf", "/usr/local/bin/alpacon")
+	require.Error(t, missing)
+	assert.NotErrorIs(t, missing, ErrOwnerUnknown, "a manager that is not installed here has answered too")
 }

--- a/pkg/selfupdate/preserve.go
+++ b/pkg/selfupdate/preserve.go
@@ -1,0 +1,105 @@
+package selfupdate
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"regexp"
+	"time"
+
+	"github.com/alpacax/alpacon-cli/utils"
+)
+
+const (
+	preservedSuffix = "old"
+	stagedSuffix    = "staged"
+)
+
+var osRename = os.Rename
+
+func PreservedName(path string, now time.Time) string {
+	return timestampedName(path, preservedSuffix, now)
+}
+
+func StagedName(path string, now time.Time) string { // A run killed mid-copy leaves the staging file behind, and a fixed name would have the next run write into it.
+	return timestampedName(path, stagedSuffix, now)
+}
+
+func timestampedName(path, suffix string, now time.Time) string {
+	return fmt.Sprintf("%s.%s.%d", path, suffix, now.UnixNano())
+}
+
+// RestorePreserved falls back to a copy because a rename cannot cross a
+// filesystem boundary, and because on Windows the target may be held open by
+// something that took it between the failure and this call.
+func RestorePreserved(preservedPath, targetPath string) error {
+	if err := osRename(preservedPath, targetPath); err == nil {
+		return nil
+	}
+
+	if err := copyPreserved(preservedPath, targetPath); err != nil {
+		return err
+	}
+	return os.Remove(preservedPath)
+}
+
+// copyPreserved exists to bound the source handle. Windows refuses to delete a
+// file anything still has open, so a deferred close in RestorePreserved would
+// make the remove that follows it fail on the platform this path is for.
+func copyPreserved(preservedPath, targetPath string) error {
+	source, err := os.Open(preservedPath)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = source.Close() }()
+
+	_, err = utils.SaveStreamAtomic(targetPath, source, 0755)
+	return err
+}
+
+// SweepPreserved clears what an earlier update could not delete: on Windows the
+// preserved copy is the executable that was running then, and a staging copy
+// outlives a run killed while it was being written.
+func SweepPreserved(dir, binaryName string) int {
+	pattern := regexp.MustCompile(`^` + regexp.QuoteMeta(binaryName) + `\.(` + preservedSuffix + `|` + stagedSuffix + `)\.\d+$`)
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return 0
+	}
+
+	removed := 0
+	for _, entry := range entries {
+		if entry.IsDir() || !pattern.MatchString(entry.Name()) {
+			continue
+		}
+		if err := os.Remove(filepath.Join(dir, entry.Name())); err == nil {
+			removed++
+		}
+	}
+	return removed
+}
+
+func copyFile(sourcePath, destPath string) error {
+	source, err := os.Open(sourcePath)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = source.Close() }()
+
+	info, err := source.Stat()
+	if err != nil {
+		return err
+	}
+
+	dest, err := os.OpenFile(destPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, info.Mode().Perm())
+	if err != nil {
+		return err
+	}
+	_, copyErr := io.Copy(dest, source)
+	closeErr := dest.Close()
+	if copyErr != nil {
+		return copyErr
+	}
+	return closeErr
+}

--- a/pkg/selfupdate/preserve.go
+++ b/pkg/selfupdate/preserve.go
@@ -11,6 +11,14 @@ import (
 	"github.com/alpacax/alpacon-cli/utils"
 )
 
+// staleTempAge is how long a utils.SaveStreamAtomic temp file must have sat
+// before the sweep will take it. The update lock is no help: 'alpacon cp' and
+// 'alpacon package download' write the same name shape into whatever directory
+// they were pointed at, and take no lock. Age is what separates a killed run's
+// litter from a download still streaming—a leftover is permanent, so collecting
+// it a day late costs nothing.
+const staleTempAge = 24 * time.Hour
+
 const (
 	preservedSuffix = "old"
 	stagedSuffix    = "staged"
@@ -61,25 +69,47 @@ func copyPreserved(preservedPath, targetPath string) error {
 // SweepPreserved clears what an earlier update could not delete: on Windows the
 // preserved copy is the executable that was running then, and a staging or
 // utils.SaveStreamAtomic temp file outlives a run killed while writing it.
-// Callers hold the update lock, which is what keeps a live write safe.
 func SweepPreserved(dir, binaryName string) int {
-	pattern := regexp.MustCompile(`^` + regexp.QuoteMeta(binaryName) + `\.(` + preservedSuffix + `|` + stagedSuffix + `)\.\d+$`)
-	entries, err := os.ReadDir(dir)
-	if err != nil {
-		return 0
-	}
-
 	removed := 0
-	for _, entry := range entries {
-		name := entry.Name()
-		if entry.IsDir() || (!pattern.MatchString(name) && !utils.IsReplacementTempName(name)) {
-			continue
-		}
-		if err := os.Remove(filepath.Join(dir, name)); err == nil {
+	for _, entry := range sweepableEntries(dir, binaryName) {
+		if err := os.Remove(filepath.Join(dir, entry.Name())); err == nil {
 			removed++
 		}
 	}
 	return removed
+}
+
+// hasSweepableEntry lets a caller find out before taking the lock, which
+// outlives the run as a file in the install directory.
+func hasSweepableEntry(dir, binaryName string) bool {
+	return len(sweepableEntries(dir, binaryName)) > 0
+}
+
+func sweepableEntries(dir, binaryName string) []os.DirEntry {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil
+	}
+
+	pattern := regexp.MustCompile(`^` + regexp.QuoteMeta(binaryName) + `\.(` + preservedSuffix + `|` + stagedSuffix + `)\.\d+$`)
+	var matched []os.DirEntry
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		if pattern.MatchString(entry.Name()) || staleReplacementTemp(entry) {
+			matched = append(matched, entry)
+		}
+	}
+	return matched
+}
+
+func staleReplacementTemp(entry os.DirEntry) bool {
+	if !utils.IsReplacementTempName(entry.Name()) {
+		return false
+	}
+	info, err := entry.Info()
+	return err == nil && time.Since(info.ModTime()) > staleTempAge
 }
 
 func copyFile(sourcePath, destPath string) error {
@@ -98,10 +128,29 @@ func copyFile(sourcePath, destPath string) error {
 	if err != nil {
 		return err
 	}
+	// A truncated copy in the install directory looks exactly like a preserved
+	// binary worth restoring.
+	cleanup := true
+	defer func() {
+		if cleanup {
+			_ = os.Remove(destPath)
+		}
+	}()
+
+	// O_CREATE only asks; the umask narrows. A rollback renames this copy over
+	// the install, so a trimmed mode would silently re-permission it.
+	chmodErr := dest.Chmod(info.Mode().Perm())
 	_, copyErr := io.Copy(dest, source)
 	closeErr := dest.Close()
 	if copyErr != nil {
 		return copyErr
 	}
-	return closeErr
+	if chmodErr != nil {
+		return chmodErr
+	}
+	if closeErr != nil {
+		return closeErr
+	}
+	cleanup = false
+	return nil
 }

--- a/pkg/selfupdate/preserve.go
+++ b/pkg/selfupdate/preserve.go
@@ -59,8 +59,9 @@ func copyPreserved(preservedPath, targetPath string) error {
 }
 
 // SweepPreserved clears what an earlier update could not delete: on Windows the
-// preserved copy is the executable that was running then, and a staging copy
-// outlives a run killed while it was being written.
+// preserved copy is the executable that was running then, and a staging or
+// utils.SaveStreamAtomic temp file outlives a run killed while writing it.
+// Callers hold the update lock, which is what keeps a live write safe.
 func SweepPreserved(dir, binaryName string) int {
 	pattern := regexp.MustCompile(`^` + regexp.QuoteMeta(binaryName) + `\.(` + preservedSuffix + `|` + stagedSuffix + `)\.\d+$`)
 	entries, err := os.ReadDir(dir)
@@ -70,10 +71,11 @@ func SweepPreserved(dir, binaryName string) int {
 
 	removed := 0
 	for _, entry := range entries {
-		if entry.IsDir() || !pattern.MatchString(entry.Name()) {
+		name := entry.Name()
+		if entry.IsDir() || (!pattern.MatchString(name) && !utils.IsReplacementTempName(name)) {
 			continue
 		}
-		if err := os.Remove(filepath.Join(dir, entry.Name())); err == nil {
+		if err := os.Remove(filepath.Join(dir, name)); err == nil {
 			removed++
 		}
 	}

--- a/pkg/selfupdate/preserve_test.go
+++ b/pkg/selfupdate/preserve_test.go
@@ -44,11 +44,14 @@ func TestRestorePreservedPutsTheBinaryBack(t *testing.T) {
 
 func TestSweepPreservedRemovesOnlyTimestampedCopies(t *testing.T) {
 	dir := t.TempDir()
-	keep := []string{"alpacon", "alpacon.old", "alpacon.old.notanumber", "other.old.123", "alpacon.staged", ".alpacon-.tmp", ".alpacon-1-2-3.tmp.bak"}
-	remove := []string{"alpacon.old.1", "alpacon.old.1735689600000000000", "alpacon.staged.1735689600000000000", ".alpacon-4242-1735689600000000000-0.tmp"}
+	keep := []string{"alpacon", "alpacon.old", "alpacon.old.notanumber", "other.old.123", "alpacon.staged", ".alpacon-.tmp", ".alpacon-1-2-3.tmp.bak", ".alpacon-4242-1735689600000000000-0.tmp"}
+	remove := []string{"alpacon.old.1", "alpacon.old.1735689600000000000", "alpacon.staged.1735689600000000000", ".alpacon-99-1735689600000000000-0.tmp"}
 	for _, name := range append(append([]string{}, keep...), remove...) {
 		require.NoError(t, os.WriteFile(filepath.Join(dir, name), []byte("x"), 0600))
 	}
+	// The kept temp is a write still in flight; only the aged one is litter.
+	aged := time.Now().Add(-staleTempAge - time.Minute)
+	require.NoError(t, os.Chtimes(filepath.Join(dir, ".alpacon-99-1735689600000000000-0.tmp"), aged, aged))
 
 	removed := SweepPreserved(dir, "alpacon")
 
@@ -96,4 +99,17 @@ func TestCopyFileRefusesToWriteOverAnExistingFile(t *testing.T) {
 	content, readErr := os.ReadFile(dest)
 	require.NoError(t, readErr)
 	assert.Equal(t, "someone else's file", string(content))
+}
+
+// A directory opens fine and fails on the first Read—the shape of ENOSPC.
+func TestCopyFileLeavesNothingBehindWhenTheCopyFails(t *testing.T) {
+	dir := t.TempDir()
+	source := filepath.Join(dir, "not-a-file")
+	require.NoError(t, os.Mkdir(source, 0755))
+	dest := filepath.Join(dir, "alpacon.old.1735689600000000000")
+
+	require.Error(t, copyFile(source, dest))
+
+	_, statErr := os.Stat(dest)
+	assert.ErrorIs(t, statErr, os.ErrNotExist, "a truncated copy in the install directory looks like a preserved binary worth restoring")
 }

--- a/pkg/selfupdate/preserve_test.go
+++ b/pkg/selfupdate/preserve_test.go
@@ -1,0 +1,99 @@
+package selfupdate
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPreservedNameCarriesATimestamp(t *testing.T) {
+	now := time.Unix(0, 1735689600000000000)
+
+	name := PreservedName("/usr/local/bin/alpacon", now)
+
+	assert.Equal(t, "/usr/local/bin/alpacon.old.1735689600000000000", name)
+}
+
+func TestStagedNameCarriesATimestamp(t *testing.T) {
+	now := time.Unix(0, 1735689600000000000)
+
+	name := StagedName("/usr/local/bin/alpacon", now)
+
+	assert.Equal(t, "/usr/local/bin/alpacon.staged.1735689600000000000", name)
+}
+
+func TestRestorePreservedPutsTheBinaryBack(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "alpacon")
+	preserved := filepath.Join(dir, "alpacon.old.1735689600000000000")
+	require.NoError(t, os.WriteFile(preserved, []byte("old binary"), 0755))
+
+	require.NoError(t, RestorePreserved(preserved, target))
+
+	content, err := os.ReadFile(target)
+	require.NoError(t, err)
+	assert.Equal(t, "old binary", string(content))
+	_, statErr := os.Stat(preserved)
+	assert.ErrorIs(t, statErr, os.ErrNotExist)
+}
+
+func TestSweepPreservedRemovesOnlyTimestampedCopies(t *testing.T) {
+	dir := t.TempDir()
+	keep := []string{"alpacon", "alpacon.old", "alpacon.old.notanumber", "other.old.123", "alpacon.staged"}
+	remove := []string{"alpacon.old.1", "alpacon.old.1735689600000000000", "alpacon.staged.1735689600000000000"}
+	for _, name := range append(append([]string{}, keep...), remove...) {
+		require.NoError(t, os.WriteFile(filepath.Join(dir, name), []byte("x"), 0600))
+	}
+
+	removed := SweepPreserved(dir, "alpacon")
+
+	assert.Equal(t, 3, removed)
+	for _, name := range keep {
+		_, err := os.Stat(filepath.Join(dir, name))
+		assert.NoError(t, err, "sweep must not remove %s", name)
+	}
+	for _, name := range remove {
+		_, err := os.Stat(filepath.Join(dir, name))
+		assert.ErrorIs(t, err, os.ErrNotExist, "sweep must remove %s", name)
+	}
+}
+
+func TestRestorePreservedCopiesWhenTheRenameFails(t *testing.T) {
+	original := osRename
+	t.Cleanup(func() { osRename = original })
+	osRename = func(string, string) error { return errors.New("cross-device link") }
+
+	dir := t.TempDir()
+	target := filepath.Join(dir, "alpacon")
+	preserved := filepath.Join(dir, "alpacon.old.1735689600000000000")
+	require.NoError(t, os.WriteFile(target, []byte("half-written binary"), 0755))
+	require.NoError(t, os.WriteFile(preserved, []byte("old binary"), 0755))
+
+	require.NoError(t, RestorePreserved(preserved, target))
+
+	content, err := os.ReadFile(target)
+	require.NoError(t, err)
+	assert.Equal(t, "old binary", string(content))
+	_, statErr := os.Stat(preserved)
+	assert.ErrorIs(t, statErr, os.ErrNotExist)
+}
+
+func TestCopyFileRefusesToWriteOverAnExistingFile(t *testing.T) {
+	dir := t.TempDir()
+	source := filepath.Join(dir, "alpacon")
+	require.NoError(t, os.WriteFile(source, []byte("new binary"), 0755))
+	dest := filepath.Join(dir, "alpacon.old.1735689600000000000")
+	require.NoError(t, os.WriteFile(dest, []byte("someone else's file"), 0600))
+
+	err := copyFile(source, dest)
+
+	require.ErrorIs(t, err, os.ErrExist, "every destination carries a fresh timestamp, so a file already there is not ours")
+	content, readErr := os.ReadFile(dest)
+	require.NoError(t, readErr)
+	assert.Equal(t, "someone else's file", string(content))
+}

--- a/pkg/selfupdate/preserve_test.go
+++ b/pkg/selfupdate/preserve_test.go
@@ -44,15 +44,15 @@ func TestRestorePreservedPutsTheBinaryBack(t *testing.T) {
 
 func TestSweepPreservedRemovesOnlyTimestampedCopies(t *testing.T) {
 	dir := t.TempDir()
-	keep := []string{"alpacon", "alpacon.old", "alpacon.old.notanumber", "other.old.123", "alpacon.staged"}
-	remove := []string{"alpacon.old.1", "alpacon.old.1735689600000000000", "alpacon.staged.1735689600000000000"}
+	keep := []string{"alpacon", "alpacon.old", "alpacon.old.notanumber", "other.old.123", "alpacon.staged", ".alpacon-.tmp", ".alpacon-1-2-3.tmp.bak"}
+	remove := []string{"alpacon.old.1", "alpacon.old.1735689600000000000", "alpacon.staged.1735689600000000000", ".alpacon-4242-1735689600000000000-0.tmp"}
 	for _, name := range append(append([]string{}, keep...), remove...) {
 		require.NoError(t, os.WriteFile(filepath.Join(dir, name), []byte("x"), 0600))
 	}
 
 	removed := SweepPreserved(dir, "alpacon")
 
-	assert.Equal(t, 3, removed)
+	assert.Equal(t, 4, removed)
 	for _, name := range keep {
 		_, err := os.Stat(filepath.Join(dir, name))
 		assert.NoError(t, err, "sweep must not remove %s", name)

--- a/pkg/selfupdate/preserve_unix_test.go
+++ b/pkg/selfupdate/preserve_unix_test.go
@@ -1,0 +1,32 @@
+//go:build !windows
+
+package selfupdate
+
+import (
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// A trimmed mode on the preserved copy re-permissions the install the moment a
+// rollback renames it back.
+func TestCopyFileKeepsTheSourceModeThroughTheUmask(t *testing.T) {
+	original := syscall.Umask(0022)
+	t.Cleanup(func() { syscall.Umask(original) })
+
+	dir := t.TempDir()
+	source := filepath.Join(dir, "alpacon")
+	require.NoError(t, os.WriteFile(source, []byte("old binary"), 0600))
+	require.NoError(t, os.Chmod(source, 0775))
+	dest := filepath.Join(dir, "alpacon.old.1735689600000000000")
+
+	require.NoError(t, copyFile(source, dest))
+
+	info, err := os.Stat(dest)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0775), info.Mode().Perm())
+}

--- a/pkg/selfupdate/release.go
+++ b/pkg/selfupdate/release.go
@@ -14,7 +14,7 @@ import (
 )
 
 // DefaultReleaseAPIURL is a var so a test can point a real alpacon process at a
-// stub. Exit code 7 is only observable in a process that actually exits, and a
+// stub. Exit code 8 is only observable in a process that actually exits, and a
 // child process cannot be handed a different endpoint any other way.
 var DefaultReleaseAPIURL = "https://api.github.com/repos/alpacax/alpacon-cli/releases/latest"
 

--- a/pkg/selfupdate/release.go
+++ b/pkg/selfupdate/release.go
@@ -13,6 +13,14 @@ import (
 	"github.com/alpacax/alpacon-cli/utils"
 )
 
+// maxReleaseMetadataSize bounds the release JSON, which is a page of text even
+// for a release carrying every platform's asset.
+const maxReleaseMetadataSize = 1 << 20
+
+// releaseMetadataTimeout is what 'alpacon version' already waited: one small
+// JSON fetch, on a client that never sees the archive download.
+const releaseMetadataTimeout = 5 * time.Second
+
 // DefaultReleaseAPIURL is a var so a test can point a real alpacon process at a
 // stub. Exit code 8 is only observable in a process that actually exits, and a
 // child process cannot be handed a different endpoint any other way.
@@ -44,7 +52,7 @@ type githubRelease struct {
 }
 
 func LatestRelease(apiURL string) (*Release, error) {
-	client := newHTTPClient(5 * time.Second) // Five seconds is what 'alpacon version' already waited: one small JSON fetch, on a client that never sees the archive download.
+	client := newHTTPClient(releaseMetadataTimeout)
 	req, err := http.NewRequest(http.MethodGet, apiURL, nil)
 	if err != nil {
 		return nil, err
@@ -63,7 +71,7 @@ func LatestRelease(apiURL string) (*Release, error) {
 	}
 
 	var raw githubRelease
-	if err := json.NewDecoder(io.LimitReader(resp.Body, 1<<20)).Decode(&raw); err != nil {
+	if err := json.NewDecoder(io.LimitReader(resp.Body, maxReleaseMetadataSize)).Decode(&raw); err != nil {
 		return nil, err
 	}
 

--- a/pkg/selfupdate/release.go
+++ b/pkg/selfupdate/release.go
@@ -1,0 +1,83 @@
+// Package selfupdate replaces the running binary with the latest release.
+package selfupdate
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/alpacax/alpacon-cli/utils"
+)
+
+// DefaultReleaseAPIURL is a var so a test can point a real alpacon process at a
+// stub. Exit code 7 is only observable in a process that actually exits, and a
+// child process cannot be handed a different endpoint any other way.
+var DefaultReleaseAPIURL = "https://api.github.com/repos/alpacax/alpacon-cli/releases/latest"
+
+// The version goes straight into the asset names and from there into a path
+// under the temp directory, so releaseTagPattern refuses a tag carrying a
+// separator, or nothing at all, rather than turning it into a filename.
+var releaseTagPattern = regexp.MustCompile(`^[0-9A-Za-z][0-9A-Za-z.+_-]*$`)
+
+type Asset struct {
+	Name        string
+	DownloadURL string
+}
+
+type Release struct {
+	Version string
+	HTMLURL string
+	Assets  []Asset
+}
+
+type githubRelease struct {
+	TagName string `json:"tag_name"`
+	HTMLURL string `json:"html_url"`
+	Assets  []struct {
+		Name        string `json:"name"`
+		DownloadURL string `json:"browser_download_url"`
+	} `json:"assets"`
+}
+
+func LatestRelease(apiURL string) (*Release, error) {
+	client := newHTTPClient(5 * time.Second) // Five seconds is what 'alpacon version' already waited: one small JSON fetch, on a client that never sees the archive download.
+	req, err := http.NewRequest(http.MethodGet, apiURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Accept", "application/vnd.github.v3+json")
+	req.Header.Set("User-Agent", utils.GetUserAgent())
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("github api returned %s", resp.Status)
+	}
+
+	var raw githubRelease
+	if err := json.NewDecoder(io.LimitReader(resp.Body, 1<<20)).Decode(&raw); err != nil {
+		return nil, err
+	}
+
+	version := strings.TrimPrefix(raw.TagName, "v")
+	if !releaseTagPattern.MatchString(version) {
+		return nil, fmt.Errorf("github api returned an unusable release tag %q", raw.TagName)
+	}
+
+	release := &Release{
+		Version: version,
+		HTMLURL: raw.HTMLURL,
+	}
+	for _, a := range raw.Assets {
+		release.Assets = append(release.Assets, Asset{Name: a.Name, DownloadURL: a.DownloadURL})
+	}
+	return release, nil
+}

--- a/pkg/selfupdate/release_test.go
+++ b/pkg/selfupdate/release_test.go
@@ -1,0 +1,83 @@
+package selfupdate
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLatestReleaseStripsTagPrefixAndReadsAssets(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "application/vnd.github.v3+json", r.Header.Get("Accept"))
+		_, _ = w.Write([]byte(`{
+			"tag_name": "v1.4.0",
+			"html_url": "https://example.test/notes",
+			"assets": [
+				{"name": "alpacon-1.4.0-linux-amd64.tar.gz", "browser_download_url": "https://example.test/a.tar.gz"},
+				{"name": "alpacon-1.4.0-checksums.sha256", "browser_download_url": "https://example.test/sums"}
+			]
+		}`))
+	}))
+	defer ts.Close()
+
+	release, err := LatestRelease(ts.URL)
+
+	require.NoError(t, err)
+	assert.Equal(t, "1.4.0", release.Version)
+	assert.Equal(t, "https://example.test/notes", release.HTMLURL)
+	require.Len(t, release.Assets, 2)
+	assert.Equal(t, "alpacon-1.4.0-linux-amd64.tar.gz", release.Assets[0].Name)
+	assert.Equal(t, "https://example.test/a.tar.gz", release.Assets[0].DownloadURL)
+}
+
+func TestLatestReleaseRejectsABodyThatIsNotJSON(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("<html>blocked by a proxy</html>"))
+	}))
+	defer ts.Close()
+
+	_, err := LatestRelease(ts.URL)
+
+	require.Error(t, err)
+}
+
+func TestLatestReleaseRejectsNonOKStatus(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+	}))
+	defer ts.Close()
+
+	_, err := LatestRelease(ts.URL)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "403")
+}
+
+func TestLatestReleaseRejectsATagItCannotTurnIntoFileNames(t *testing.T) {
+	tests := []struct {
+		name string
+		tag  string
+	}{
+		{name: "no tag at all", tag: ""},
+		{name: "only the v prefix", tag: "v"},
+		{name: "a path separator", tag: "v../../etc/passwd"},
+		{name: "a space", tag: "v1.4.0 latest"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				_, _ = fmt.Fprintf(w, `{"tag_name": %q, "html_url": "https://example.test/notes"}`, tt.tag)
+			}))
+			defer ts.Close()
+
+			_, err := LatestRelease(ts.URL)
+
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "unusable release tag")
+		})
+	}
+}

--- a/pkg/selfupdate/replace_test.go
+++ b/pkg/selfupdate/replace_test.go
@@ -1,0 +1,83 @@
+//go:build !windows
+
+package selfupdate
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReplaceBinaryKeepsTheDestinationMode(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "alpacon")
+	require.NoError(t, os.WriteFile(target, []byte("old binary"), 0700)) // 0700, not the 0755 the implementation passes: a fixture at 0755 cannot tell keeping the destination's mode from forcing that literal.
+	replacement := filepath.Join(dir, "alpacon.new")
+	require.NoError(t, os.WriteFile(replacement, []byte("new binary"), 0600))
+
+	require.NoError(t, ReplaceBinary(target, replacement))
+
+	content, err := os.ReadFile(target)
+	require.NoError(t, err)
+	assert.Equal(t, "new binary", string(content))
+
+	info, err := os.Stat(target)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0700), info.Mode().Perm())
+}
+
+func TestReplaceBinaryLeavesNoPreservedCopyOnSuccess(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "alpacon")
+	require.NoError(t, os.WriteFile(target, []byte("old binary"), 0755))
+	replacement := filepath.Join(dir, "alpacon.new")
+	require.NoError(t, os.WriteFile(replacement, []byte("new binary"), 0600))
+
+	require.NoError(t, ReplaceBinary(target, replacement))
+
+	assert.Equal(t, 0, SweepPreserved(dir, "alpacon"), "a successful replace must leave no preserved copy behind")
+}
+
+func TestReplaceBinaryRestoresTheOldBinaryWhenTheSourceIsMissing(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "alpacon")
+	require.NoError(t, os.WriteFile(target, []byte("old binary"), 0755))
+
+	err := ReplaceBinary(target, filepath.Join(dir, "does-not-exist"))
+
+	require.Error(t, err)
+	content, readErr := os.ReadFile(target)
+	require.NoError(t, readErr)
+	assert.Equal(t, "old binary", string(content))
+	assert.Equal(t, 0, SweepPreserved(dir, "alpacon"), "giving up before the write must not leave a copy behind either")
+}
+
+func TestReplaceBinaryRollsBackWhenTheWriteIsRefused(t *testing.T) {
+	// Today's SaveStreamAtomic cannot damage the target—its last act is the
+	// rename—but the contract ReplaceBinary owes is that a reported failure
+	// leaves the old binary installed, and only the rollback can keep it.
+	original := saveStream
+	t.Cleanup(func() { saveStream = original })
+	saveStream = func(name string, _ io.Reader, perm os.FileMode) (int64, error) {
+		require.NoError(t, os.WriteFile(name, []byte("half-written binary"), perm))
+		return 0, os.ErrPermission
+	}
+
+	dir := t.TempDir()
+	target := filepath.Join(dir, "alpacon")
+	require.NoError(t, os.WriteFile(target, []byte("old binary"), 0755))
+	replacement := filepath.Join(dir, "alpacon.new")
+	require.NoError(t, os.WriteFile(replacement, []byte("new binary"), 0600))
+
+	err := ReplaceBinary(target, replacement)
+
+	require.ErrorIs(t, err, os.ErrPermission, "the write's own error must survive the rollback beside it")
+	content, readErr := os.ReadFile(target)
+	require.NoError(t, readErr)
+	assert.Equal(t, "old binary", string(content))
+	assert.Equal(t, 0, SweepPreserved(dir, "alpacon"), "a rolled-back replace must leave no preserved copy behind")
+}

--- a/pkg/selfupdate/replace_test.go
+++ b/pkg/selfupdate/replace_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/alpacax/alpacon-cli/pkg/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -28,6 +29,39 @@ func TestReplaceBinaryKeepsTheDestinationMode(t *testing.T) {
 	info, err := os.Stat(target)
 	require.NoError(t, err)
 	assert.Equal(t, os.FileMode(0700), info.Mode().Perm())
+}
+
+func TestReplaceBinaryWarnsWhenAnyLocalAccountCanRewriteTheInstall(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "alpacon")
+	require.NoError(t, os.WriteFile(target, []byte("old binary"), 0777))
+	require.NoError(t, os.Chmod(target, 0777)) // A umask that narrows WriteFile's 0777 would retire the branch rather than test it.
+	replacement := filepath.Join(dir, "alpacon.new")
+	require.NoError(t, os.WriteFile(replacement, []byte("new binary"), 0600))
+
+	_, stderr := testutil.CaptureOutput(t, func() {
+		require.NoError(t, ReplaceBinary(target, replacement))
+	})
+
+	assert.Contains(t, stderr, "writable by group or other (0777)")
+	assert.Contains(t, stderr, "chmod go-w")
+	info, err := os.Stat(target)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0777), info.Mode().Perm(), "the warning replaces a chmod; it must not become one")
+}
+
+func TestReplaceBinaryStaysQuietOnAnOrdinaryInstallMode(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "alpacon")
+	require.NoError(t, os.WriteFile(target, []byte("old binary"), 0755))
+	replacement := filepath.Join(dir, "alpacon.new")
+	require.NoError(t, os.WriteFile(replacement, []byte("new binary"), 0600))
+
+	_, stderr := testutil.CaptureOutput(t, func() {
+		require.NoError(t, ReplaceBinary(target, replacement))
+	})
+
+	assert.Empty(t, stderr, "0755 is what a normal install looks like, and a warning on every update teaches operators to ignore it")
 }
 
 func TestReplaceBinaryLeavesNoPreservedCopyOnSuccess(t *testing.T) {

--- a/pkg/selfupdate/replace_unix.go
+++ b/pkg/selfupdate/replace_unix.go
@@ -4,15 +4,20 @@ package selfupdate
 
 import (
 	"errors"
+	"fmt"
 	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/alpacax/alpacon-cli/utils"
 )
 
-var saveStream = utils.SaveStreamAtomic
+var writeReplacement = utils.SaveStreamAtomic
 
 func ReplaceBinary(targetPath, newBinaryPath string) error { // The 0755 handed to utils.SaveStreamAtomic is only a fallback for a target that does not exist: an installed binary keeps its own permission mode.
+	if err := refuseSymlinkTarget(targetPath); err != nil { // Before the copy, so a swapped target is not read at all.
+		return err
+	}
 	warnWorldWritableInstall(targetPath)
 
 	preservedPath := PreservedName(targetPath, time.Now())
@@ -27,7 +32,11 @@ func ReplaceBinary(targetPath, newBinaryPath string) error { // The 0755 handed 
 	}
 	defer func() { _ = source.Close() }()
 
-	if _, err := saveStream(targetPath, source, 0755); err != nil {
+	if err := refuseSymlinkTarget(targetPath); err != nil { // Again: the download between the two checks is the window a planted link needs.
+		return errors.Join(err, RestorePreserved(preservedPath, targetPath))
+	}
+
+	if _, err := writeReplacement(targetPath, source, 0755); err != nil {
 		return errors.Join(err, RestorePreserved(preservedPath, targetPath))
 	}
 
@@ -35,15 +44,43 @@ func ReplaceBinary(targetPath, newBinaryPath string) error { // The 0755 handed 
 	return nil
 }
 
-// A warning, not a chmod: re-permissioning a file the operator set up is not
+// utils.SaveStreamAtomic walks links when it writes, so a target swapped for a
+// link sends this write—running as root—wherever it points. Two Lstats narrow
+// the window to the write itself; closing it needs a writer that opens
+// O_NOFOLLOW, which SaveStreamAtomic deliberately does not.
+func refuseSymlinkTarget(targetPath string) error {
+	info, err := os.Lstat(targetPath)
+	if err != nil {
+		return err
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("refusing to replace %s: it became a symlink after the update started", targetPath)
+	}
+	return nil
+}
+
+// A warning, not a chmod: re-permissioning something the operator set up is not
 // the CLI's call, but a binary any local account can swap is worth saying aloud.
 func warnWorldWritableInstall(targetPath string) {
-	const groupOtherWrite = os.FileMode(0022)
+	if info, err := os.Stat(targetPath); err == nil && groupOrOtherWritable(info) {
+		utils.CliWarning("%s is writable by group or other (%04o) and the update keeps that mode; any local account can then replace the binary you run. Close it with 'chmod go-w %s'.",
+			targetPath, info.Mode().Perm(), targetPath)
+	}
 
-	info, err := os.Stat(targetPath)
-	if err != nil || info.Mode().Perm()&groupOtherWrite == 0 {
+	// The directory matters more than the file. Replacing a file is a rename,
+	// which needs no permission on the file at all—so a 0755 root-owned binary
+	// in a 0775 directory is swappable by anyone in that group. Sticky is the
+	// exemption: it stops a non-owner from renaming over somebody else's file.
+	installDir := filepath.Dir(targetPath)
+	info, err := os.Stat(installDir)
+	if err != nil || info.Mode()&os.ModeSticky != 0 || !groupOrOtherWritable(info) {
 		return
 	}
-	utils.CliWarning("%s is writable by group or other (%04o) and the update keeps that mode; any local account can then replace the binary you run. Close it with 'chmod go-w %s'.",
-		targetPath, info.Mode().Perm(), targetPath)
+	utils.CliWarning("%s is writable by group or other (%04o); replacing a file there needs no permission on the file itself, so any local account can swap the binary you run. Close it with 'chmod go-w %s'.",
+		installDir, info.Mode().Perm(), installDir)
+}
+
+func groupOrOtherWritable(info os.FileInfo) bool {
+	const groupOtherWrite = os.FileMode(0022)
+	return info.Mode().Perm()&groupOtherWrite != 0
 }

--- a/pkg/selfupdate/replace_unix.go
+++ b/pkg/selfupdate/replace_unix.go
@@ -13,6 +13,8 @@ import (
 var saveStream = utils.SaveStreamAtomic
 
 func ReplaceBinary(targetPath, newBinaryPath string) error { // The 0755 handed to utils.SaveStreamAtomic is only a fallback for a target that does not exist: an installed binary keeps its own permission mode.
+	warnWorldWritableInstall(targetPath)
+
 	preservedPath := PreservedName(targetPath, time.Now())
 	if err := copyFile(targetPath, preservedPath); err != nil {
 		return err
@@ -31,4 +33,17 @@ func ReplaceBinary(targetPath, newBinaryPath string) error { // The 0755 handed 
 
 	_ = os.Remove(preservedPath)
 	return nil
+}
+
+// A warning, not a chmod: re-permissioning a file the operator set up is not
+// the CLI's call, but a binary any local account can swap is worth saying aloud.
+func warnWorldWritableInstall(targetPath string) {
+	const groupOtherWrite = os.FileMode(0022)
+
+	info, err := os.Stat(targetPath)
+	if err != nil || info.Mode().Perm()&groupOtherWrite == 0 {
+		return
+	}
+	utils.CliWarning("%s is writable by group or other (%04o) and the update keeps that mode; any local account can then replace the binary you run. Close it with 'chmod go-w %s'.",
+		targetPath, info.Mode().Perm(), targetPath)
 }

--- a/pkg/selfupdate/replace_unix.go
+++ b/pkg/selfupdate/replace_unix.go
@@ -1,0 +1,34 @@
+//go:build !windows
+
+package selfupdate
+
+import (
+	"errors"
+	"os"
+	"time"
+
+	"github.com/alpacax/alpacon-cli/utils"
+)
+
+var saveStream = utils.SaveStreamAtomic
+
+func ReplaceBinary(targetPath, newBinaryPath string) error { // The 0755 handed to utils.SaveStreamAtomic is only a fallback for a target that does not exist: an installed binary keeps its own permission mode.
+	preservedPath := PreservedName(targetPath, time.Now())
+	if err := copyFile(targetPath, preservedPath); err != nil {
+		return err
+	}
+
+	source, err := os.Open(newBinaryPath)
+	if err != nil {
+		_ = os.Remove(preservedPath)
+		return err
+	}
+	defer func() { _ = source.Close() }()
+
+	if _, err := saveStream(targetPath, source, 0755); err != nil {
+		return errors.Join(err, RestorePreserved(preservedPath, targetPath))
+	}
+
+	_ = os.Remove(preservedPath)
+	return nil
+}

--- a/pkg/selfupdate/replace_unix_test.go
+++ b/pkg/selfupdate/replace_unix_test.go
@@ -94,9 +94,9 @@ func TestReplaceBinaryRollsBackWhenTheWriteIsRefused(t *testing.T) {
 	// Today's SaveStreamAtomic cannot damage the target—its last act is the
 	// rename—but the contract ReplaceBinary owes is that a reported failure
 	// leaves the old binary installed, and only the rollback can keep it.
-	original := saveStream
-	t.Cleanup(func() { saveStream = original })
-	saveStream = func(name string, _ io.Reader, perm os.FileMode) (int64, error) {
+	original := writeReplacement
+	t.Cleanup(func() { writeReplacement = original })
+	writeReplacement = func(name string, _ io.Reader, perm os.FileMode) (int64, error) {
 		require.NoError(t, os.WriteFile(name, []byte("half-written binary"), perm))
 		return 0, os.ErrPermission
 	}
@@ -114,4 +114,69 @@ func TestReplaceBinaryRollsBackWhenTheWriteIsRefused(t *testing.T) {
 	require.NoError(t, readErr)
 	assert.Equal(t, "old binary", string(content))
 	assert.Equal(t, 0, SweepPreserved(dir, "alpacon"), "a rolled-back replace must leave no preserved copy behind")
+}
+
+// The install path is resolved through EvalSymlinks before the download; a link
+// planted in the gap would send a root write wherever it points.
+func TestReplaceBinaryRefusesATargetThatBecameASymlink(t *testing.T) {
+	dir := t.TempDir()
+	victim := filepath.Join(dir, "victim")
+	require.NoError(t, os.WriteFile(victim, []byte("someone else's file"), 0600))
+	target := filepath.Join(dir, "alpacon")
+	require.NoError(t, os.Symlink(victim, target))
+	replacement := filepath.Join(dir, "alpacon.new")
+	require.NoError(t, os.WriteFile(replacement, []byte("new binary"), 0600))
+
+	original := writeReplacement
+	t.Cleanup(func() { writeReplacement = original })
+	writeReplacement = func(string, io.Reader, os.FileMode) (int64, error) {
+		t.Error("the write must not run against a symlinked target")
+		return 0, nil
+	}
+
+	err := ReplaceBinary(target, replacement)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "symlink")
+	content, readErr := os.ReadFile(victim)
+	require.NoError(t, readErr)
+	assert.Equal(t, "someone else's file", string(content))
+}
+
+// The file bits are clean here, and the binary is still swappable: replacing a
+// file is a rename, which needs permission on the directory and none on the file.
+func TestReplaceBinaryWarnsWhenTheInstallDirectoryIsTheWritableOne(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.Chmod(dir, 0775))
+	t.Cleanup(func() { _ = os.Chmod(dir, 0700) })
+	target := filepath.Join(dir, "alpacon")
+	require.NoError(t, os.WriteFile(target, []byte("old binary"), 0755))
+	replacement := filepath.Join(dir, "alpacon.new")
+	require.NoError(t, os.WriteFile(replacement, []byte("new binary"), 0600))
+
+	_, stderr := testutil.CaptureOutput(t, func() {
+		require.NoError(t, ReplaceBinary(target, replacement))
+	})
+
+	assert.Contains(t, stderr, dir)
+	assert.Contains(t, stderr, "needs no permission on the file itself")
+	info, err := os.Stat(dir)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0775), info.Mode().Perm(), "the warning replaces a chmod; it must not become one")
+}
+
+func TestReplaceBinaryStaysQuietOnAStickyWritableDirectory(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.Chmod(dir, os.ModeSticky|0777))
+	t.Cleanup(func() { _ = os.Chmod(dir, 0700) })
+	target := filepath.Join(dir, "alpacon")
+	require.NoError(t, os.WriteFile(target, []byte("old binary"), 0755))
+	replacement := filepath.Join(dir, "alpacon.new")
+	require.NoError(t, os.WriteFile(replacement, []byte("new binary"), 0600))
+
+	_, stderr := testutil.CaptureOutput(t, func() {
+		require.NoError(t, ReplaceBinary(target, replacement))
+	})
+
+	assert.Empty(t, stderr, "sticky stops a non-owner renaming over somebody else's file, so there is nothing to warn about")
 }

--- a/pkg/selfupdate/replace_windows.go
+++ b/pkg/selfupdate/replace_windows.go
@@ -1,0 +1,36 @@
+//go:build windows
+
+package selfupdate
+
+import (
+	"errors"
+	"os"
+	"time"
+)
+
+// ReplaceBinary renames the target aside instead of overwriting it: Windows
+// refuses to overwrite or delete a running executable but allows renaming it.
+// The copy runs first, so a Ctrl-C during it leaves the install path untouched.
+// The gap is between the two renames—the restore covers a second rename that
+// reports failure, but a process killed there leaves the install path empty with
+// only the preserved copy beside it. That copy is swept on the next update,
+// since it can stay locked for as long as this process lives.
+func ReplaceBinary(targetPath, newBinaryPath string) error {
+	now := time.Now()
+	stagedPath := StagedName(targetPath, now)
+	if err := copyFile(newBinaryPath, stagedPath); err != nil {
+		_ = os.Remove(stagedPath)
+		return err
+	}
+
+	preservedPath := PreservedName(targetPath, now)
+	if err := os.Rename(targetPath, preservedPath); err != nil {
+		_ = os.Remove(stagedPath)
+		return err
+	}
+	if err := os.Rename(stagedPath, targetPath); err != nil {
+		_ = os.Remove(stagedPath)
+		return errors.Join(err, RestorePreserved(preservedPath, targetPath))
+	}
+	return nil
+}

--- a/pkg/selfupdate/replace_windows.go
+++ b/pkg/selfupdate/replace_windows.go
@@ -12,24 +12,22 @@ import (
 // refuses to overwrite or delete a running executable but allows renaming it.
 // The copy runs first, so a Ctrl-C during it leaves the install path untouched.
 // The gap is between the two renames—the restore covers a second rename that
-// reports failure, but a process killed there leaves only
-// alpacon.exe.old.<timestamp>. Nothing recovers that: the binary that would run
-// the next update is the missing one, so README tells the operator to rename it
-// back by hand.
+// reports failure, but a process killed there leaves no executable and both
+// copies beside it. Nothing recovers that, since the binary that would run the
+// next update is the missing one, so README says which one to rename back.
 func ReplaceBinary(targetPath, newBinaryPath string) error {
 	now := time.Now()
 	stagedPath := StagedName(targetPath, now)
-	if err := copyFile(newBinaryPath, stagedPath); err != nil {
-		_ = os.Remove(stagedPath)
+	if err := copyFile(newBinaryPath, stagedPath); err != nil { // copyFile removes its own partial file, as the unix twin also relies on.
 		return err
 	}
 
 	preservedPath := PreservedName(targetPath, now)
-	if err := os.Rename(targetPath, preservedPath); err != nil {
+	if err := osRename(targetPath, preservedPath); err != nil {
 		_ = os.Remove(stagedPath)
 		return err
 	}
-	if err := os.Rename(stagedPath, targetPath); err != nil {
+	if err := osRename(stagedPath, targetPath); err != nil {
 		_ = os.Remove(stagedPath)
 		return errors.Join(err, RestorePreserved(preservedPath, targetPath))
 	}

--- a/pkg/selfupdate/replace_windows.go
+++ b/pkg/selfupdate/replace_windows.go
@@ -12,9 +12,10 @@ import (
 // refuses to overwrite or delete a running executable but allows renaming it.
 // The copy runs first, so a Ctrl-C during it leaves the install path untouched.
 // The gap is between the two renames—the restore covers a second rename that
-// reports failure, but a process killed there leaves the install path empty with
-// only the preserved copy beside it. That copy is swept on the next update,
-// since it can stay locked for as long as this process lives.
+// reports failure, but a process killed there leaves only
+// alpacon.exe.old.<timestamp>. Nothing recovers that: the binary that would run
+// the next update is the missing one, so README tells the operator to rename it
+// back by hand.
 func ReplaceBinary(targetPath, newBinaryPath string) error {
 	now := time.Now()
 	stagedPath := StagedName(targetPath, now)

--- a/pkg/selfupdate/replace_windows_test.go
+++ b/pkg/selfupdate/replace_windows_test.go
@@ -1,0 +1,53 @@
+//go:build windows
+
+package selfupdate
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReplaceBinaryInstallsTheNewBinary(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "alpacon.exe")
+	require.NoError(t, os.WriteFile(target, []byte("old binary"), 0755))
+	replacement := filepath.Join(dir, "alpacon.exe.new")
+	require.NoError(t, os.WriteFile(replacement, []byte("new binary"), 0600))
+
+	require.NoError(t, ReplaceBinary(target, replacement))
+
+	content, err := os.ReadFile(target)
+	require.NoError(t, err)
+	assert.Equal(t, "new binary", string(content))
+}
+
+func TestReplaceBinaryKeepsThePreservedCopyForTheNextSweep(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "alpacon.exe")
+	require.NoError(t, os.WriteFile(target, []byte("old binary"), 0755))
+	replacement := filepath.Join(dir, "alpacon.exe.new")
+	require.NoError(t, os.WriteFile(replacement, []byte("new binary"), 0600))
+
+	require.NoError(t, ReplaceBinary(target, replacement))
+
+	assert.Equal(t, 1, SweepPreserved(dir, "alpacon.exe"),
+		"the running executable stays locked, so its copy waits for the next update to sweep it—the staging copy was renamed into place and must not be among them")
+}
+
+func TestReplaceBinaryRestoresTheOldBinaryWhenTheSourceIsMissing(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "alpacon.exe")
+	require.NoError(t, os.WriteFile(target, []byte("old binary"), 0755))
+
+	err := ReplaceBinary(target, filepath.Join(dir, "does-not-exist"))
+
+	require.Error(t, err)
+	content, readErr := os.ReadFile(target)
+	require.NoError(t, readErr)
+	assert.Equal(t, "old binary", string(content), "a copy that never started must leave the install path alone")
+	assert.Equal(t, 0, SweepPreserved(dir, "alpacon.exe"), "nothing was moved aside, so nothing may be left behind")
+}

--- a/pkg/selfupdate/update.go
+++ b/pkg/selfupdate/update.go
@@ -1,0 +1,69 @@
+package selfupdate
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+var ErrWorkDirUnavailable = errors.New("cannot create the download directory") // Separates the download's scratch directory from the install path: both refuse with EACCES, and sudo answers only one of them.
+
+type Options struct {
+	ReleaseAPIURL  string
+	CurrentVersion string
+	GOOS           string
+	GOARCH         string
+	ExecutablePath string
+	Runner         CommandRunner
+}
+
+type Result struct {
+	Kind           InstallKind
+	Guidance       string
+	UpdatedTo      string
+	AlreadyCurrent bool
+}
+
+func Run(opts Options) (Result, error) {
+	release, err := LatestRelease(opts.ReleaseAPIURL)
+	if err != nil {
+		return Result{}, err
+	}
+	if !IsOutdated(opts.CurrentVersion, release.Version) {
+		return Result{AlreadyCurrent: true}, nil
+	}
+
+	kind := DetectInstallKind(opts.Runner, opts.ExecutablePath)
+	if kind != InstallManual {
+		return Result{Kind: kind, Guidance: UpgradeGuidance(kind)}, nil
+	}
+
+	// The lock comes after every question that needs no write. It lives in the
+	// install directory, which for a deb or an rpm belongs to root, so taking it
+	// first turned "run apt-get instead" into "not writable, re-run with sudo".
+	lock, err := AcquireLock(LockPath(opts.ExecutablePath))
+	if err != nil {
+		return Result{Kind: kind}, err
+	}
+	defer func() { _ = lock.Release() }()
+
+	installDir := filepath.Dir(opts.ExecutablePath)
+	binaryName := filepath.Base(opts.ExecutablePath)
+	SweepPreserved(installDir, binaryName)
+
+	workDir, err := os.MkdirTemp("", "alpacon-update-")
+	if err != nil {
+		return Result{Kind: kind}, fmt.Errorf("%w: %w", ErrWorkDirUnavailable, err)
+	}
+	defer func() { _ = os.RemoveAll(workDir) }()
+
+	newBinary, err := FetchVerifiedBinary(release, opts.GOOS, opts.GOARCH, BinaryName(opts.GOOS), workDir)
+	if err != nil {
+		return Result{Kind: kind}, err
+	}
+	if err := ReplaceBinary(opts.ExecutablePath, newBinary); err != nil {
+		return Result{Kind: kind}, err
+	}
+	return Result{Kind: kind, UpdatedTo: release.Version}, nil
+}

--- a/pkg/selfupdate/update.go
+++ b/pkg/selfupdate/update.go
@@ -19,7 +19,7 @@ type Options struct {
 	GOOS           string
 	GOARCH         string
 	ExecutablePath string
-	Runner         CommandRunner
+	Runner         CommandRunner // Defaults to ExecRunner: a zero value that skipped the ownership question would read as permission to overwrite.
 }
 
 type Result struct {
@@ -27,6 +27,24 @@ type Result struct {
 	Guidance       string
 	UpdatedTo      string
 	AlreadyCurrent bool
+}
+
+// Windows leaves the replaced executable behind on every update, and the run
+// that clears it is usually one with nothing to install—so waiting for the next
+// release can mean months. A refused lock is somebody else's install.
+func sweepIfPossible(executablePath string) {
+	installDir, binaryName := filepath.Dir(executablePath), filepath.Base(executablePath)
+	if !hasSweepableEntry(installDir, binaryName) { // The lock file stays behind, and an install another tool owns never has anything to sweep.
+		return
+	}
+
+	lock, err := AcquireLock(LockPath(executablePath))
+	if err != nil {
+		return
+	}
+	defer func() { _ = lock.Release() }()
+
+	SweepPreserved(installDir, binaryName)
 }
 
 func Run(opts Options) (Result, error) {
@@ -39,10 +57,19 @@ func Run(opts Options) (Result, error) {
 		return Result{}, err
 	}
 	if !IsOutdated(opts.CurrentVersion, release.Version) {
+		sweepIfPossible(opts.ExecutablePath)
 		return Result{AlreadyCurrent: true}, nil
 	}
 
-	kind := DetectInstallKind(opts.Runner, opts.ExecutablePath)
+	runner := opts.Runner
+	if runner == nil {
+		runner = ExecRunner
+	}
+
+	kind, err := DetectInstallKind(runner, opts.ExecutablePath)
+	if err != nil { // Not knowing is not permission: overwriting an rpm-owned binary leaves the database pointing at the version it replaced.
+		return Result{}, err
+	}
 	if kind != InstallManual {
 		return Result{Kind: kind, Guidance: UpgradeGuidance(kind)}, nil
 	}

--- a/pkg/selfupdate/update.go
+++ b/pkg/selfupdate/update.go
@@ -9,6 +9,10 @@ import (
 
 var ErrWorkDirUnavailable = errors.New("cannot create the download directory") // Separates the download's scratch directory from the install path: both refuse with EACCES, and sudo answers only one of them.
 
+// compareVersions reads an unparseable core as 0.0.0, so an importer that skips
+// IsUnknownVersion would have a dev build reinstall the latest release forever.
+var ErrUnknownVersion = errors.New("the running build's version matches no release")
+
 type Options struct {
 	ReleaseAPIURL  string
 	CurrentVersion string
@@ -26,6 +30,10 @@ type Result struct {
 }
 
 func Run(opts Options) (Result, error) {
+	if IsUnknownVersion(opts.CurrentVersion) {
+		return Result{}, fmt.Errorf("%w: %q", ErrUnknownVersion, opts.CurrentVersion)
+	}
+
 	release, err := LatestRelease(opts.ReleaseAPIURL)
 	if err != nil {
 		return Result{}, err

--- a/pkg/selfupdate/update_test.go
+++ b/pkg/selfupdate/update_test.go
@@ -1,0 +1,182 @@
+package selfupdate
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func updateFixture(t *testing.T, runner CommandRunner) (Options, string) {
+	t.Helper()
+
+	dir := t.TempDir()
+	_, release := releaseServer(t, dir, false)
+
+	installDir := t.TempDir()
+	executable := filepath.Join(installDir, "alpacon")
+	require.NoError(t, os.WriteFile(executable, []byte("old binary"), 0755))
+
+	api := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		payload := map[string]any{"tag_name": "v" + release.Version, "html_url": "https://example.test/notes"}
+		assets := make([]map[string]string, 0, len(release.Assets))
+		for _, asset := range release.Assets {
+			assets = append(assets, map[string]string{"name": asset.Name, "browser_download_url": asset.DownloadURL})
+		}
+		payload["assets"] = assets
+		_ = json.NewEncoder(w).Encode(payload)
+	}))
+	t.Cleanup(api.Close)
+
+	return Options{
+		ReleaseAPIURL:  api.URL,
+		CurrentVersion: "1.3.0",
+		GOOS:           "linux",
+		GOARCH:         "amd64",
+		ExecutablePath: executable,
+		Runner:         runner,
+	}, executable
+}
+
+func noOwnerRunner(name string, args ...string) ([]byte, error) {
+	return nil, errors.New("exit status 1")
+}
+
+func TestRunReplacesAManualInstall(t *testing.T) {
+	opts, executable := updateFixture(t, noOwnerRunner)
+
+	result, err := Run(opts)
+
+	require.NoError(t, err)
+	assert.Equal(t, InstallManual, result.Kind)
+	assert.Equal(t, "1.4.0", result.UpdatedTo)
+	content, readErr := os.ReadFile(executable)
+	require.NoError(t, readErr)
+	assert.Equal(t, "new binary", string(content))
+}
+
+func TestRunReleasesTheLockItTook(t *testing.T) {
+	opts, _ := updateFixture(t, noOwnerRunner)
+
+	_, err := Run(opts)
+	require.NoError(t, err)
+
+	lock, err := AcquireLock(LockPath(opts.ExecutablePath))
+	require.NoError(t, err, "a lock still held after Run returned would refuse every later update in this process")
+	require.NoError(t, lock.Release())
+}
+
+func debRunner(called *[]string) CommandRunner {
+	return func(name string, args ...string) ([]byte, error) {
+		*called = append(*called, name)
+		if name == "dpkg" {
+			return []byte("alpacon: /usr/local/bin/alpacon\n"), nil
+		}
+		return nil, errors.New("exit status 1")
+	}
+}
+
+func TestRunLeavesAPackageManagerInstallAlone(t *testing.T) {
+	var called []string
+	opts, executable := updateFixture(t, debRunner(&called))
+
+	result, err := Run(opts)
+
+	require.NoError(t, err)
+	assert.Equal(t, InstallDeb, result.Kind)
+	assert.Contains(t, result.Guidance, "sudo apt-get")
+	assert.Empty(t, result.UpdatedTo)
+	content, readErr := os.ReadFile(executable)
+	require.NoError(t, readErr)
+	assert.Equal(t, "old binary", string(content), "a package-manager install must not be replaced")
+	assert.NotContains(t, called, "sudo", "the CLI must never run sudo itself")
+	assert.NotContains(t, called, "apt-get", "the CLI must never run the package manager itself")
+}
+
+func TestRunStopsWhenTheRunningVersionIsNewest(t *testing.T) {
+	opts, executable := updateFixture(t, noOwnerRunner)
+	opts.CurrentVersion = "1.4.0"
+
+	result, err := Run(opts)
+
+	require.NoError(t, err)
+	assert.Equal(t, Result{AlreadyCurrent: true}, result)
+	content, readErr := os.ReadFile(executable)
+	require.NoError(t, readErr)
+	assert.Equal(t, "old binary", string(content))
+}
+
+func TestRunRefusesWhileAnotherUpdateHoldsTheLock(t *testing.T) {
+	opts, _ := updateFixture(t, noOwnerRunner)
+	held, err := AcquireLock(LockPath(opts.ExecutablePath))
+	require.NoError(t, err)
+	defer func() { _ = held.Release() }()
+
+	_, err = Run(opts)
+
+	assert.ErrorIs(t, err, ErrUpdateInProgress)
+}
+
+func TestRunSweepsWhatAnEarlierUpdateCouldNotDelete(t *testing.T) {
+	opts, executable := updateFixture(t, noOwnerRunner)
+	installDir := filepath.Dir(executable) // Windows leaves the running executable behind on every update, so this sweep is the only thing that ever removes it.
+	leftovers := []string{"alpacon.old.1735689600000000000", "alpacon.staged.1735689600000000000"}
+	for _, name := range leftovers {
+		require.NoError(t, os.WriteFile(filepath.Join(installDir, name), []byte("x"), 0600))
+	}
+
+	_, err := Run(opts)
+
+	require.NoError(t, err)
+	for _, name := range leftovers {
+		_, statErr := os.Stat(filepath.Join(installDir, name))
+		assert.ErrorIs(t, statErr, os.ErrNotExist, "an update must clear %s", name)
+	}
+}
+
+func TestRunNamesThePackageManagerEvenWhenItOwnsTheInstallDirectory(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("os.Chmod does not take the write bit off a Windows directory, so nothing here would be refused")
+	}
+	if os.Geteuid() == 0 {
+		t.Skip("root writes into a directory with no write bit, so the refusal this test needs never happens")
+	}
+
+	var called []string
+	opts, executable := updateFixture(t, debRunner(&called))
+	installDir := filepath.Dir(executable)
+	require.NoError(t, os.Chmod(installDir, 0500))
+	t.Cleanup(func() { _ = os.Chmod(installDir, 0700) })
+
+	result, err := Run(opts)
+
+	require.NoError(t, err, "the answer is apt-get, and reaching it must not require a writable install directory")
+	assert.Equal(t, InstallDeb, result.Kind)
+	assert.Contains(t, result.Guidance, "sudo apt-get")
+}
+
+func TestRunNamesTheTemporaryDirectoryWhenItCannotBeWritten(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("os.Chmod does not take the write bit off a Windows directory, so nothing here would be refused")
+	}
+	if os.Geteuid() == 0 {
+		t.Skip("root writes into a directory with no write bit, so the refusal this test needs never happens")
+	}
+
+	opts, _ := updateFixture(t, noOwnerRunner)
+	readOnly := filepath.Join(t.TempDir(), "tmp")
+	require.NoError(t, os.Mkdir(readOnly, 0500))
+	t.Setenv("TMPDIR", readOnly)
+
+	_, err := Run(opts)
+
+	require.ErrorIs(t, err, ErrWorkDirUnavailable)
+	assert.ErrorIs(t, err, os.ErrPermission)
+}

--- a/pkg/selfupdate/update_test.go
+++ b/pkg/selfupdate/update_test.go
@@ -1,8 +1,10 @@
 package selfupdate
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -18,7 +20,7 @@ func updateFixture(t *testing.T, runner CommandRunner) (Options, string) {
 	t.Helper()
 
 	dir := t.TempDir()
-	_, release := releaseServer(t, dir, false)
+	release := releaseServer(t, dir, false)
 
 	installDir := t.TempDir()
 	executable := filepath.Join(installDir, "alpacon")
@@ -117,7 +119,7 @@ func TestRunRefusesWhileAnotherUpdateHoldsTheLock(t *testing.T) {
 	opts, _ := updateFixture(t, noOwnerRunner)
 	held, err := AcquireLock(LockPath(opts.ExecutablePath))
 	require.NoError(t, err)
-	defer func() { _ = held.Release() }()
+	t.Cleanup(func() { _ = held.Release() })
 
 	_, err = Run(opts)
 
@@ -192,4 +194,63 @@ func TestRunRefusesABuildThatMatchesNoRelease(t *testing.T) {
 	content, readErr := os.ReadFile(executable)
 	require.NoError(t, readErr)
 	assert.Equal(t, "old binary", string(content))
+}
+
+// The run that clears a Windows leftover is usually one with nothing to install.
+func TestRunSweepsEvenWhenThereIsNothingToInstall(t *testing.T) {
+	opts, executable := updateFixture(t, noOwnerRunner)
+	opts.CurrentVersion = "1.4.0"
+	installDir := filepath.Dir(executable)
+	leftover := filepath.Join(installDir, "alpacon.old.1735689600000000000")
+	require.NoError(t, os.WriteFile(leftover, []byte("x"), 0600))
+
+	result, err := Run(opts)
+
+	require.NoError(t, err)
+	assert.Equal(t, Result{AlreadyCurrent: true}, result)
+	_, statErr := os.Stat(leftover)
+	assert.ErrorIs(t, statErr, os.ErrNotExist)
+}
+
+// Not knowing is not permission: overwriting an rpm-owned binary leaves the
+// database pointing at the version it replaced.
+func TestRunLeavesTheBinaryAloneWhenItCannotTellWhoOwnsIt(t *testing.T) {
+	stalled := func(name string, args ...string) ([]byte, error) {
+		return nil, fmt.Errorf("%w: %s: %w", ErrOwnerUnknown, name, context.DeadlineExceeded)
+	}
+	opts, executable := updateFixture(t, stalled)
+
+	_, err := Run(opts)
+
+	require.ErrorIs(t, err, ErrOwnerUnknown)
+	content, readErr := os.ReadFile(executable)
+	require.NoError(t, readErr)
+	assert.Equal(t, "old binary", string(content))
+}
+
+// The lock file outlives the run, and an install another tool owns never has
+// anything to sweep—so a run that finds nothing must leave the directory alone.
+func TestRunWritesNoLockFileWhenThereIsNothingToSweep(t *testing.T) {
+	opts, executable := updateFixture(t, noOwnerRunner)
+	opts.CurrentVersion = "1.4.0"
+
+	_, err := Run(opts)
+
+	require.NoError(t, err)
+	_, statErr := os.Stat(LockPath(executable))
+	assert.ErrorIs(t, statErr, os.ErrNotExist)
+}
+
+// Options.Runner has a zero value, and a caller who leaves it there must not
+// get "nobody owns it" for free—the real query answers instead.
+func TestRunAsksTheRealQueryWhenTheCallerSuppliedNone(t *testing.T) {
+	opts, executable := updateFixture(t, nil)
+
+	result, err := Run(opts)
+
+	require.NoError(t, err, "a nil runner must not surface as ErrOwnerUnknown")
+	assert.Equal(t, InstallManual, result.Kind, "no package owns a binary in a temp directory")
+	content, readErr := os.ReadFile(executable)
+	require.NoError(t, readErr)
+	assert.Equal(t, "new binary", string(content))
 }

--- a/pkg/selfupdate/update_test.go
+++ b/pkg/selfupdate/update_test.go
@@ -180,3 +180,16 @@ func TestRunNamesTheTemporaryDirectoryWhenItCannotBeWritten(t *testing.T) {
 	require.ErrorIs(t, err, ErrWorkDirUnavailable)
 	assert.ErrorIs(t, err, os.ErrPermission)
 }
+
+// The command guards this too, but the package is public and an importer may not.
+func TestRunRefusesABuildThatMatchesNoRelease(t *testing.T) {
+	opts, executable := updateFixture(t, noOwnerRunner)
+	opts.CurrentVersion = "dev"
+
+	_, err := Run(opts)
+
+	require.ErrorIs(t, err, ErrUnknownVersion)
+	content, readErr := os.ReadFile(executable)
+	require.NoError(t, readErr)
+	assert.Equal(t, "old binary", string(content))
+}

--- a/pkg/selfupdate/version.go
+++ b/pkg/selfupdate/version.go
@@ -1,6 +1,7 @@
 package selfupdate
 
 import (
+	"cmp"
 	"strconv"
 	"strings"
 
@@ -60,12 +61,12 @@ func compareVersions(a, b string) int {
 func comparePrerelease(a, b string) int { // Lexically, rc10 sorts below rc2, so an rc series would stop advancing at its tenth build.
 	aParts := strings.Split(a, ".")
 	bParts := strings.Split(b, ".")
-	for i := 0; i < len(aParts) && i < len(bParts); i++ {
+	for i := range min(len(aParts), len(bParts)) {
 		if order := compareIdentifier(aParts[i], bParts[i]); order != 0 {
 			return order
 		}
 	}
-	return compareInt(len(aParts), len(bParts))
+	return cmp.Compare(len(aParts), len(bParts))
 }
 
 func compareIdentifier(a, b string) int {
@@ -74,7 +75,7 @@ func compareIdentifier(a, b string) int {
 	if order := strings.Compare(aText, bText); order != 0 {
 		return order
 	}
-	return compareInt(aNumber, bNumber)
+	return cmp.Compare(aNumber, bNumber)
 }
 
 func splitTrailingNumber(identifier string) (string, int) {
@@ -89,21 +90,11 @@ func splitTrailingNumber(identifier string) (string, int) {
 	return identifier[:digits], number
 }
 
-func compareInt(a, b int) int {
-	switch {
-	case a < b:
-		return -1
-	case a > b:
-		return 1
-	}
-	return 0
-}
-
 func compareCore(a, b string) int {
 	aParts := strings.Split(a, ".")
 	bParts := strings.Split(b, ".")
-	for i := 0; i < len(aParts) || i < len(bParts); i++ {
-		if order := compareInt(numberAt(aParts, i), numberAt(bParts, i)); order != 0 {
+	for i := range max(len(aParts), len(bParts)) {
+		if order := cmp.Compare(numberAt(aParts, i), numberAt(bParts, i)); order != 0 {
 			return order
 		}
 	}

--- a/pkg/selfupdate/version.go
+++ b/pkg/selfupdate/version.go
@@ -1,0 +1,128 @@
+package selfupdate
+
+import (
+	"strconv"
+	"strings"
+
+	"github.com/alpacax/alpacon-cli/utils"
+)
+
+// IsUnknownVersion answers for a build this CLI cannot place against a release:
+// the literal dev build, and anything whose first part is not a number. Both
+// sort as 0.0.0—compareCore reads an unreadable part as zero—so without this
+// they would pull the latest release down on top of themselves on every run.
+func IsUnknownVersion(version string) bool {
+	if version == utils.DevVersion {
+		return true
+	}
+	core, _ := splitPrerelease(normalizeVersion(version))
+	first, _, _ := strings.Cut(core, ".")
+	_, err := strconv.Atoi(first)
+	return err != nil
+}
+
+// normalizeVersion drops the leading v a tag may carry. LatestRelease already
+// strips it from the release side, so leaving it on the running version would
+// make a build stamped v1.4.0 reinstall 1.4.0 every time it is asked.
+func normalizeVersion(version string) string {
+	return strings.TrimPrefix(version, "v")
+}
+
+// IsOutdated only ever moves forward. The release workflow publishes a
+// pre-release tag with --latest=false, so /releases/latest answers an rc build
+// with the previous stable release; treating any difference as outdated would
+// install that older binary and report it as an update.
+func IsOutdated(current, latest string) bool {
+	return compareVersions(current, latest) < 0
+}
+
+// A part that is not a number counts as zero, so a tag this CLI cannot read
+// compares equal rather than newer: the update declines instead of installing
+// something it could not place.
+func compareVersions(a, b string) int {
+	aCore, aPre := splitPrerelease(normalizeVersion(a))
+	bCore, bPre := splitPrerelease(normalizeVersion(b))
+	if order := compareCore(aCore, bCore); order != 0 {
+		return order
+	}
+
+	switch {
+	case aPre == bPre:
+		return 0
+	case aPre == "":
+		return 1
+	case bPre == "":
+		return -1
+	}
+	return comparePrerelease(aPre, bPre)
+}
+
+func comparePrerelease(a, b string) int { // Lexically, rc10 sorts below rc2, so an rc series would stop advancing at its tenth build.
+	aParts := strings.Split(a, ".")
+	bParts := strings.Split(b, ".")
+	for i := 0; i < len(aParts) && i < len(bParts); i++ {
+		if order := compareIdentifier(aParts[i], bParts[i]); order != 0 {
+			return order
+		}
+	}
+	return compareInt(len(aParts), len(bParts))
+}
+
+func compareIdentifier(a, b string) int {
+	aText, aNumber := splitTrailingNumber(a)
+	bText, bNumber := splitTrailingNumber(b)
+	if order := strings.Compare(aText, bText); order != 0 {
+		return order
+	}
+	return compareInt(aNumber, bNumber)
+}
+
+func splitTrailingNumber(identifier string) (string, int) {
+	digits := len(identifier)
+	for digits > 0 && identifier[digits-1] >= '0' && identifier[digits-1] <= '9' {
+		digits--
+	}
+	number, err := strconv.Atoi(identifier[digits:])
+	if err != nil {
+		return identifier, -1
+	}
+	return identifier[:digits], number
+}
+
+func compareInt(a, b int) int {
+	switch {
+	case a < b:
+		return -1
+	case a > b:
+		return 1
+	}
+	return 0
+}
+
+func compareCore(a, b string) int {
+	aParts := strings.Split(a, ".")
+	bParts := strings.Split(b, ".")
+	for i := 0; i < len(aParts) || i < len(bParts); i++ {
+		if order := compareInt(numberAt(aParts, i), numberAt(bParts, i)); order != 0 {
+			return order
+		}
+	}
+	return 0
+}
+
+func numberAt(parts []string, index int) int {
+	if index >= len(parts) {
+		return 0
+	}
+	number, err := strconv.Atoi(parts[index])
+	if err != nil || number < 0 {
+		return 0
+	}
+	return number
+}
+
+func splitPrerelease(version string) (string, string) {
+	version, _, _ = strings.Cut(version, "+")
+	core, prerelease, _ := strings.Cut(version, "-")
+	return core, prerelease
+}

--- a/pkg/selfupdate/version_test.go
+++ b/pkg/selfupdate/version_test.go
@@ -1,0 +1,61 @@
+package selfupdate
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsUnknownVersion(t *testing.T) {
+	tests := []struct {
+		name    string
+		version string
+		want    bool
+	}{
+		{name: "local build", version: "dev", want: true},
+		{name: "released build", version: "1.4.0", want: false},
+		{name: "a tag-shaped version is placeable", version: "v1.4.0", want: false},
+		{name: "empty version", version: "", want: true},
+		{name: "a version nothing can order", version: "nightly", want: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, IsUnknownVersion(tt.version))
+		})
+	}
+}
+
+func TestIsOutdatedIgnoresATagsLeadingV(t *testing.T) {
+	assert.False(t, IsOutdated("v1.4.0", "1.4.0"), "the release side is already stripped; a v on this side would reinstall the running release forever")
+	assert.True(t, IsOutdated("v1.4.0", "1.5.0"))
+}
+
+func TestIsOutdated(t *testing.T) {
+	tests := []struct {
+		name    string
+		current string
+		latest  string
+		want    bool
+	}{
+		{name: "same version", current: "1.4.0", latest: "1.4.0", want: false},
+		{name: "older version", current: "1.3.9", latest: "1.4.0", want: true},
+		{name: "a version ahead of the release is not outdated", current: "1.5.0", latest: "1.4.0", want: false},
+		{name: "an rc is not outdated by the stable release it follows", current: "1.5.0-rc1", latest: "1.4.0", want: false},
+		{name: "an rc is outdated by its own stable release", current: "1.5.0-rc1", latest: "1.5.0", want: true},
+		{name: "an rc is outdated by a later rc", current: "1.5.0-rc1", latest: "1.5.0-rc2", want: true},
+		{name: "an rc series keeps advancing past its tenth build", current: "1.5.0-rc2", latest: "1.5.0-rc10", want: true},
+		{name: "a later rc is not outdated by an earlier one", current: "1.5.0-rc10", latest: "1.5.0-rc2", want: false},
+		{name: "alpha is outdated by beta", current: "1.5.0-alpha.3", latest: "1.5.0-beta.1", want: true},
+		{name: "a stable release is not outdated by its own rc", current: "1.4.0", latest: "1.4.0-rc1", want: false},
+		{name: "fewer prerelease identifiers sort first", current: "1.5.0-rc", latest: "1.5.0-rc.1", want: true},
+		{name: "build metadata does not make a version outdated", current: "1.4.0+build7", latest: "1.4.0", want: false},
+		{name: "a shorter version compares as trailing zeros", current: "1.4", latest: "1.4.0", want: false},
+		{name: "a fourth part still counts", current: "1.2.3.4", latest: "1.2.3.9", want: true},
+		{name: "an unparsable version is outdated by any release", current: "dev", latest: "1.4.0", want: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, IsOutdated(tt.current, tt.latest))
+		})
+	}
+}

--- a/utils/error.go
+++ b/utils/error.go
@@ -104,6 +104,12 @@ const (
 	// PurposeRequiredStatus is the stable machine-readable status string emitted
 	// under --output json when a command is parked awaiting its purpose.
 	PurposeRequiredStatus = "purpose_required"
+
+	// ExitCodeUpdateAvailable is the process exit code for `alpacon update --check`
+	// finding a newer release. It is distinct from ExitCodeGeneralError (1): 1 means
+	// the check itself failed, 8 means the check succeeded and a newer version
+	// exists. Scripts and CI branch on it to schedule an update.
+	ExitCodeUpdateAvailable = 8
 )
 
 type ErrorResponse struct {

--- a/utils/file_save.go
+++ b/utils/file_save.go
@@ -19,8 +19,8 @@ const stagingPerm = 0600
 var replacementTempPattern = regexp.MustCompile(`^\.alpacon-\d+-\d+-\d+\.tmp$`)
 
 // IsReplacementTempName reports whether name is a createReplacementTempFile
-// staging file, which only a killed process leaves behind. A live write wears
-// the same name, so sweep one only while holding the directory's writer lock.
+// staging file. A write still in flight wears the same name and takes no lock
+// any sweeper can see, so a caller must age one out rather than trust a lock.
 func IsReplacementTempName(name string) bool {
 	return replacementTempPattern.MatchString(name)
 }

--- a/utils/file_save.go
+++ b/utils/file_save.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"time"
 )
@@ -14,6 +15,15 @@ import (
 // stagingPerm is the mode a replacement is written under, never a final mode:
 // it hides partial content from other local accounts until the write completes.
 const stagingPerm = 0600
+
+var replacementTempPattern = regexp.MustCompile(`^\.alpacon-\d+-\d+-\d+\.tmp$`)
+
+// IsReplacementTempName reports whether name is a createReplacementTempFile
+// staging file, which only a killed process leaves behind. A live write wears
+// the same name, so sweep one only while holding the directory's writer lock.
+func IsReplacementTempName(name string) bool {
+	return replacementTempPattern.MatchString(name)
+}
 
 func SaveFile(fileName string, data []byte) error {
 	_, err := saveStream(fileName, bytes.NewReader(data))

--- a/utils/version.go
+++ b/utils/version.go
@@ -1,6 +1,8 @@
 package utils
 
-var Version string = "dev"
+const DevVersion = "dev" // What Version carries when no -ldflags set it.
+
+var Version string = DevVersion
 
 func GetCLIVersion() string {
 	return Version


### PR DESCRIPTION
Closes #378.

`alpacon update` brings the CLI to the latest GitHub release. `alpacon update --check` reports whether one exists and installs nothing.

If a package manager or version manager installed the binary, that tool owns it: the command prints how to upgrade there and exits `1` without touching the file. Homebrew, deb, and rpm get the exact command; mise and asdf are named without one. Ownership is asked of `dpkg` and `rpm`, and the CLI never runs `sudo` or a package manager itself.

For a binary you placed yourself, the archive is downloaded, verified against the release's SHA-256 checksums, and only then does the running executable get replaced. On unix a temp file is renamed over the target, so a failure leaves the old binary intact. Windows forbids overwriting a running executable but allows renaming it, so the new binary is copied in and two renames follow, and the displaced copy stays as `alpacon.exe.old.<timestamp>`. A process killed between those renames leaves no `alpacon.exe`, and nothing recovers it on its own, because the binary that would run the next update is the missing one. The README says how to rename the preserved copy back.

The update holds `.alpacon-update.lock` beside the binary: `flock` on unix, `LockFileEx` on Windows. The kernel drops it however the process exits, so there is no staleness rule to get wrong.

## What the update trusts

Verification happens before extraction, and both asset URLs are pinned to the origins GitHub serves releases from, so an `http://` or off-GitHub URL is refused rather than fetched. Redirects past the first hop stay unpinned because the CDN host changes; the https requirement carries.

What that does not cover: the checksums come from the same release as the archive, and `.goreleaser.yaml` publishes no signature, so the hash proves the bytes arrived intact, not who published them. Signing the checksums and verifying against a pinned identity is follow-up work (#412). The README says `unsigned` plainly.

Extraction lets the archive decide nothing. `ExtractBinary` builds the destination itself and reads entry names only through `filepath.Base`, pinned by a test because a refactor that starts honoring the name would pass every other one. The bytes gzip inflates are bounded separately from the entry written and the archive downloaded.

Two things are deliberately left alone. A group- or world-writable binary keeps its mode and earns a warning rather than a `chmod`, since re-permissioning a file the operator set up is not the CLI's call. And a build whose version matches no release is refused inside `pkg/selfupdate` as well as in the command, because the package is public and an importer may skip the command's guard.

## Exit codes

`--check` adds exit code `8`, meaning a newer release exists; the README table and `--help` both state it. Everything else is the existing `0` and `1`. The branch first claimed `7`, which #410 took for `purpose_required` on main, so it was rebased and renumbered.

## Version handling

Comparison follows semver ordering including pre-releases, and only moves forward. The release workflow publishes pre-release tags with `--latest=false`, so `/releases/latest` answers an rc build with the previous stable release, and treating any difference as outdated would install that older binary and call it an update. A leading `v` is stripped from both sides, and a version this CLI cannot place, such as `dev`, is refused rather than compared.

## alpacon version

`alpacon version` shares the release lookup with the update path and names `alpacon update` in its notice, printing another tool's command where that tool owns the install. It does not query ownership, which would spawn `dpkg` and `rpm` on every call.

## CI

A `windows-latest` leg runs `./pkg/selfupdate/... ./cmd`. Replacing a running executable is the one thing only Windows forbids, so its build-tagged files compile nowhere else and would ship untested. The leg is scoped to those packages because the rest of the suite asserts unix file modes. `golangci-lint` runs for `linux` and `windows`.

The matrix job is `test`, and a `build-and-test` job that `needs` it reports the flat context an `alpacax` org ruleset requires on main. A matrix emits one context per leg, which left this PR waiting for a status that never arrived. An earlier round read main as unprotected because the repository protection endpoint answers 404; the rule lives in the org ruleset instead. `release.yaml` names a job in its own file and is unaffected.

## Follow-up

- Sign the release checksums (cosign keyless or minisign) and verify against an identity compiled into the binary rather than one the release names (#412). Until then the update is integrity-protected but not authenticated.
- Release metadata freshness. `LatestRelease` reads only `tag_name`, `html_url` and `assets`. There is no `published_at`, no ETag and no persisted last-seen version, so a pinned stale-but-newer response is undetectable. Fold this into #412 rather than opening another issue.
- Apply the same aggregator shape to `lint.yaml` so the flat `golangci-lint` context comes back. Harmless while the ruleset requires `build-and-test` alone, but it breaks silently the moment `golangci-lint` is added, and both main and alpamon emit the flat one.
- `README.md:75-82` fetches the archive and the checksums from the release the CLI would have used, so it re-checks transport integrity rather than the publisher question the paragraph above it raises. Reword it honestly, and add a PowerShell equivalent for the `.zip` Windows gets.
- `warnKeptWiderMode` and `keptModeIsWider` still cannot fire for a `0755` caller. `warnWorldWritableInstall` bypassed them rather than fixing them, so repair or delete them before someone assumes they work.
- A SIGKILL leaks `/tmp/alpacon-update-*` holding the archive, the checksums and the staged binary, and nothing sweeps that path. The install directory is handled by `SweepPreserved`.
- `replace_windows.go:31` removes the staged file before attempting the restore, so a failed restore leaves neither.
- Say in one line why `maxReleaseFileSize` and `maxArchiveStreamSize` are `var` rather than `const`, the way `DefaultReleaseAPIURL` does.
- The Windows rollback branch, where the second rename fails, has no test. `osRename` is a seam that makes one possible, but it cannot be watched failing from a non-Windows machine.
- The symlink defence narrows its window rather than closing it. Closing it needs a writer that opens `O_NOFOLLOW`, which `utils.SaveStreamAtomic` deliberately does not.
- Trim the impact framing in #412, which is a public issue, and keep the detail in the private repo.
- `README.md:321` cites an internal decision-record number a public reader cannot follow. Pre-existing, so a separate cleanup issue.
