### PR TITLE
ci: report the build job under the canonical build-and-test context

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -15,8 +15,9 @@ permissions:
   contents: read
 
 jobs:
+  # No `name:` on purpose. The check context is then the job id, which is the
+  # canonical single-segment `build-and-test` the other Go repos already emit.
   build-and-test:
-    name: Build and Test
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
## What

Drops `name: Build and Test` from the build job in `build-and-test.yaml`. The job id was already `build-and-test`; the name was overriding it, so the pull-request check context read `Build and Test`.

## Why

A check context is the exact string a branch rule names, so a rule can only cover several repositories if they all spell the check the same way. The other Go repositories in the fleet already emit a flat `build-and-test`; this one was the outlier by one line.

## Contexts

| | Before | After |
| --- | --- | --- |
| Pull request | `Build and Test` | `build-and-test` |
| Tag (`release.yaml` calls this workflow) | `build-and-test / Build and Test` | `build-and-test / build-and-test` |

`golangci-lint` and `govulncheck` are untouched and keep their own names. Nothing references the old job name: `release.yaml` depends on its own caller job of the same id, which does not change.

## Verification

- `actionlint` clean across all workflows in the repo.
- No `paths:` or `branches:` filter on the `pull_request` trigger, so the context reports on every pull request.