### PR TITLE
test: run independent tests in parallel and name table cases as subtests

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -154,7 +154,8 @@ _ = json.NewEncoder(w).Encode(resp)
 
 ### Test patterns
 
-- Table-driven tests with `testify/assert`
+- Table-driven tests with `testify/assert`. Every table loop runs each case under `t.Run` so a failure names the case and `-run 'TestX/case'` can select one
+- Every test calls `t.Parallel()` first unless it touches process-wide state or reads a package-level Cobra command. Process-wide state is `t.Setenv` (Go panics when a test calls both), an `os.Stdout`/`os.Stderr` swap including `testutil.CaptureOutput`, `utils.OutputFormat`, and any package-level seam a test reassigns (`runPresenceStepUp`, `approvalWaitPollInterval`, `maxGapWidth`). Cobra commands are out because `Commands()` and `Find()` sort and build flag sets lazily, so even a read-only test races with its neighbor. Serial tests run to completion before the parallel ones start, so a serial test may reassign a global as long as it restores it
 - API tests use `httptest.NewServer` with a minimal `*client.AlpaconClient` pointing at `ts.URL`
 - Command logic is extracted to unexported helpers (e.g., `parseExecArgs`) for direct unit testing
 

--- a/api/approval/approval_test.go
+++ b/api/approval/approval_test.go
@@ -22,6 +22,7 @@ func newTestClient(ts *httptest.Server) *client.AlpaconClient {
 }
 
 func TestListApprovalRequests(t *testing.T) {
+	t.Parallel()
 	now := time.Now().UTC().Truncate(time.Second)
 	requests := []ApprovalRequest{
 		{
@@ -50,6 +51,7 @@ func TestListApprovalRequests(t *testing.T) {
 }
 
 func TestListApprovalRequests_TypeFilter(t *testing.T) {
+	t.Parallel()
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "sudo", r.URL.Query().Get("request_type"))
 		w.Header().Set("Content-Type", "application/json")
@@ -62,6 +64,7 @@ func TestListApprovalRequests_TypeFilter(t *testing.T) {
 }
 
 func TestListMyApprovalRequests(t *testing.T) {
+	t.Parallel()
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "/api/approvals/approvals/-/", r.URL.Path)
 		w.Header().Set("Content-Type", "application/json")
@@ -74,6 +77,7 @@ func TestListMyApprovalRequests(t *testing.T) {
 }
 
 func TestGetApprovalRequest(t *testing.T) {
+	t.Parallel()
 	now := time.Now().UTC().Truncate(time.Second)
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.True(t, strings.HasSuffix(r.URL.Path, "apr-abc/"))
@@ -91,6 +95,7 @@ func TestGetApprovalRequest(t *testing.T) {
 }
 
 func TestCancelRequest(t *testing.T) {
+	t.Parallel()
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodPost, r.Method)
 		assert.True(t, strings.HasSuffix(r.URL.Path, "apr-abc/cancel/"))
@@ -103,6 +108,7 @@ func TestCancelRequest(t *testing.T) {
 }
 
 func TestCancelRequest_403PropagatesError(t *testing.T) {
+	t.Parallel()
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusForbidden)

--- a/api/audit/audit_test.go
+++ b/api/audit/audit_test.go
@@ -16,6 +16,7 @@ import (
 
 // Regression for #274: a cursor-token next crashed the old int-typed unmarshal.
 func TestGetAuditLogList_FollowsCursor(t *testing.T) {
+	t.Parallel()
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		if r.URL.Query().Get("cursor") == "" {
@@ -39,6 +40,7 @@ func TestGetAuditLogList_FollowsCursor(t *testing.T) {
 }
 
 func TestGetAuditLogList_Filters(t *testing.T) {
+	t.Parallel()
 	var gotQuery url.Values
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")

--- a/api/auth/auth_test.go
+++ b/api/auth/auth_test.go
@@ -119,6 +119,7 @@ func assertSavedTarget(t *testing.T, wantURL, wantName, wantBaseDomain, wantToke
 }
 
 func TestGetAPITokenList_Pagination(t *testing.T) {
+	t.Parallel()
 	var requestCount atomic.Int32
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -187,6 +188,7 @@ func TestGetAPITokenList_Pagination(t *testing.T) {
 }
 
 func TestGetAPITokenIDByName(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name      string
 		tokenName string
@@ -231,6 +233,7 @@ func TestGetAPITokenIDByName(t *testing.T) {
 }
 
 func TestResolveTokenID(t *testing.T) {
+	t.Parallel()
 	const (
 		validUUID = "550e8400-e29b-41d4-a716-446655440000"
 		tokenName = "ci-token"
@@ -288,6 +291,7 @@ func TestResolveTokenID(t *testing.T) {
 }
 
 func TestCreateAPIToken(t *testing.T) {
+	t.Parallel()
 	const wantKey = "secret-api-key-xyz"
 
 	tests := []struct {
@@ -354,6 +358,7 @@ func TestCreateAPIToken(t *testing.T) {
 }
 
 func TestDeleteAPIToken(t *testing.T) {
+	t.Parallel()
 	var deleteCalled bool
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -375,6 +380,7 @@ func TestDeleteAPIToken(t *testing.T) {
 }
 
 func TestDuplicateAPIToken(t *testing.T) {
+	t.Parallel()
 	const wantKey = "duplicated-token-key-xyz"
 
 	tests := []struct {
@@ -431,6 +437,7 @@ func TestDuplicateAPIToken(t *testing.T) {
 }
 
 func TestGetTokenScopes(t *testing.T) {
+	t.Parallel()
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet {
 			t.Errorf("expected GET, got %s", r.Method)
@@ -479,6 +486,7 @@ func TestGetTokenScopes(t *testing.T) {
 }
 
 func TestGetWhoamiApplicationPrincipal(t *testing.T) {
+	t.Parallel()
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != whoamiURL {
 			t.Errorf("unexpected path %q", r.URL.Path)
@@ -512,6 +520,7 @@ func TestGetWhoamiApplicationPrincipal(t *testing.T) {
 }
 
 func TestGetWhoamiUserPrincipal(t *testing.T) {
+	t.Parallel()
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{
@@ -536,6 +545,7 @@ func TestGetWhoamiUserPrincipal(t *testing.T) {
 }
 
 func TestGetWhoamiEmptyPrincipalTypeFailsClosed(t *testing.T) {
+	t.Parallel()
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{}`))

--- a/api/auth0/auth0_test.go
+++ b/api/auth0/auth0_test.go
@@ -45,6 +45,7 @@ type refreshServer struct {
 }
 
 func TestAppendDeviceScope(t *testing.T) {
+	t.Parallel()
 	const base = "openid profile email offline_access cli org:myws"
 
 	tests := []struct {
@@ -92,6 +93,7 @@ func TestAppendDeviceScope(t *testing.T) {
 }
 
 func TestDeviceCodeScope(t *testing.T) {
+	t.Parallel()
 	assert.Equal(t,
 		"openid profile email offline_access cli org:myws device:"+testDeviceID,
 		deviceCodeScope("myws", testDeviceID),
@@ -103,6 +105,7 @@ func TestDeviceCodeScope(t *testing.T) {
 }
 
 func TestRefreshScope(t *testing.T) {
+	t.Parallel()
 	assert.Equal(t, "cli org:myws device:"+testDeviceID, refreshScope("myws", testDeviceID))
 	assert.Equal(t, "cli org:myws", refreshScope("myws", ""))
 }
@@ -118,6 +121,7 @@ func TestCurrentDeviceID_StableAcrossCalls(t *testing.T) {
 }
 
 func TestResolveOrgName(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		envInfo  *AuthEnvResponse
@@ -164,6 +168,7 @@ func TestResolveOrgName(t *testing.T) {
 }
 
 func TestFetchAuthEnv(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name             string
 		responseBody     string
@@ -219,6 +224,7 @@ func TestFetchAuthEnv(t *testing.T) {
 }
 
 func TestExtractSubdomain(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name      string
 		url       string

--- a/api/cert/cert_test.go
+++ b/api/cert/cert_test.go
@@ -25,6 +25,7 @@ func newTestClient(server *httptest.Server) *client.AlpaconClient {
 }
 
 func TestGetCSRList_Pagination(t *testing.T) {
+	t.Parallel()
 	var requestCount atomic.Int32
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -97,6 +98,7 @@ func TestGetCSRList_Pagination(t *testing.T) {
 }
 
 func TestGetAuthorityIDByName(t *testing.T) {
+	t.Parallel()
 	authorities := []AuthorityResponse{
 		{ID: "aaaa-0000-0000-0000-000000000001", Name: "Root CA"},
 		{ID: "aaaa-0000-0000-0000-000000000002", Name: "Intermediate CA"},
@@ -142,6 +144,7 @@ func TestGetAuthorityIDByName(t *testing.T) {
 }
 
 func TestGetAuthorityList_Pagination(t *testing.T) {
+	t.Parallel()
 	var requestCount atomic.Int32
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -212,6 +215,7 @@ func TestGetAuthorityList_Pagination(t *testing.T) {
 }
 
 func TestGetCertificateList_Pagination(t *testing.T) {
+	t.Parallel()
 	var requestCount atomic.Int32
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -280,6 +284,7 @@ func TestGetCertificateList_Pagination(t *testing.T) {
 }
 
 func TestCreateSignRequest(t *testing.T) {
+	t.Parallel()
 	expectedResponse := SignRequestResponse{
 		ID:         "new-csr-id",
 		CommonName: "example.com",
@@ -315,6 +320,7 @@ func TestCreateSignRequest(t *testing.T) {
 }
 
 func TestSubmitCSR(t *testing.T) {
+	t.Parallel()
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodPatch, r.Method)
 
@@ -336,6 +342,7 @@ func TestSubmitCSR(t *testing.T) {
 }
 
 func TestApproveCSR(t *testing.T) {
+	t.Parallel()
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodPost, r.Method)
 		assert.Contains(t, r.URL.Path, "approve")
@@ -352,6 +359,7 @@ func TestApproveCSR(t *testing.T) {
 }
 
 func TestDenyCSR(t *testing.T) {
+	t.Parallel()
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodPost, r.Method)
 		assert.Contains(t, r.URL.Path, "deny")
@@ -368,6 +376,7 @@ func TestDenyCSR(t *testing.T) {
 }
 
 func TestDeleteCSR(t *testing.T) {
+	t.Parallel()
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodDelete, r.Method)
 		w.WriteHeader(http.StatusNoContent)
@@ -380,6 +389,7 @@ func TestDeleteCSR(t *testing.T) {
 }
 
 func TestDownloadCertificateByCSR(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name        string
 		response    SignRequestDetail
@@ -478,6 +488,7 @@ func TestDownloadCertificateByCSR(t *testing.T) {
 }
 
 func TestDownloadCertificateByCSR_APIError(t *testing.T) {
+	t.Parallel()
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusNotFound)
@@ -495,6 +506,7 @@ func TestDownloadCertificateByCSR_APIError(t *testing.T) {
 }
 
 func TestDownloadCertificateByCSR_InvalidJSON(t *testing.T) {
+	t.Parallel()
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
@@ -511,6 +523,7 @@ func TestDownloadCertificateByCSR_InvalidJSON(t *testing.T) {
 }
 
 func TestDownloadCertificate(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name        string
 		response    Certificate

--- a/api/config_boundary_test.go
+++ b/api/config_boundary_test.go
@@ -29,6 +29,7 @@ var configReaders = map[string]bool{
 // here can name a workspace the request is no longer going to (issue #401). It
 // walks the AST, so a comment naming config.LoadConfig is not one and an alias is.
 func TestAPILayerNeverReadsConfig(t *testing.T) {
+	t.Parallel()
 	var offenders []string
 
 	err := filepath.WalkDir(".", func(path string, d fs.DirEntry, err error) error {

--- a/api/event/chunks_test.go
+++ b/api/event/chunks_test.go
@@ -15,6 +15,7 @@ import (
 )
 
 func TestGetCommandChunks_PassesSeqGteAndReturnsResults(t *testing.T) {
+	t.Parallel()
 	cmdID := "a1b2c3d4-1234-5678-abcd-000000000000"
 	var capturedQuery string
 
@@ -52,6 +53,7 @@ func TestGetCommandChunks_PassesSeqGteAndReturnsResults(t *testing.T) {
 // TestGetCommandOutput_ConcatenatesChunksInSeqOrder verifies the full output is
 // reconstructed from chunks in seq order regardless of server ordering.
 func TestGetCommandOutput_ConcatenatesChunksInSeqOrder(t *testing.T) {
+	t.Parallel()
 	cmdID := "a1b2c3d4-1234-5678-abcd-000000000000"
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -78,6 +80,7 @@ func TestGetCommandOutput_ConcatenatesChunksInSeqOrder(t *testing.T) {
 // TestGetCommandChunks_SortsBySeq verifies out-of-order server results are
 // returned sorted by seq.
 func TestGetCommandChunks_SortsBySeq(t *testing.T) {
+	t.Parallel()
 	cmdID := "a1b2c3d4-1234-5678-abcd-000000000000"
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -108,6 +111,7 @@ func TestGetCommandChunks_SortsBySeq(t *testing.T) {
 // TestGetCommandChunks_SendsSeqLteWhenBounded verifies a non-negative toSeq is
 // sent as the seq__lte upper bound.
 func TestGetCommandChunks_SendsSeqLteWhenBounded(t *testing.T) {
+	t.Parallel()
 	cmdID := "a1b2c3d4-1234-5678-abcd-000000000000"
 	tests := []struct {
 		name    string

--- a/api/event/commandoutput_listener_test.go
+++ b/api/event/commandoutput_listener_test.go
@@ -14,6 +14,7 @@ import (
 )
 
 func TestCommandOutputListener_HandleMessage_FiltersAndEmits(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name      string
 		payload   string
@@ -65,6 +66,7 @@ func TestCommandOutputListener_HandleMessage_FiltersAndEmits(t *testing.T) {
 
 // The fin subscription targets the server, so every command on it reports here.
 func TestCommandOutputListener_HandleMessage_FinishedIsPerCommand(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name         string
 		payload      string
@@ -106,6 +108,7 @@ func TestCommandOutputListener_HandleMessage_FinishedIsPerCommand(t *testing.T) 
 }
 
 func TestCommandOutputListener_Start_DeliversChunks(t *testing.T) {
+	t.Parallel()
 	cmdID := "cmd-uuid"
 
 	ts, _, _ := newWatcherTestServer(t, alwaysCreated, alwaysUpgrade, alwaysCreated, func(conn *websocket.Conn, _ int32) {
@@ -155,6 +158,7 @@ func TestCommandOutputListener_Start_DeliversChunks(t *testing.T) {
 }
 
 func TestCommandOutputListener_Reconnects(t *testing.T) {
+	t.Parallel()
 	cmdID := "cmd-uuid"
 
 	ts, sessions, _ := newWatcherTestServer(t, alwaysCreated, alwaysUpgrade, alwaysCreated, func(conn *websocket.Conn, n int32) {
@@ -201,6 +205,7 @@ func TestCommandOutputListener_Reconnects(t *testing.T) {
 }
 
 func TestCommandOutputListener_CreatesANewSessionAndResubscribesOnReconnect(t *testing.T) {
+	t.Parallel()
 	ts, sessions, subscribes := newWatcherTestServer(t, alwaysCreated, alwaysUpgrade, alwaysCreated, func(conn *websocket.Conn, n int32) {
 		if n == 1 {
 			// The token is single-use, so recovering means a whole new session.
@@ -229,6 +234,7 @@ func TestCommandOutputListener_CreatesANewSessionAndResubscribesOnReconnect(t *t
 }
 
 func TestCommandOutputListener_FirstConnectSubscribesToNothing(t *testing.T) {
+	t.Parallel()
 	ts, _, subscribes := newWatcherTestServer(t, alwaysCreated, alwaysUpgrade, alwaysCreated, func(conn *websocket.Conn, _ int32) {
 		for {
 			if _, _, err := conn.ReadMessage(); err != nil {
@@ -247,6 +253,7 @@ func TestCommandOutputListener_FirstConnectSubscribesToNothing(t *testing.T) {
 }
 
 func TestCommandOutputListener_SurfacesAFatalSessionFailure(t *testing.T) {
+	t.Parallel()
 	ts, _, _ := newWatcherTestServer(t, alwaysRejected, alwaysUpgrade, alwaysCreated, func(conn *websocket.Conn, _ int32) {})
 
 	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
@@ -264,10 +271,12 @@ func TestCommandOutputListener_SurfacesAFatalSessionFailure(t *testing.T) {
 }
 
 func TestListenerFailureFallsBackToTheConnectBudget(t *testing.T) {
+	t.Parallel()
 	assert.Contains(t, listenerFailure(NewCommandOutputListener(nil)).Error(), "connect timeout")
 }
 
 func TestCommandOutputListener_KeepsRetryingAfterTheFirstSubscribe(t *testing.T) {
+	t.Parallel()
 	rejectSecond := func(attempt int32) int {
 		if attempt == 2 {
 			return http.StatusUnauthorized
@@ -307,6 +316,7 @@ func TestCommandOutputListener_KeepsRetryingAfterTheFirstSubscribe(t *testing.T)
 }
 
 func TestCommandOutputListener_SubscribeFailsOnAStoppedListener(t *testing.T) {
+	t.Parallel()
 	ts, _, _ := newWatcherTestServer(t, alwaysCreated, alwaysUpgrade, alwaysCreated, func(conn *websocket.Conn, _ int32) {})
 
 	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
@@ -319,6 +329,7 @@ func TestCommandOutputListener_SubscribeFailsOnAStoppedListener(t *testing.T) {
 }
 
 func TestCommandOutputListener_SubscribeCarriesWhyTheListenerStopped(t *testing.T) {
+	t.Parallel()
 	ts, _, _ := newWatcherTestServer(t, alwaysCreated, alwaysUpgrade, alwaysCreated, func(conn *websocket.Conn, _ int32) {})
 
 	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
@@ -336,6 +347,7 @@ func TestCommandOutputListener_SubscribeCarriesWhyTheListenerStopped(t *testing.
 }
 
 func TestCommandOutputListener_SubscribeFailsWhenTheListenerStopsMidSubscription(t *testing.T) {
+	t.Parallel()
 	var l *CommandOutputListener
 	// Stop lands while SubscribeEvent is in flight, which is the window a single check
 	// before the request cannot see.

--- a/api/event/event_test.go
+++ b/api/event/event_test.go
@@ -29,6 +29,7 @@ import (
 // GetEventList is that tail reaches the helper as its limit, so a tail larger than the
 // server's 100-item page cap still yields exactly tail commands.
 func TestGetEventList_PassesTailAsTheLimit(t *testing.T) {
+	t.Parallel()
 	// Twice the pages the tail needs, so a walk that ignored the limit comes back with 500
 	// and fails the length assertion instead of running until the test timeout.
 	const lastPage = 5
@@ -65,6 +66,7 @@ func TestGetEventList_PassesTailAsTheLimit(t *testing.T) {
 // The --server and --user filters are path segments, not query params, so a broken join
 // does not fail the request—it returns every command as if no filter had been given.
 func TestGetEventList_PutsTheResolvedFilterIDsInThePath(t *testing.T) {
+	t.Parallel()
 	// Mirrors the lookup endpoints of api/server and api/iam, whose consts are unexported.
 	const (
 		serverLookupURL = "/api/servers/servers/"
@@ -128,6 +130,7 @@ func TestGetEventList_PutsTheResolvedFilterIDsInThePath(t *testing.T) {
 }
 
 func TestPollCommandExecution(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name           string
 		statusSequence []string
@@ -268,6 +271,7 @@ func newRunCommandBodyCaptureServer(t *testing.T, capture *runCommandBodyCapture
 }
 
 func TestSubmitCommand_BodyIncludesWorkSession_WhenSet(t *testing.T) {
+	t.Parallel()
 	var capture runCommandBodyCapture
 	ts := newRunCommandBodyCaptureServer(t, &capture)
 	defer ts.Close()
@@ -283,6 +287,7 @@ func TestSubmitCommand_BodyIncludesWorkSession_WhenSet(t *testing.T) {
 }
 
 func TestSubmitCommand_BodyOmitsWorkSession_WhenEmpty(t *testing.T) {
+	t.Parallel()
 	var capture runCommandBodyCapture
 	ts := newRunCommandBodyCaptureServer(t, &capture)
 	defer ts.Close()
@@ -297,6 +302,7 @@ func TestSubmitCommand_BodyOmitsWorkSession_WhenEmpty(t *testing.T) {
 }
 
 func TestErrorFromDetails_PropagatesExitCode(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name           string
 		respSuccess    *bool
@@ -364,6 +370,7 @@ func TestErrorFromDetails_PropagatesExitCode(t *testing.T) {
 }
 
 func TestErrorFromDetails_AwaitingApprovalReturnsPendingApprovalError(t *testing.T) {
+	t.Parallel()
 	err := errorFromDetails(EventDetails{ID: "cmd-9", Status: "awaiting_approval"})
 	var pending *PendingApprovalError
 	require.ErrorAs(t, err, &pending)
@@ -371,6 +378,7 @@ func TestErrorFromDetails_AwaitingApprovalReturnsPendingApprovalError(t *testing
 }
 
 func TestErrorFromDetails_RejectedReturnsCommandRejectedError(t *testing.T) {
+	t.Parallel()
 	err := errorFromDetails(EventDetails{ID: "cmd-9", Status: "rejected"})
 	var rejected *CommandRejectedError
 	require.ErrorAs(t, err, &rejected)
@@ -378,6 +386,7 @@ func TestErrorFromDetails_RejectedReturnsCommandRejectedError(t *testing.T) {
 }
 
 func TestPollCommandExecution_WaitApprovalResumesAfterApproval(t *testing.T) {
+	t.Parallel()
 	// awaiting_approval, then the transient "error" the server emits in the
 	// approve→deliver window, then completed: waitApproval must poll through both.
 	seq := []string{"awaiting_approval", "awaiting_approval", "error", "completed"}
@@ -399,6 +408,7 @@ func TestPollCommandExecution_WaitApprovalResumesAfterApproval(t *testing.T) {
 }
 
 func TestStreamApprovedCommand_StreamsAfterApproval(t *testing.T) {
+	t.Parallel()
 	stdoutBuf := &bytes.Buffer{}
 	var mu sync.Mutex
 	var subscriptions [][2]string
@@ -433,6 +443,7 @@ func TestStreamApprovedCommand_StreamsAfterApproval(t *testing.T) {
 // The fin subscription needs the server the command ran on, which only a read of
 // the command names. A failed read costs the run its fin event, not the run.
 func TestStreamApprovedCommand_ServerLookupFailureSkipsFinSubscription(t *testing.T) {
+	t.Parallel()
 	stdoutBuf := &bytes.Buffer{}
 	var mu sync.Mutex
 	var subscriptions [][2]string
@@ -465,6 +476,7 @@ func intPtr(i int) *int       { return &i }
 func strPtr(s string) *string { return &s }
 
 func TestPollCommandExecution_ClientTimeout(t *testing.T) {
+	t.Parallel()
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Always fail GETs so SendGetRequest returns an error, and with a status
 		// that is not 429 so the poll loop never extends its deadline.
@@ -522,6 +534,7 @@ func fakePollClock() (pollSeams, func() []time.Duration) {
 
 // A throttled poll must space its requests out instead of spending one per tick.
 func TestPollCommandExecution_ThrottleBacksOff(t *testing.T) {
+	t.Parallel()
 	tick := 10 * time.Millisecond
 	tests := []struct {
 		name       string
@@ -558,6 +571,7 @@ func TestPollCommandExecution_ThrottleBacksOff(t *testing.T) {
 // A 429 must not starve the deadline: the command may already have finished,
 // with only its result GET throttled.
 func TestPollCommandExecution_ThrottleDoesNotStarveDeadline(t *testing.T) {
+	t.Parallel()
 	ts, reqCount := throttleServer(t, 1, "1")
 	defer ts.Close()
 
@@ -577,6 +591,7 @@ func TestPollCommandExecution_ThrottleDoesNotStarveDeadline(t *testing.T) {
 // Extending the deadline by exactly the wait keeps it ahead of the clock forever,
 // so the extension is capped: a token stuck over quota has to give up.
 func TestPollCommandExecution_ThrottleExtensionIsBoundedByDuration(t *testing.T) {
+	t.Parallel()
 	ts, reqCount := throttleServer(t, math.MaxInt, "1")
 	defer ts.Close()
 
@@ -597,6 +612,7 @@ func TestPollCommandExecution_ThrottleExtensionIsBoundedByDuration(t *testing.T)
 // A duration budget alone is spent at the server's pace, so short mandated waits
 // would trade the whole extension for a request storm.
 func TestPollCommandExecution_ThrottleExtensionIsBoundedByCount(t *testing.T) {
+	t.Parallel()
 	ts, _ := throttleServer(t, math.MaxInt, "1")
 	defer ts.Close()
 
@@ -625,6 +641,7 @@ func TestPollCommandExecution_ThrottleExtensionIsBoundedByCount(t *testing.T) {
 // with it: a throttle late in a long command must not be refused an extension
 // because an unrelated one early on spent the budget.
 func TestPollCommandExecution_ProgressRestoresThrottleAllowance(t *testing.T) {
+	t.Parallel()
 	reqCount := &atomic.Int32{}
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
@@ -656,6 +673,7 @@ func TestPollCommandExecution_ProgressRestoresThrottleAllowance(t *testing.T) {
 // The count belongs to the deadline it protects: held across a refresh, one early
 // stretch would leave a long command no grants for the next.
 func TestPollCommandExecution_ProgressRestoresThrottleExtensions(t *testing.T) {
+	t.Parallel()
 	const tick = 100 * time.Microsecond
 	// One timeout is worth exactly one round of capped grants, so a second round is
 	// only reachable through the reset.
@@ -694,6 +712,7 @@ func TestPollCommandExecution_ProgressRestoresThrottleExtensions(t *testing.T) {
 // The loop paces by how long the poll has been running, not by the gap since the
 // last poll—measured the latter way a command never leaves the fast window.
 func TestPollCommandExecution_PacingWidensWithPollAge(t *testing.T) {
+	t.Parallel()
 	tick := 10 * time.Millisecond
 	// The 21st request answers terminal, so the reply that earns the slow tick is
 	// still polled for.
@@ -724,6 +743,7 @@ func TestPollCommandExecution_PacingWidensWithPollAge(t *testing.T) {
 }
 
 func TestPollCommandExecution_TerminalStatusReturnsBeforeTimeout(t *testing.T) {
+	t.Parallel()
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(EventDetails{ID: "cmd-1", Status: "completed"})
@@ -737,6 +757,7 @@ func TestPollCommandExecution_TerminalStatusReturnsBeforeTimeout(t *testing.T) {
 }
 
 func TestSubmitCommand_ReturnsJobID(t *testing.T) {
+	t.Parallel()
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/api/servers/servers/"):
@@ -761,6 +782,7 @@ func TestSubmitCommand_ReturnsJobID(t *testing.T) {
 }
 
 func TestGetCommandByID_ReturnsEventDetails(t *testing.T) {
+	t.Parallel()
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/api/events/commands/") {
 			w.Header().Set("Content-Type", "application/json")
@@ -784,6 +806,7 @@ func TestGetCommandByID_ReturnsEventDetails(t *testing.T) {
 }
 
 func TestGetCommandByID_PropagatesError(t *testing.T) {
+	t.Parallel()
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "server error", http.StatusInternalServerError)
 	}))
@@ -810,6 +833,7 @@ func TestExecTimeout_InvalidEnvFallsBackToDefault(t *testing.T) {
 }
 
 func TestSubmitCommand_401WithDetailSurfacesServerReason(t *testing.T) {
+	t.Parallel()
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/api/servers/servers/"):
@@ -838,6 +862,7 @@ func TestSubmitCommand_401WithDetailSurfacesServerReason(t *testing.T) {
 }
 
 func TestRunCommandStreaming_NormalFlow(t *testing.T) {
+	t.Parallel()
 	stdoutBuf := &bytes.Buffer{}
 	ac := newStreamingServers(t, streamingServerConfig{
 		cmdID:        "cmd-uuid",
@@ -884,6 +909,7 @@ func awaitStream(t *testing.T, done <-chan error) error {
 // a finished command—a tick away at best, ten once it is a minute old. The tick here
 // is longer than the test can run, so nothing but the fin event can end this one.
 func TestStreamSubscribed_FinEndsRunWithoutThePoll(t *testing.T) {
+	t.Parallel()
 	stdoutBuf := &bytes.Buffer{}
 	var mu sync.Mutex
 	var subscriptions [][2]string
@@ -915,6 +941,7 @@ func TestStreamSubscribed_FinEndsRunWithoutThePoll(t *testing.T) {
 // on requesting a command that is already over—spending the throttle budget this
 // pacing exists to protect, and outliving the process's other streams.
 func TestStreamSubscribed_FinCancelsThePoll(t *testing.T) {
+	t.Parallel()
 	tick := 20 * time.Millisecond
 	details := &atomic.Int32{}
 	ac := newStreamingServers(t, streamingServerConfig{
@@ -936,6 +963,7 @@ func TestStreamSubscribed_FinCancelsThePoll(t *testing.T) {
 // The fin channel is the command's server, which on this path only the submit
 // response names—the command's own id would subscribe to nothing that fires.
 func TestRunCommandStreaming_FinSubscriptionTargetsTheCommandsServer(t *testing.T) {
+	t.Parallel()
 	var mu sync.Mutex
 	var subscriptions [][2]string
 	ac := newStreamingServers(t, streamingServerConfig{
@@ -964,6 +992,7 @@ func TestRunCommandStreaming_FinSubscriptionTargetsTheCommandsServer(t *testing.
 // A fin racing a status the server has not written yet must not end the run on a
 // half-finished read: the poll picks it up on its next tick instead.
 func TestStreamSubscribed_FinOnStillRunningStatusWaitsForPoll(t *testing.T) {
+	t.Parallel()
 	stdoutBuf := &bytes.Buffer{}
 	details := &atomic.Int32{}
 	ac := newStreamingServers(t, streamingServerConfig{
@@ -986,6 +1015,7 @@ func TestStreamSubscribed_FinOnStillRunningStatusWaitsForPoll(t *testing.T) {
 
 // Same fallback when the read the fin triggers fails outright.
 func TestStreamSubscribed_FinWithFailedReadWaitsForPoll(t *testing.T) {
+	t.Parallel()
 	stdoutBuf := &bytes.Buffer{}
 	details := &atomic.Int32{}
 	ac := newStreamingServers(t, streamingServerConfig{
@@ -1008,6 +1038,7 @@ func TestStreamSubscribed_FinWithFailedReadWaitsForPoll(t *testing.T) {
 // "error" the approve→deliver window emits. The fin path reads the same command, so
 // it has to wait on the same statuses or it reports a run that has not started.
 func TestStreamSubscribed_FinOnApprovalHoldWaitsForPoll(t *testing.T) {
+	t.Parallel()
 	for _, status := range []string{"awaiting_approval", "error"} {
 		t.Run(status, func(t *testing.T) {
 			stdoutBuf := &bytes.Buffer{}
@@ -1032,6 +1063,7 @@ func TestStreamSubscribed_FinOnApprovalHoldWaitsForPoll(t *testing.T) {
 }
 
 func TestRunCommandStreaming_GapFilledByREST(t *testing.T) {
+	t.Parallel()
 	stdoutBuf := &bytes.Buffer{}
 	ac := newStreamingServers(t, streamingServerConfig{
 		cmdID:    "cmd-uuid",
@@ -1060,6 +1092,7 @@ func TestRunCommandStreaming_GapFilledByREST(t *testing.T) {
 // written rather than skipped as a duplicate. seq 3 is then filled by the
 // terminal drain in order.
 func TestRunCommandStreaming_WarmFireGapDoesNotSkipLaterChunk(t *testing.T) {
+	t.Parallel()
 	stdoutBuf := &bytes.Buffer{}
 	ac := newStreamingServers(t, streamingServerConfig{
 		cmdID:    "cmd-uuid",
@@ -1086,6 +1119,7 @@ func TestRunCommandStreaming_WarmFireGapDoesNotSkipLaterChunk(t *testing.T) {
 }
 
 func TestRunCommandStreaming_DuplicateSeqIgnored(t *testing.T) {
+	t.Parallel()
 	stdoutBuf := &bytes.Buffer{}
 	ac := newStreamingServers(t, streamingServerConfig{
 		cmdID:    "cmd-uuid",
@@ -1109,6 +1143,7 @@ func TestRunCommandStreaming_DuplicateSeqIgnored(t *testing.T) {
 // TestRunCommandStreaming_FailedStatusPropagatesExitCode guards that terminal
 // status "failed" yields a *RemoteCommandError carrying the exit code.
 func TestRunCommandStreaming_FailedStatusPropagatesExitCode(t *testing.T) {
+	t.Parallel()
 	stdoutBuf := &bytes.Buffer{}
 	ac := newStreamingServers(t, streamingServerConfig{
 		cmdID:        "cmd-uuid",
@@ -1130,6 +1165,7 @@ func TestRunCommandStreaming_FailedStatusPropagatesExitCode(t *testing.T) {
 // fetch returns a hole (seq 1,3; 2 not yet persisted), applyChunk stops at the
 // hole so the later WS seq 2 isn't dropped as a duplicate.
 func TestRunCommandStreaming_GapFillRaceDoesNotDropChunk(t *testing.T) {
+	t.Parallel()
 	stdoutBuf := &bytes.Buffer{}
 	ac := newStreamingServers(t, streamingServerConfig{
 		cmdID:    "cmd-uuid",
@@ -1160,6 +1196,7 @@ func TestRunCommandStreaming_GapFillRaceDoesNotDropChunk(t *testing.T) {
 }
 
 func TestRunCommandStreaming_FallbackOnSubscribeFailureReusesCommand(t *testing.T) {
+	t.Parallel()
 	stdoutBuf := &bytes.Buffer{}
 	cmdID := "cmd-uuid"
 	serverID := "srv-uuid"
@@ -1237,6 +1274,7 @@ func TestRunCommandStreaming_FallbackOnSubscribeFailureReusesCommand(t *testing.
 // reconstructs output from chunks when the server leaves Result empty (the
 // chunk-streaming contract), instead of silently dropping it.
 func TestRunCommandStreaming_FallbackDrainsChunks(t *testing.T) {
+	t.Parallel()
 	stdoutBuf := &bytes.Buffer{}
 	cmdID := "cmd-uuid"
 	serverID := "srv-uuid"
@@ -1280,6 +1318,7 @@ func TestRunCommandStreaming_FallbackDrainsChunks(t *testing.T) {
 }
 
 func TestRunCommandStreaming_FallbackOnSessionFailure(t *testing.T) {
+	t.Parallel()
 	stdoutBuf := &bytes.Buffer{}
 	cmdID := "cmd-uuid"
 	serverID := "srv-uuid"
@@ -1327,6 +1366,7 @@ func TestRunCommandStreaming_FallbackOnSessionFailure(t *testing.T) {
 // TestRunCommandStreaming_FallbackQuietWhenChunksUnavailable: when the chunks
 // endpoint errors, the polling fallback emits the buffered Result, not an error.
 func TestRunCommandStreaming_FallbackQuietWhenChunksUnavailable(t *testing.T) {
+	t.Parallel()
 	stdoutBuf := &bytes.Buffer{}
 	cmdID := "cmd-uuid"
 	serverID := "srv-uuid"
@@ -1505,6 +1545,7 @@ func newStreamingServers(t *testing.T, cfg streamingServerConfig) *client.Alpaco
 // the chunks were already streamed. The Result is still carried on the error so
 // cmd/exec can inspect it (e.g. for the sudo-denial hint) without reprinting.
 func TestRunCommandStreaming_NoDuplicateOutputOnFailure(t *testing.T) {
+	t.Parallel()
 	stdoutBuf := &bytes.Buffer{}
 	ac := newStreamingServers(t, streamingServerConfig{
 		cmdID:        "cmd-uuid",
@@ -1527,6 +1568,7 @@ func TestRunCommandStreaming_NoDuplicateOutputOnFailure(t *testing.T) {
 // TestRunCommandStreaming_TerminalStatusErrors covers errorFromDetails' non-nil
 // branches reached through the streaming select loop.
 func TestRunCommandStreaming_TerminalStatusErrors(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		terminal EventDetails
@@ -1601,6 +1643,7 @@ func TestRunCommandStreaming_TerminalStatusErrors(t *testing.T) {
 // TestRunCommandStreaming_DrainsTrailingChunksOnTerminal covers the drain path:
 // trailing chunks never seen over the WS are recovered by the final REST drain.
 func TestRunCommandStreaming_DrainsTrailingChunksOnTerminal(t *testing.T) {
+	t.Parallel()
 	stdoutBuf := &bytes.Buffer{}
 	ac := newStreamingServers(t, streamingServerConfig{
 		cmdID:    "cmd-uuid",
@@ -1626,6 +1669,7 @@ func TestRunCommandStreaming_DrainsTrailingChunksOnTerminal(t *testing.T) {
 // last-resort path: when no chunks arrive over the WS and none are persisted,
 // the buffered Result must still be written so output is never silently dropped.
 func TestRunCommandStreaming_FallbackToResultWhenNothingStreamed(t *testing.T) {
+	t.Parallel()
 	stdoutBuf := &bytes.Buffer{}
 	ac := newStreamingServers(t, streamingServerConfig{
 		cmdID:        "cmd-uuid",
@@ -1855,6 +1899,7 @@ func TestRecoverSkippedChunks_RecoversLatePersistedSeq(t *testing.T) {
 }
 
 func TestRecoverSkippedChunks_NoopWhenNothingSkipped(t *testing.T) {
+	t.Parallel()
 	var fetches atomic.Int32
 	ac := holeServer(t, 10, map[int]bool{}, &fetches)
 
@@ -1971,6 +2016,7 @@ func TestDrainRemainingChunks_BoundsHugeServerSeq(t *testing.T) {
 // A sub-maxGapWidth gap can still hold thousands of seqs; warnings must
 // collapse them to a range instead of dumping the full slice.
 func TestFormatSeqs_CollapsesLargeLists(t *testing.T) {
+	t.Parallel()
 	assert.Equal(t, "[3 5 7]", formatSeqs([]int{3, 5, 7}))
 
 	seqs := make([]int, 1000)
@@ -2015,6 +2061,7 @@ func lteCapturingServer(t *testing.T, results []Chunk) (ac *client.AlpaconClient
 // TestApplyChunk_SendsSeqLteBound verifies the gap-fill re-fetch is bounded by
 // the live chunk that exposed the hole (seq__gte == lastSeq+1, seq__lte == chunk.Seq-1).
 func TestApplyChunk_SendsSeqLteBound(t *testing.T) {
+	t.Parallel()
 	// Return the whole gap so applyChunk can advance contiguously.
 	ac, bounds := lteCapturingServer(t, []Chunk{{Seq: 1, Content: "c1\n"}, {Seq: 2, Content: "c2\n"}})
 
@@ -2048,6 +2095,7 @@ func TestRecoverSkippedChunks_SendsSeqLteBound(t *testing.T) {
 // server ignores seq__lte and returns the full tail, applyChunk's contiguous
 // consumption still stops at the live chunk (client-side upper-bound filter).
 func TestApplyChunk_OldServerIgnoringSeqLte_OutputIdentical(t *testing.T) {
+	t.Parallel()
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Old server: ignores seq__lte, returns everything from seq__gte on.
 		from, _ := strconv.Atoi(r.URL.Query().Get("seq__gte"))

--- a/api/event/subscribe_test.go
+++ b/api/event/subscribe_test.go
@@ -14,6 +14,7 @@ import (
 )
 
 func TestCreateEventSession(t *testing.T) {
+	t.Parallel()
 	expected := EventSessionResponse{
 		ID:           "session-123",
 		WebsocketURL: "ws://localhost/ws/event/session-123/channel-456/token/",
@@ -42,6 +43,7 @@ func TestCreateEventSession(t *testing.T) {
 }
 
 func TestSubscribeEvent_SendsExpectedPayload(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name      string
 		eventType EventType
@@ -85,6 +87,7 @@ func TestSubscribeEvent_SendsExpectedPayload(t *testing.T) {
 }
 
 func TestSubscribeEvent_OmitsEmptyTarget(t *testing.T) {
+	t.Parallel()
 	bodies := make(chan map[string]any, 1)
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -114,6 +117,7 @@ func TestSubscribeEvent_OmitsEmptyTarget(t *testing.T) {
 }
 
 func TestCreateEventSession_ServerError(t *testing.T) {
+	t.Parallel()
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
 	}))
@@ -130,6 +134,7 @@ func TestCreateEventSession_ServerError(t *testing.T) {
 }
 
 func TestSubscribeEvent_ServerError(t *testing.T) {
+	t.Parallel()
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
 	}))
@@ -146,6 +151,7 @@ func TestSubscribeEvent_ServerError(t *testing.T) {
 }
 
 func TestSubscribeEvent_NotFoundKeepsTheStatusReachable(t *testing.T) {
+	t.Parallel()
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusNotFound)

--- a/api/event/sudolistener_test.go
+++ b/api/event/sudolistener_test.go
@@ -19,6 +19,7 @@ import (
 )
 
 func TestSudoMFAEvent_JSONRoundTrip(t *testing.T) {
+	t.Parallel()
 	payload := sudoMFAEvent{}
 	payload.Payload.Type = "auth"
 	payload.Payload.Query = "mfa_request"
@@ -40,6 +41,7 @@ func TestSudoMFAEvent_JSONRoundTrip(t *testing.T) {
 }
 
 func TestSudoListener_HandleMessage_IgnoresNonMFA(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name    string
 		payload string
@@ -72,6 +74,7 @@ func TestSudoListener_HandleMessage_IgnoresNonMFA(t *testing.T) {
 }
 
 func TestSudoListener_HandleSudoMFA_DropsRequestWhenClientIsNil(t *testing.T) {
+	t.Parallel()
 	sl := NewSudoListener(nil, "", "")
 
 	var event sudoMFAEvent
@@ -83,6 +86,7 @@ func TestSudoListener_HandleSudoMFA_DropsRequestWhenClientIsNil(t *testing.T) {
 }
 
 func TestSudoListener_StopClosesConnection(t *testing.T) {
+	t.Parallel()
 	ts, _, _ := newWatcherTestServer(t, alwaysCreated, alwaysUpgrade, alwaysCreated, func(conn *websocket.Conn, _ int32) {
 		for {
 			if _, _, err := conn.ReadMessage(); err != nil {
@@ -111,6 +115,7 @@ func TestSudoListener_StopClosesConnection(t *testing.T) {
 }
 
 func TestSudoListener_ConnectAndListen_ExitsOnDisconnect(t *testing.T) {
+	t.Parallel()
 	clientRead := make(chan struct{})
 
 	ts, _, _ := newWatcherTestServer(t, alwaysCreated, alwaysUpgrade, alwaysCreated, func(conn *websocket.Conn, _ int32) {
@@ -152,6 +157,7 @@ func newTestSudoListener(ts *httptest.Server) *SudoListener {
 }
 
 func TestSudoListener_VerifySudoGrant_Success(t *testing.T) {
+	t.Parallel()
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodPost, r.Method)
 		assert.Contains(t, r.URL.Path, "/api/sudo/grants/grant-123/verify/")
@@ -175,6 +181,7 @@ func TestSudoListener_VerifySudoGrant_Success(t *testing.T) {
 }
 
 func TestSudoListener_VerifySudoGrant_ServerError(t *testing.T) {
+	t.Parallel()
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusForbidden)
 	}))
@@ -187,6 +194,7 @@ func TestSudoListener_VerifySudoGrant_ServerError(t *testing.T) {
 }
 
 func TestSudoListener_PollMFACompletion_Timeout(t *testing.T) {
+	t.Parallel()
 	sl := NewSudoListener(nil, "", "")
 
 	start := time.Now()
@@ -203,6 +211,7 @@ func TestSudoListener_PollMFACompletion_Timeout(t *testing.T) {
 }
 
 func TestSudoListener_CreatesANewSessionOnReconnect(t *testing.T) {
+	t.Parallel()
 	ts, sessions, _ := newWatcherTestServer(t, alwaysCreated, alwaysUpgrade, alwaysCreated, func(conn *websocket.Conn, n int32) {
 		if n == 1 {
 			// The token is single-use, so recovering means a whole new session.
@@ -228,6 +237,7 @@ func TestSudoListener_CreatesANewSessionOnReconnect(t *testing.T) {
 }
 
 func TestSudoListener_ResubscribesOnReconnect(t *testing.T) {
+	t.Parallel()
 	ts, _, subscribes := newWatcherTestServer(t, alwaysCreated, alwaysUpgrade, alwaysCreated, func(conn *websocket.Conn, n int32) {
 		if n == 1 {
 			_ = conn.Close()
@@ -252,6 +262,7 @@ func TestSudoListener_ResubscribesOnReconnect(t *testing.T) {
 }
 
 func TestSudoListener_FirstSubscribeFailureStopsAndSurfaces(t *testing.T) {
+	t.Parallel()
 	ts, _, _ := newWatcherTestServer(t, alwaysCreated, alwaysUpgrade, alwaysRejected, func(conn *websocket.Conn, _ int32) {
 		for {
 			if _, _, err := conn.ReadMessage(); err != nil {
@@ -273,6 +284,7 @@ func TestSudoListener_FirstSubscribeFailureStopsAndSurfaces(t *testing.T) {
 }
 
 func TestSudoListener_SessionCreateRetryableStatusIsRetried(t *testing.T) {
+	t.Parallel()
 	failFirst := func(attempt int32) int {
 		if attempt == 1 {
 			return http.StatusServiceUnavailable
@@ -440,6 +452,7 @@ func TestSudoListener_AnnouncesTheNextOutageAfterRecovering(t *testing.T) {
 }
 
 func TestSudoListener_FirstSessionFailureStopsAndSurfaces(t *testing.T) {
+	t.Parallel()
 	ts, _, _ := newWatcherTestServer(t, alwaysRejected, alwaysUpgrade, alwaysCreated, func(conn *websocket.Conn, _ int32) {})
 
 	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
@@ -544,6 +557,7 @@ func TestSudoListener_StaysQuietWhenAFailureLandsAfterStop(t *testing.T) {
 }
 
 func TestSudoListener_SurfacesANonFatalCauseAfterTheWaitEnds(t *testing.T) {
+	t.Parallel()
 	alwaysServerError := func(int32) int { return http.StatusInternalServerError }
 
 	ts, _, _ := newWatcherTestServer(t, alwaysServerError, alwaysUpgrade, alwaysCreated, func(conn *websocket.Conn, _ int32) {})
@@ -563,6 +577,7 @@ func TestSudoListener_SurfacesANonFatalCauseAfterTheWaitEnds(t *testing.T) {
 }
 
 func TestSudoListener_TriesOneRefreshBeforeGivingUpOnAnUnauthorizedFirstSession(t *testing.T) {
+	t.Parallel()
 	alwaysUnauthorized := func(int32) int { return http.StatusUnauthorized }
 
 	ts, sessions, _ := newWatcherTestServer(t, alwaysUnauthorized, alwaysUpgrade, alwaysCreated, func(conn *websocket.Conn, _ int32) {})

--- a/api/event/waiter_test.go
+++ b/api/event/waiter_test.go
@@ -39,6 +39,7 @@ func newTestWaiter(t *testing.T, ts *httptest.Server, opts WaitOptions) *Waiter 
 }
 
 func TestWaiter_CatchUpRunsOnlyAfterTheSubscriptionStands(t *testing.T) {
+	t.Parallel()
 	var subscribes atomic.Int32
 	var catchUpSawSubscribes atomic.Int32
 
@@ -66,6 +67,7 @@ func TestWaiter_CatchUpRunsOnlyAfterTheSubscriptionStands(t *testing.T) {
 }
 
 func TestWaiter_CatchUpDecidesWithoutAnEvent(t *testing.T) {
+	t.Parallel()
 	ts, _, _ := newWatcherTestServer(t, alwaysCreated, alwaysUpgrade, alwaysCreated, holdOpen)
 
 	w := newTestWaiter(t, ts, WaitOptions{
@@ -91,6 +93,7 @@ func TestWaiter_CatchUpDecidesWithoutAnEvent(t *testing.T) {
 }
 
 func TestWaiter_ClassifiesFrameSubTypes(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name    string
 		subType string
@@ -125,6 +128,7 @@ func TestWaiter_ClassifiesFrameSubTypes(t *testing.T) {
 }
 
 func TestWaiter_IgnoresAnUnrelatedSubType(t *testing.T) {
+	t.Parallel()
 	ts, _, _ := newWatcherTestServer(t, alwaysCreated, alwaysUpgrade, alwaysCreated, func(conn *websocket.Conn, _ int32) {
 		_ = conn.WriteMessage(websocket.TextMessage, []byte(`{"event_type":"work_session","payload":{"sub_type":"extended"}}`))
 		holdOpen(conn, 0)
@@ -143,6 +147,7 @@ func TestWaiter_IgnoresAnUnrelatedSubType(t *testing.T) {
 }
 
 func TestWaiter_UnparseableFrameDoesNotEndTheWait(t *testing.T) {
+	t.Parallel()
 	ts, _, _ := newWatcherTestServer(t, alwaysCreated, alwaysUpgrade, alwaysCreated, func(conn *websocket.Conn, _ int32) {
 		_ = conn.WriteMessage(websocket.TextMessage, []byte("not json at all"))
 		holdOpen(conn, 0)
@@ -157,6 +162,7 @@ func TestWaiter_UnparseableFrameDoesNotEndTheWait(t *testing.T) {
 }
 
 func TestWaiter_StopCancelsTheWait(t *testing.T) {
+	t.Parallel()
 	ts, _, _ := newWatcherTestServer(t, alwaysCreated, alwaysUpgrade, alwaysCreated, holdOpen)
 
 	w := newTestWaiter(t, ts, WaitOptions{OK: []string{"approved"}, Timeout: time.Minute})
@@ -173,6 +179,7 @@ func TestWaiter_StopCancelsTheWait(t *testing.T) {
 }
 
 func TestWaiter_CatchUpErrorIsReportedButDoesNotEndTheWait(t *testing.T) {
+	t.Parallel()
 	ts, _, _ := newWatcherTestServer(t, alwaysCreated, alwaysUpgrade, alwaysCreated, holdOpen)
 
 	w := newTestWaiter(t, ts, WaitOptions{
@@ -196,6 +203,7 @@ func TestWaiter_CatchUpErrorIsReportedButDoesNotEndTheWait(t *testing.T) {
 }
 
 func TestWaiter_RejectedSubscriptionSurfacesTheServerMessage(t *testing.T) {
+	t.Parallel()
 	ts, _, _ := newWatcherTestServer(t, alwaysCreated, alwaysUpgrade, alwaysRejected, holdOpen)
 
 	w := newTestWaiter(t, ts, WaitOptions{OK: []string{"approved"}, Timeout: testWaitTimeout})
@@ -208,6 +216,7 @@ func TestWaiter_RejectedSubscriptionSurfacesTheServerMessage(t *testing.T) {
 }
 
 func TestWaiter_ReconnectRerunsCatchUp(t *testing.T) {
+	t.Parallel()
 	var catchUps atomic.Int32
 
 	ts, _, _ := newWatcherTestServer(t, alwaysCreated, alwaysUpgrade, alwaysCreated, func(conn *websocket.Conn, n int32) {

--- a/api/event/watcher_test.go
+++ b/api/event/watcher_test.go
@@ -77,6 +77,7 @@ func alwaysUpgrade(int32) bool { return true }
 func alwaysRejected(int32) int { return http.StatusBadRequest }
 
 func TestWatcher_ForwardsFramesVerbatim(t *testing.T) {
+	t.Parallel()
 	frame := `{"event_type":"work_session","payload":{"category":"status","sub_type":"approved","unknown":1}}`
 
 	ts, _, _ := newWatcherTestServer(t, alwaysCreated, alwaysUpgrade, alwaysCreated, func(conn *websocket.Conn, _ int32) {
@@ -105,6 +106,7 @@ func TestWatcher_ForwardsFramesVerbatim(t *testing.T) {
 }
 
 func TestWatcher_CreatesANewSessionOnReconnect(t *testing.T) {
+	t.Parallel()
 	ts, sessions, subscribes := newWatcherTestServer(t, alwaysCreated, alwaysUpgrade, alwaysCreated, func(conn *websocket.Conn, n int32) {
 		if n == 1 {
 			// The token is single-use, so recovering means a whole new session.
@@ -136,6 +138,7 @@ func TestWatcher_CreatesANewSessionOnReconnect(t *testing.T) {
 }
 
 func TestWatcher_FirstSubscribeFailureStopsAndSurfaces(t *testing.T) {
+	t.Parallel()
 	ts, _, _ := newWatcherTestServer(t, alwaysCreated, alwaysUpgrade, alwaysRejected, func(conn *websocket.Conn, _ int32) {
 		for {
 			if _, _, err := conn.ReadMessage(); err != nil {
@@ -157,6 +160,7 @@ func TestWatcher_FirstSubscribeFailureStopsAndSurfaces(t *testing.T) {
 }
 
 func TestWatcher_FailureAfterFirstSuccessIsNonFatal(t *testing.T) {
+	t.Parallel()
 	firstOnly := func(attempt int32) int {
 		if attempt == 1 {
 			return http.StatusCreated
@@ -218,6 +222,7 @@ func TestWatcher_FailureAfterFirstSuccessIsNonFatal(t *testing.T) {
 }
 
 func TestWatcher_DialFailureAfterFirstSuccessIsAnnounced(t *testing.T) {
+	t.Parallel()
 	// A refused handshake is a real dial error, which reaches neither provision nor
 	// subscribe.
 	firstConnOnly := func(attempt int32) bool { return attempt == 1 }
@@ -245,6 +250,7 @@ func TestWatcher_DialFailureAfterFirstSuccessIsAnnounced(t *testing.T) {
 }
 
 func TestWatcher_StaleFailureNoticeIsDroppedOnRecovery(t *testing.T) {
+	t.Parallel()
 	secondOnly := func(attempt int32) int {
 		if attempt == 2 {
 			return http.StatusBadRequest
@@ -292,6 +298,7 @@ func TestWatcher_StaleFailureNoticeIsDroppedOnRecovery(t *testing.T) {
 }
 
 func TestWatcher_MalformedWebsocketURLStopsAndSurfaces(t *testing.T) {
+	t.Parallel()
 	const token = "hunter2"
 	// A DEL byte makes url.Parse fail; left to the dialer that surfaces as a *url.Error
 	// quoting the whole URL, token included.
@@ -321,6 +328,7 @@ func TestWatcher_MalformedWebsocketURLStopsAndSurfaces(t *testing.T) {
 }
 
 func TestWatcher_SessionCreateRejectionStopsAndSurfaces(t *testing.T) {
+	t.Parallel()
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusUnauthorized)
@@ -339,6 +347,7 @@ func TestWatcher_SessionCreateRejectionStopsAndSurfaces(t *testing.T) {
 }
 
 func TestWatcher_SessionCreateRetryableStatusIsRetried(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name   string
 		status int

--- a/api/event/wslistener_test.go
+++ b/api/event/wslistener_test.go
@@ -18,6 +18,7 @@ import (
 const testReconnectBaseDelay = 10 * time.Millisecond
 
 func TestWSListener_StartPanicsWithoutHandleFrame(t *testing.T) {
+	t.Parallel()
 	w := newProvisionedWSListener(nil, func() (string, error) { return "", nil }, 0)
 
 	assert.PanicsWithValue(t, "event: wsListener.handleFrame must be assigned before Start", func() {
@@ -26,6 +27,7 @@ func TestWSListener_StartPanicsWithoutHandleFrame(t *testing.T) {
 }
 
 func TestWSListener_StopIsIdempotent(t *testing.T) {
+	t.Parallel()
 	w := newProvisionedWSListener(nil, func() (string, error) { return "", nil }, 0)
 
 	w.Stop()
@@ -34,6 +36,7 @@ func TestWSListener_StopIsIdempotent(t *testing.T) {
 }
 
 func TestWSListener_WaitConnected_Success(t *testing.T) {
+	t.Parallel()
 	w := newProvisionedWSListener(nil, func() (string, error) { return "", nil }, 0)
 
 	// Simulate connection after short delay
@@ -47,6 +50,7 @@ func TestWSListener_WaitConnected_Success(t *testing.T) {
 }
 
 func TestWSListener_WaitConnected_Timeout(t *testing.T) {
+	t.Parallel()
 	w := newProvisionedWSListener(nil, func() (string, error) { return "", nil }, 0)
 
 	start := time.Now()
@@ -59,6 +63,7 @@ func TestWSListener_WaitConnected_Timeout(t *testing.T) {
 }
 
 func TestWSListener_NextReconnectDelay(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name  string
 		delay time.Duration
@@ -78,6 +83,7 @@ func TestWSListener_NextReconnectDelay(t *testing.T) {
 }
 
 func TestWSListener_ConnectAndListen_ReturnsFalseOnFailedHandshake(t *testing.T) {
+	t.Parallel()
 	// Responds 200 instead of upgrading, so Dial fails with ErrBadHandshake.
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
 	defer server.Close()
@@ -90,6 +96,7 @@ func TestWSListener_ConnectAndListen_ReturnsFalseOnFailedHandshake(t *testing.T)
 }
 
 func TestWSListener_ListenLoop_DoesNotDialWhenAlreadyStopped(t *testing.T) {
+	t.Parallel()
 	var dialed atomic.Int32
 
 	// Counted at handler entry so the increment happens-before Dial returns.
@@ -118,6 +125,7 @@ func TestWSListener_ListenLoop_DoesNotDialWhenAlreadyStopped(t *testing.T) {
 }
 
 func TestWSListener_WaitConnected_Shutdown(t *testing.T) {
+	t.Parallel()
 	w := newProvisionedWSListener(nil, func() (string, error) { return "", nil }, 0)
 
 	go func() {
@@ -134,6 +142,7 @@ func TestWSListener_WaitConnected_Shutdown(t *testing.T) {
 }
 
 func TestWSListener_ProvisionCalledPerDialAttempt(t *testing.T) {
+	t.Parallel()
 	upgrader := websocket.Upgrader{}
 	var conns atomic.Int32
 
@@ -183,6 +192,7 @@ func TestWSListener_ProvisionCalledPerDialAttempt(t *testing.T) {
 }
 
 func TestWSListener_ProvisionErrorIsAFailedAttempt(t *testing.T) {
+	t.Parallel()
 	var provisions atomic.Int32
 
 	w := newProvisionedWSListener(nil, func() (string, error) {
@@ -197,6 +207,7 @@ func TestWSListener_ProvisionErrorIsAFailedAttempt(t *testing.T) {
 }
 
 func TestWSListener_OnConnectedRunsBeforeConnectedCloses(t *testing.T) {
+	t.Parallel()
 	upgrader := websocket.Upgrader{}
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -233,6 +244,7 @@ func TestWSListener_OnConnectedRunsBeforeConnectedCloses(t *testing.T) {
 }
 
 func TestWSListener_OnConnectedErrorIsAFailedAttempt(t *testing.T) {
+	t.Parallel()
 	upgrader := websocket.Upgrader{}
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/api/ftp/ftp_test.go
+++ b/api/ftp/ftp_test.go
@@ -48,6 +48,7 @@ func createTestZip(t *testing.T, files map[string]string) []byte {
 }
 
 func TestPollTransferStatus(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name        string
 		response    TransferStatusResponse
@@ -91,6 +92,7 @@ func TestPollTransferStatus(t *testing.T) {
 }
 
 func TestUploadToS3(t *testing.T) {
+	t.Parallel()
 	var receivedBody []byte
 	var receivedMethod string
 
@@ -110,6 +112,7 @@ func TestUploadToS3(t *testing.T) {
 }
 
 func TestUploadToS3_Failure(t *testing.T) {
+	t.Parallel()
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusForbidden)
 	}))
@@ -121,6 +124,7 @@ func TestUploadToS3_Failure(t *testing.T) {
 }
 
 func TestExecuteBulkUpload(t *testing.T) {
+	t.Parallel()
 	var bulkReq BulkUploadRequest
 	var triggerReq BulkUploadTriggerRequest
 	var s3Uploads atomic.Int32
@@ -188,6 +192,7 @@ func TestExecuteBulkUpload(t *testing.T) {
 }
 
 func TestExecuteBulkUpload_UploadsConcurrently(t *testing.T) {
+	t.Parallel()
 	uploadsEntered := make(chan struct{}, 2)
 	releaseUploads := make(chan struct{})
 	var releaseOnce sync.Once
@@ -251,6 +256,7 @@ func TestExecuteBulkUpload_UploadsConcurrently(t *testing.T) {
 }
 
 func TestExecuteBulkUpload_PollsConcurrently(t *testing.T) {
+	t.Parallel()
 	pollsEntered := make(chan struct{}, 2)
 	releasePolls := make(chan struct{})
 	var releaseOnce sync.Once
@@ -311,6 +317,7 @@ func TestExecuteBulkUpload_PollsConcurrently(t *testing.T) {
 }
 
 func TestExecuteBulkUpload_NoOverwrite(t *testing.T) {
+	t.Parallel()
 	var bulkReq BulkUploadRequest
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -359,6 +366,7 @@ func TestExecuteBulkUpload_NoOverwrite(t *testing.T) {
 }
 
 func TestExecuteBulkUpload_WithUnzip(t *testing.T) {
+	t.Parallel()
 	var bulkReq BulkUploadRequest
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -407,6 +415,7 @@ func TestExecuteBulkUpload_WithUnzip(t *testing.T) {
 }
 
 func TestDownloadBulk(t *testing.T) {
+	t.Parallel()
 	var bulkReq BulkDownloadRequest
 
 	zipContent := createTestZip(t, map[string]string{
@@ -480,6 +489,7 @@ func TestDownloadBulk(t *testing.T) {
 }
 
 func TestDownloadBulk_PreservesExistingArchiveName(t *testing.T) {
+	t.Parallel()
 	zipContent := createTestZip(t, map[string]string{
 		"file.txt": "downloaded",
 	})
@@ -535,6 +545,7 @@ func TestDownloadBulk_PreservesExistingArchiveName(t *testing.T) {
 }
 
 func TestExecuteSingleUpload(t *testing.T) {
+	t.Parallel()
 	var uploadReq UploadRequest
 	var s3Uploaded bool
 	var triggerCalled bool
@@ -598,6 +609,7 @@ func TestExecuteSingleUpload(t *testing.T) {
 }
 
 func TestExecuteSingleUpload_TransferFailure(t *testing.T) {
+	t.Parallel()
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 
@@ -642,6 +654,7 @@ func TestExecuteSingleUpload_TransferFailure(t *testing.T) {
 }
 
 func TestExecuteSingleUpload_WithUnzip(t *testing.T) {
+	t.Parallel()
 	var uploadReq UploadRequest
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -689,6 +702,7 @@ func TestExecuteSingleUpload_WithUnzip(t *testing.T) {
 }
 
 func TestExecuteBulkUpload_TransferFailure(t *testing.T) {
+	t.Parallel()
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 
@@ -733,6 +747,7 @@ func TestExecuteBulkUpload_TransferFailure(t *testing.T) {
 }
 
 func TestExecuteBulkUpload_MismatchedResponseCount(t *testing.T) {
+	t.Parallel()
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 
@@ -766,6 +781,7 @@ func TestExecuteBulkUpload_MismatchedResponseCount(t *testing.T) {
 }
 
 func TestPollTransferStatus_Timeout(t *testing.T) {
+	t.Parallel()
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		// Always return nil success (pending state)
@@ -786,6 +802,7 @@ func TestPollTransferStatus_Timeout(t *testing.T) {
 }
 
 func TestFetchFromURL_ClientErrorNoRetry(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name    string
 		status  int
@@ -817,6 +834,7 @@ func TestFetchFromURL_ClientErrorNoRetry(t *testing.T) {
 }
 
 func TestFetchFromURLToFile_ReadErrorKeepsExistingFile(t *testing.T) {
+	t.Parallel()
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Length", "100")
 		_, _ = w.Write([]byte("partial"))
@@ -840,6 +858,7 @@ func TestFetchFromURLToFile_ReadErrorKeepsExistingFile(t *testing.T) {
 }
 
 func TestFetchFromURLToFile_CreatesOwnerOnlyFile(t *testing.T) {
+	t.Parallel()
 	if runtime.GOOS == "windows" {
 		t.Skip("Unix file modes are not enforced on Windows")
 	}
@@ -866,6 +885,7 @@ func TestFetchFromURLToFile_CreatesOwnerOnlyFile(t *testing.T) {
 }
 
 func TestSaveDownloadedURL_RecursiveUsesTempArchive(t *testing.T) {
+	t.Parallel()
 	zipContent := createTestZip(t, map[string]string{
 		"folder/file.txt": "downloaded",
 	})
@@ -899,6 +919,7 @@ func TestSaveDownloadedURL_RecursiveUsesTempArchive(t *testing.T) {
 }
 
 func TestDownloadFile_InputValidation(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name    string
 		sources []string
@@ -916,6 +937,7 @@ func TestDownloadFile_InputValidation(t *testing.T) {
 }
 
 func TestDownloadFile_SpaceInPath(t *testing.T) {
+	t.Parallel()
 	// Verify that a path with spaces is preserved as a single path,
 	// not split by whitespace (the old strings.Fields bug).
 	serverResp := api.ListResponse[server.ServerDetails]{
@@ -954,6 +976,7 @@ func TestDownloadFile_SpaceInPath(t *testing.T) {
 }
 
 func TestDownloadFile_SingleVsBulkRouting(t *testing.T) {
+	t.Parallel()
 	serverResp := api.ListResponse[server.ServerDetails]{
 		Count:   1,
 		Results: []server.ServerDetails{{ID: "srv-123", Name: "my-server"}},
@@ -1019,6 +1042,7 @@ func TestDownloadFile_SingleVsBulkRouting(t *testing.T) {
 // TestExecuteSingleUpload_WorkSession verifies the WorkSession field is sent
 // when present and omitted when empty, on the single upload create-request.
 func TestExecuteSingleUpload_WorkSession(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name            string
 		workSessionID   string
@@ -1077,6 +1101,7 @@ func TestExecuteSingleUpload_WorkSession(t *testing.T) {
 }
 
 func TestUploadLocalFileAsUsesRemoteBasenameAndDirectory(t *testing.T) {
+	t.Parallel()
 	var uploadReq UploadRequest
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -1125,6 +1150,7 @@ func TestUploadLocalFileAsUsesRemoteBasenameAndDirectory(t *testing.T) {
 }
 
 func TestUploadLocalFileAsRejectsInvalidRemoteBasename(t *testing.T) {
+	t.Parallel()
 	for _, remotePath := range []string{"/tmp/..", "/tmp/app.conf/", `/tmp/..\saved`} {
 		t.Run(remotePath, func(t *testing.T) {
 			err := UploadLocalFileAs(&client.AlpaconClient{}, "/tmp/local", "prod", remotePath, "", "", "")
@@ -1137,6 +1163,7 @@ func TestUploadLocalFileAsRejectsInvalidRemoteBasename(t *testing.T) {
 // TestExecuteBulkUpload_WorkSession verifies the WorkSession field is sent
 // when present and omitted when empty, on the bulk upload create-request.
 func TestExecuteBulkUpload_WorkSession(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name            string
 		workSessionID   string
@@ -1198,6 +1225,7 @@ func TestExecuteBulkUpload_WorkSession(t *testing.T) {
 // single- and bulk-download create-requests when DownloadFile is invoked with
 // a non-empty workSessionID, and omitted when the ID is empty.
 func TestDownloadFile_WorkSession(t *testing.T) {
+	t.Parallel()
 	serverResp := api.ListResponse[server.ServerDetails]{
 		Count:   1,
 		Results: []server.ServerDetails{{ID: "srv-123", Name: "my-server"}},
@@ -1279,6 +1307,7 @@ func TestDownloadFile_WorkSession(t *testing.T) {
 }
 
 func TestNextPollInterval(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name    string
 		attempt int
@@ -1300,6 +1329,7 @@ func TestNextPollInterval(t *testing.T) {
 }
 
 func TestAlignedPollDelay(t *testing.T) {
+	t.Parallel()
 	// The delay is the backoff for the attempt, clamped so the poll never lands
 	// past the next maxPollInterval grid boundary. This keeps the adaptive
 	// schedule a superset of a fixed maxPollInterval poller (poll points 0, 250,
@@ -1333,6 +1363,7 @@ func TestAlignedPollDelay(t *testing.T) {
 }
 
 func TestPollTransferStatus_BacksOffThenSucceeds(t *testing.T) {
+	t.Parallel()
 	// Server reports "not yet complete" (success=null) twice, then succeeds.
 	// With adaptive backoff the two waits are 250ms + 500ms = 750ms, far below
 	// the old fixed 2s+2s = 4s. Assert both the poll count and a loose upper
@@ -1367,6 +1398,7 @@ func TestPollTransferStatus_BacksOffThenSucceeds(t *testing.T) {
 }
 
 func TestPollTransferStatus_RetriesWhileInProgress(t *testing.T) {
+	t.Parallel()
 	// Retry keys off the "webftp_transfer_in_progress" payload, not the 422
 	// status: PollTransferStatus must back off and retry, not treat it as fatal.
 	var calls atomic.Int32
@@ -1393,6 +1425,7 @@ func TestPollTransferStatus_RetriesWhileInProgress(t *testing.T) {
 }
 
 func TestPollTransferStatus_FatalErrorNoRetry(t *testing.T) {
+	t.Parallel()
 	// A non-in-progress error (e.g. 403) is fatal: return immediately without
 	// polling again.
 	var calls atomic.Int32
@@ -1414,6 +1447,7 @@ func TestPollTransferStatus_FatalErrorNoRetry(t *testing.T) {
 }
 
 func TestPollTransferStatus_TimesOut(t *testing.T) {
+	t.Parallel()
 	// Server never completes (success=null). With a timeout below the initial
 	// poll interval, the deadline check breaks before the first sleep, so a
 	// single poll happens and the timeout error is returned.
@@ -1436,6 +1470,7 @@ func TestPollTransferStatus_TimesOut(t *testing.T) {
 }
 
 func TestFetchFromURLToFile_RetriesRetryableStatuses(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name        string
 		firstStatus int
@@ -1528,6 +1563,7 @@ func TestFetchFromURLToFile_StopsAtTheAttemptBudget(t *testing.T) {
 }
 
 func TestFetchFromURLToFile_StopsDrainingAStalledErrorBody(t *testing.T) {
+	t.Parallel()
 	stall := make(chan struct{})
 	var releaseOnce sync.Once
 	release := func() { releaseOnce.Do(func() { close(stall) }) }
@@ -1559,6 +1595,7 @@ func TestFetchFromURLToFile_StopsDrainingAStalledErrorBody(t *testing.T) {
 }
 
 func TestBackoffDelay(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name    string
 		attempt int
@@ -1579,6 +1616,7 @@ func TestBackoffDelay(t *testing.T) {
 }
 
 func TestBackoffDelay_CapsAnInitialAlreadyOverTheLimit(t *testing.T) {
+	t.Parallel()
 	assert.Equal(t, time.Second, backoffDelay(0, 5*time.Second, time.Second))
 	assert.Equal(t, time.Second, backoffDelay(3, 5*time.Second, time.Second))
 }

--- a/api/iam/iam_test.go
+++ b/api/iam/iam_test.go
@@ -15,6 +15,7 @@ import (
 )
 
 func TestGetUserList_Pagination(t *testing.T) {
+	t.Parallel()
 	var requestCount atomic.Int32
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -79,6 +80,7 @@ func TestGetUserList_Pagination(t *testing.T) {
 }
 
 func TestGetGroupList_Pagination(t *testing.T) {
+	t.Parallel()
 	var requestCount atomic.Int32
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -143,6 +145,7 @@ func TestGetGroupList_Pagination(t *testing.T) {
 }
 
 func TestGetUserIDByName(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		username string
@@ -187,6 +190,7 @@ func TestGetUserIDByName(t *testing.T) {
 }
 
 func TestGetGroupIDByName(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name      string
 		groupName string
@@ -231,6 +235,7 @@ func TestGetGroupIDByName(t *testing.T) {
 }
 
 func TestCreateUser_SetsIsActive(t *testing.T) {
+	t.Parallel()
 	var gotIsActive bool
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -258,6 +263,7 @@ func TestCreateUser_SetsIsActive(t *testing.T) {
 }
 
 func TestGetUserList_StatusMapping(t *testing.T) {
+	t.Parallel()
 	users := []UserResponse{
 		{ID: "1", Username: "superadmin", IsSuperuser: true},
 		{ID: "2", Username: "staffuser", IsStaff: true},
@@ -300,6 +306,7 @@ func TestGetUserList_StatusMapping(t *testing.T) {
 }
 
 func TestInviteUser(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name       string
 		statusCode int
@@ -347,6 +354,7 @@ func TestInviteUser(t *testing.T) {
 }
 
 func TestAddMember(t *testing.T) {
+	t.Parallel()
 	const (
 		groupID = "group-uuid-111"
 		userID  = "user-uuid-222"

--- a/api/iam/username_error_test.go
+++ b/api/iam/username_error_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 func TestUsernameErrorMessage(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		code      string
 		wantOK    bool
@@ -35,6 +36,7 @@ func TestUsernameErrorMessage(t *testing.T) {
 }
 
 func TestIsRetryableUsernameError(t *testing.T) {
+	t.Parallel()
 	assert.True(t, isRetryableUsernameError("user_username_invalid"))
 	assert.True(t, isRetryableUsernameError("user_username_disallowed"))
 	assert.True(t, isRetryableUsernameError("user_username_in_use"))

--- a/api/log/log_test.go
+++ b/api/log/log_test.go
@@ -15,6 +15,7 @@ import (
 )
 
 func TestGetSystemLogList_NoExtraPagination(t *testing.T) {
+	t.Parallel()
 	var logRequestCount atomic.Int32
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/api/mfa/mfa_test.go
+++ b/api/mfa/mfa_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func TestCheckMFACompletion_Completed(t *testing.T) {
+	t.Parallel()
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, mfaCompletionURL, r.URL.Path)
 		w.Header().Set("Content-Type", "application/json")
@@ -30,6 +31,7 @@ func TestCheckMFACompletion_Completed(t *testing.T) {
 }
 
 func TestCheckMFACompletion_NotCompleted(t *testing.T) {
+	t.Parallel()
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"completed": false}`))
@@ -47,6 +49,7 @@ func TestCheckMFACompletion_NotCompleted(t *testing.T) {
 }
 
 func TestCheckMFACompletion_ServerError(t *testing.T) {
+	t.Parallel()
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
 		_, _ = w.Write([]byte(`{"detail": "internal server error"}`))
@@ -77,6 +80,7 @@ func mfaLinkServer(t *testing.T, body string) (*client.AlpaconClient, *url.Value
 }
 
 func TestGetMFALink_ReturnsTheURLAndScopesItToTheServer(t *testing.T) {
+	t.Parallel()
 	ac, query := mfaLinkServer(t, `{"mfa_url": "https://example.com/mfa"}`)
 
 	link, err := GetMFALink(ac, "server-id")
@@ -90,6 +94,7 @@ func TestGetMFALink_ReturnsTheURLAndScopesItToTheServer(t *testing.T) {
 
 // It used to yield ("", nil), so callers opened a browser on a blank link.
 func TestGetMFALink_MalformedBodyIsAnError(t *testing.T) {
+	t.Parallel()
 	ac, _ := mfaLinkServer(t, `not json`)
 
 	link, err := GetMFALink(ac, "server-id")
@@ -99,6 +104,7 @@ func TestGetMFALink_MalformedBodyIsAnError(t *testing.T) {
 }
 
 func TestGetMFALink_EmptyURLIsAnError(t *testing.T) {
+	t.Parallel()
 	ac, _ := mfaLinkServer(t, `{"mfa_url": ""}`)
 
 	link, err := GetMFALink(ac, "server-id")
@@ -108,6 +114,7 @@ func TestGetMFALink_EmptyURLIsAnError(t *testing.T) {
 }
 
 func TestGetWorkspaceSecurityMFALink_SendsNoServerScope(t *testing.T) {
+	t.Parallel()
 	ac, query := mfaLinkServer(t, `{"mfa_url": "https://example.com/mfa"}`)
 
 	link, err := GetWorkspaceSecurityMFALink(ac)
@@ -120,6 +127,7 @@ func TestGetWorkspaceSecurityMFALink_SendsNoServerScope(t *testing.T) {
 }
 
 func TestGetMFALink_ServerErrorIsAnError(t *testing.T) {
+	t.Parallel()
 	reached := false
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		reached = true
@@ -142,6 +150,7 @@ func TestGetMFALink_ServerErrorIsAnError(t *testing.T) {
 }
 
 func TestErrorCallbacks_WiresEveryField(t *testing.T) {
+	t.Parallel()
 	ac := &client.AlpaconClient{}
 	retried := false
 
@@ -160,6 +169,7 @@ func TestErrorCallbacks_WiresEveryField(t *testing.T) {
 }
 
 func TestGetMFALink_EmptyWorkspaceIsAnErrorBeforeAnyRequest(t *testing.T) {
+	t.Parallel()
 	called := false
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		called = true
@@ -207,6 +217,7 @@ func TestGetMFALinkByServerName_NamesTheWorkspaceTheClientIsPinnedTo(t *testing.
 }
 
 func TestGetMFALinkByServerName_EmptyWorkspaceCostsNoRoundTrip(t *testing.T) {
+	t.Parallel()
 	called := false
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		called = true

--- a/api/note/note_test.go
+++ b/api/note/note_test.go
@@ -18,6 +18,7 @@ import (
 )
 
 func TestGetNoteList_SendsFilterOrderingAndPinnedParams(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name            string
 		serverName      string
@@ -108,6 +109,7 @@ func TestGetNoteList_SendsFilterOrderingAndPinnedParams(t *testing.T) {
 // is that tail reaches the helper as its limit, so a server offering endless pages still
 // yields exactly tail notes.
 func TestGetNoteList_PassesTailAsTheLimit(t *testing.T) {
+	t.Parallel()
 	var mu sync.Mutex
 	requests := 0
 
@@ -144,6 +146,7 @@ func TestGetNoteList_PassesTailAsTheLimit(t *testing.T) {
 }
 
 func TestGetNoteList_MapsResponseFields(t *testing.T) {
+	t.Parallel()
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		results := []NoteResponse{{

--- a/api/packages/packages_test.go
+++ b/api/packages/packages_test.go
@@ -52,6 +52,7 @@ func jsonTestResponse(statusCode int, body string) *http.Response {
 }
 
 func TestGetSystemPackageEntry_Pagination(t *testing.T) {
+	t.Parallel()
 	var requestCount atomic.Int32
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -116,6 +117,7 @@ func TestGetSystemPackageEntry_Pagination(t *testing.T) {
 }
 
 func TestUploadPackage_MultipartFromFile(t *testing.T) {
+	t.Parallel()
 	var uploadedName string
 	var uploadedContent string
 	var contentLength int64
@@ -181,6 +183,7 @@ func TestUploadPackage_MultipartFromFile(t *testing.T) {
 }
 
 func TestDownloadPackage_StreamsToFile(t *testing.T) {
+	t.Parallel()
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		switch {
@@ -222,6 +225,7 @@ func TestDownloadPackage_StreamsToFile(t *testing.T) {
 }
 
 func TestDownloadPackage_StatusErrorDoesNotWriteFile(t *testing.T) {
+	t.Parallel()
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		switch {
@@ -259,6 +263,7 @@ func TestDownloadPackage_StatusErrorDoesNotWriteFile(t *testing.T) {
 }
 
 func TestDownloadPackage_NoContentDoesNotOverwriteExistingFile(t *testing.T) {
+	t.Parallel()
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		switch {
@@ -305,6 +310,7 @@ func TestDownloadPackage_NoContentDoesNotOverwriteExistingFile(t *testing.T) {
 }
 
 func TestDownloadPackage_JSONSuccessDoesNotWriteFile(t *testing.T) {
+	t.Parallel()
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		switch {
@@ -341,6 +347,7 @@ func TestDownloadPackage_JSONSuccessDoesNotWriteFile(t *testing.T) {
 }
 
 func TestDownloadPackage_ReadErrorKeepsExistingFile(t *testing.T) {
+	t.Parallel()
 	ac := &client.AlpaconClient{
 		HTTPClient: &http.Client{
 			Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
@@ -390,6 +397,7 @@ func TestDownloadPackage_ReadErrorKeepsExistingFile(t *testing.T) {
 }
 
 func TestGetPythonPackageEntry_Pagination(t *testing.T) {
+	t.Parallel()
 	var requestCount atomic.Int32
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/api/pagination_test.go
+++ b/api/pagination_test.go
@@ -55,6 +55,7 @@ func (rec *requestRecorder) queried(key string) []string {
 }
 
 func TestFetchCursorPages_SinglePageNullNext(t *testing.T) {
+	t.Parallel()
 	rec := &requestRecorder{}
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		rec.record(r)
@@ -72,6 +73,7 @@ func TestFetchCursorPages_SinglePageNullNext(t *testing.T) {
 }
 
 func TestFetchCursorPages_FollowsCursorAndCaps(t *testing.T) {
+	t.Parallel()
 	rec := &requestRecorder{}
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		rec.record(r)
@@ -98,6 +100,7 @@ func TestFetchCursorPages_FollowsCursorAndCaps(t *testing.T) {
 }
 
 func TestFetchCursorPages_PageSize(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		limit        int
 		wantPageSize string
@@ -124,6 +127,7 @@ func TestFetchCursorPages_PageSize(t *testing.T) {
 }
 
 func TestFetchCursorPages_NonPositiveLimit(t *testing.T) {
+	t.Parallel()
 	for _, limit := range []int{0, -1} {
 		t.Run(strconv.Itoa(limit), func(t *testing.T) {
 			ts := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
@@ -140,6 +144,7 @@ func TestFetchCursorPages_NonPositiveLimit(t *testing.T) {
 }
 
 func TestFetchCursorPages_SecondPageErrorDiscardsPartial(t *testing.T) {
+	t.Parallel()
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		if r.URL.Query().Get("cursor") == "" {
@@ -161,6 +166,7 @@ func TestFetchCursorPages_SecondPageErrorDiscardsPartial(t *testing.T) {
 }
 
 func TestFetchCursorPages_MalformedJSON(t *testing.T) {
+	t.Parallel()
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"results": [`))
@@ -174,6 +180,7 @@ func TestFetchCursorPages_MalformedJSON(t *testing.T) {
 }
 
 func TestFetchCursorPages_StopsOnEmptyResults(t *testing.T) {
+	t.Parallel()
 	rec := &requestRecorder{}
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		rec.record(r)
@@ -191,6 +198,7 @@ func TestFetchCursorPages_StopsOnEmptyResults(t *testing.T) {
 }
 
 func TestFetchCursorPages_IgnoresStaleCursorParam(t *testing.T) {
+	t.Parallel()
 	rec := &requestRecorder{}
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		rec.record(r)
@@ -208,6 +216,7 @@ func TestFetchCursorPages_IgnoresStaleCursorParam(t *testing.T) {
 }
 
 func TestFetchCursorPages_DoesNotMutateCallerParams(t *testing.T) {
+	t.Parallel()
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		if r.URL.Query().Get("cursor") == "" {
@@ -279,6 +288,7 @@ func servedIDs(items []pageItem) []string {
 }
 
 func TestFetchPagesUpTo_WalksPagesWithoutGapsOrDuplicates(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name          string
 		total         int
@@ -332,6 +342,7 @@ func TestFetchPagesUpTo_WalksPagesWithoutGapsOrDuplicates(t *testing.T) {
 }
 
 func TestFetchPagesUpTo_TruncatesWhenServerOverServes(t *testing.T) {
+	t.Parallel()
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"count":5,"next":0,"results":[{"id":"0"},{"id":"1"},{"id":"2"},{"id":"3"},{"id":"4"}]}`))
@@ -348,6 +359,7 @@ func TestFetchPagesUpTo_TruncatesWhenServerOverServes(t *testing.T) {
 }
 
 func TestFetchPagesUpTo_SecondPageErrorDiscardsPartial(t *testing.T) {
+	t.Parallel()
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		if r.URL.Query().Get("page") == "1" {
@@ -370,6 +382,7 @@ func TestFetchPagesUpTo_SecondPageErrorDiscardsPartial(t *testing.T) {
 }
 
 func TestFetchPagesUpTo_MalformedJSON(t *testing.T) {
+	t.Parallel()
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"results": [`))
@@ -386,6 +399,7 @@ func TestFetchPagesUpTo_MalformedJSON(t *testing.T) {
 }
 
 func TestFetchPagesUpTo_DoesNotMutateCallerParams(t *testing.T) {
+	t.Parallel()
 	rec := &requestRecorder{}
 	ts := newPageServer(t, 10, rec)
 	defer ts.Close()
@@ -400,6 +414,7 @@ func TestFetchPagesUpTo_DoesNotMutateCallerParams(t *testing.T) {
 }
 
 func TestFetchPagesUpTo_NonPositiveLimit(t *testing.T) {
+	t.Parallel()
 	for _, limit := range []int{0, -1} {
 		t.Run(strconv.Itoa(limit), func(t *testing.T) {
 			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -420,6 +435,7 @@ func TestFetchPagesUpTo_NonPositiveLimit(t *testing.T) {
 
 // A server that keeps claiming a next page while returning nothing would spin the loop forever.
 func TestFetchPagesUpTo_StopsOnEmptyResults(t *testing.T) {
+	t.Parallel()
 	rec := &requestRecorder{}
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		rec.record(r)
@@ -438,6 +454,7 @@ func TestFetchPagesUpTo_StopsOnEmptyResults(t *testing.T) {
 }
 
 func TestFetchAllPages_WalksEveryPageAtTheCap(t *testing.T) {
+	t.Parallel()
 	rec := &requestRecorder{}
 	ts := newPageServer(t, 250, rec)
 	defer ts.Close()

--- a/api/security/security_test.go
+++ b/api/security/security_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 func TestGetCommandAclList_Pagination(t *testing.T) {
+	t.Parallel()
 	var requestCount atomic.Int32
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -79,6 +80,7 @@ func TestGetCommandAclList_Pagination(t *testing.T) {
 }
 
 func TestGetServerAclList_Pagination(t *testing.T) {
+	t.Parallel()
 	var requestCount atomic.Int32
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -147,6 +149,7 @@ func TestGetServerAclList_Pagination(t *testing.T) {
 }
 
 func TestGetFileAclList_Pagination(t *testing.T) {
+	t.Parallel()
 	var requestCount atomic.Int32
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/api/server/server_test.go
+++ b/api/server/server_test.go
@@ -17,6 +17,7 @@ import (
 )
 
 func TestGetServerList_PaginationBug(t *testing.T) {
+	t.Parallel()
 	var requestCount atomic.Int32
 
 	// mock server: 150 servers total (page1=100, page2=50)
@@ -94,6 +95,7 @@ func TestGetServerList_PaginationBug(t *testing.T) {
 }
 
 func TestGetServerIDByName(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name       string
 		serverName string
@@ -138,6 +140,7 @@ func TestGetServerIDByName(t *testing.T) {
 }
 
 func TestCreateRegistrationToken(t *testing.T) {
+	t.Parallel()
 	want := RegistrationTokenCreatedResponse{
 		ID:   "token-uuid-abc",
 		Name: "new-server",
@@ -164,6 +167,7 @@ func TestCreateRegistrationToken(t *testing.T) {
 }
 
 func TestListRegistrationTokens(t *testing.T) {
+	t.Parallel()
 	tokens := []RegistrationTokenDetails{
 		{ID: "uuid-1", Name: "prod-token", Enabled: true},
 		{ID: "uuid-2", Name: "dev-token", Enabled: true},
@@ -193,6 +197,7 @@ func TestListRegistrationTokens(t *testing.T) {
 }
 
 func TestCreateRegistrationToken_WithExpiresAt(t *testing.T) {
+	t.Parallel()
 	expiresAt := "2026-12-31T00:00:00Z"
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -224,6 +229,7 @@ func TestCreateRegistrationToken_WithExpiresAt(t *testing.T) {
 }
 
 func TestCreateRegistrationToken_WithoutExpiresAt(t *testing.T) {
+	t.Parallel()
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		body, _ := io.ReadAll(r.Body)
 		if strings.Contains(string(body), "expires_at") {
@@ -242,6 +248,7 @@ func TestCreateRegistrationToken_WithoutExpiresAt(t *testing.T) {
 }
 
 func TestDeleteRegistrationToken_ByName_Success(t *testing.T) {
+	t.Parallel()
 	const tokenID = "tok-uuid-abc"
 	var deleteCalled bool
 
@@ -274,6 +281,7 @@ func TestDeleteRegistrationToken_ByName_Success(t *testing.T) {
 }
 
 func TestDeleteRegistrationToken_ByName_NotFound(t *testing.T) {
+	t.Parallel()
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := api.ListResponse[RegistrationTokenDetails]{Count: 0, Results: []RegistrationTokenDetails{}}
 		w.Header().Set("Content-Type", "application/json")
@@ -292,6 +300,7 @@ func TestDeleteRegistrationToken_ByName_NotFound(t *testing.T) {
 }
 
 func TestGetRegistrationTokenAttributes_MapsGroupNames(t *testing.T) {
+	t.Parallel()
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		if strings.HasPrefix(r.URL.Path, "/api/iam/groups/") {
@@ -334,6 +343,7 @@ func TestGetRegistrationTokenAttributes_MapsGroupNames(t *testing.T) {
 }
 
 func TestGetRegistrationTokenAttributes_FallsBackToUUID(t *testing.T) {
+	t.Parallel()
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		if strings.HasPrefix(r.URL.Path, "/api/iam/groups/") {
@@ -364,6 +374,7 @@ func TestGetRegistrationTokenAttributes_FallsBackToUUID(t *testing.T) {
 }
 
 func TestGetRegistrationTokenAttributes_ExpiresNever(t *testing.T) {
+	t.Parallel()
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		if strings.HasPrefix(r.URL.Path, "/api/iam/groups/") {
@@ -398,6 +409,7 @@ func TestGetRegistrationTokenAttributes_ExpiresNever(t *testing.T) {
 }
 
 func TestGetRegistrationTokenAttributes_EmptyList(t *testing.T) {
+	t.Parallel()
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		if strings.HasPrefix(r.URL.Path, "/api/iam/groups/") {
@@ -424,6 +436,7 @@ func TestGetRegistrationTokenAttributes_EmptyList(t *testing.T) {
 }
 
 func TestGetAnsibleRegistrationGuideJSON(t *testing.T) {
+	t.Parallel()
 	want := AnsibleGuideJsonResponse{
 		RegistrationGuideMeta: RegistrationGuideMeta{
 			MethodID:         "ansible",
@@ -478,6 +491,7 @@ func TestGetAnsibleRegistrationGuideJSON(t *testing.T) {
 }
 
 func TestDeleteServer(t *testing.T) {
+	t.Parallel()
 	const serverID = "delete-server-id"
 	var deleteCalled bool
 
@@ -511,6 +525,7 @@ func TestDeleteServer(t *testing.T) {
 }
 
 func TestRequestServerAction(t *testing.T) {
+	t.Parallel()
 	const serverID = "action-server-id"
 
 	tests := []struct {

--- a/api/tunnel/tunnel_test.go
+++ b/api/tunnel/tunnel_test.go
@@ -78,6 +78,7 @@ func newCreateTunnelBodyCaptureServer(t *testing.T, capture *createTunnelBodyCap
 }
 
 func TestCreateTunnelSession_BodyIncludesWorkSession_WhenSet(t *testing.T) {
+	t.Parallel()
 	var capture createTunnelBodyCapture
 	ts := newCreateTunnelBodyCaptureServer(t, &capture)
 	defer ts.Close()
@@ -95,6 +96,7 @@ func TestCreateTunnelSession_BodyIncludesWorkSession_WhenSet(t *testing.T) {
 }
 
 func TestCreateTunnelSession_BodyOmitsWorkSession_WhenEmpty(t *testing.T) {
+	t.Parallel()
 	var capture createTunnelBodyCapture
 	ts := newCreateTunnelBodyCaptureServer(t, &capture)
 	defer ts.Close()

--- a/api/webftp/webftp_test.go
+++ b/api/webftp/webftp_test.go
@@ -14,6 +14,7 @@ import (
 )
 
 func TestGetWebFTPLogList(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name            string
 		serverName      string
@@ -123,6 +124,7 @@ func TestGetWebFTPLogList(t *testing.T) {
 
 // Regression for #274: a cursor-token next crashed the old int-typed unmarshal.
 func TestGetWebFTPLogList_FollowsCursor(t *testing.T) {
+	t.Parallel()
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		if r.URL.Query().Get("cursor") == "" {

--- a/api/webhook/webhook_test.go
+++ b/api/webhook/webhook_test.go
@@ -15,6 +15,7 @@ import (
 )
 
 func TestGetWebhookList_Pagination(t *testing.T) {
+	t.Parallel()
 	var requestCount atomic.Int32
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -69,6 +70,7 @@ func TestGetWebhookList_Pagination(t *testing.T) {
 }
 
 func TestGetWebhookIDByName(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name        string
 		webhookName string
@@ -113,6 +115,7 @@ func TestGetWebhookIDByName(t *testing.T) {
 }
 
 func TestDeleteWebhook(t *testing.T) {
+	t.Parallel()
 	const webhookID = "wh-delete-uuid"
 	var deleteCalled bool
 

--- a/api/websh/websh_test.go
+++ b/api/websh/websh_test.go
@@ -34,6 +34,7 @@ const (
 // GetSessionList is that tail reaches the helper as its limit, so a tail larger than the
 // server's 100-item page cap still yields exactly tail sessions.
 func TestGetSessionList_PassesTailAsTheLimit(t *testing.T) {
+	t.Parallel()
 	// Twice the pages the tail needs, so a walk that ignored the limit comes back with 500
 	// and fails the length assertion instead of running until the test timeout.
 	const lastPage = 5
@@ -68,6 +69,7 @@ func TestGetSessionList_PassesTailAsTheLimit(t *testing.T) {
 }
 
 func TestGetSessionList(t *testing.T) {
+	t.Parallel()
 	closedTime := "2026-03-01T00:00:00Z"
 
 	sessions := []SessionDetailResponse{
@@ -121,6 +123,7 @@ func TestGetSessionList(t *testing.T) {
 }
 
 func TestGetSessionDetail(t *testing.T) {
+	t.Parallel()
 	detail := SessionDetailResponse{
 		ID:       "sess-abc",
 		Server:   types.ServerSummary{Name: "test-server"},
@@ -148,6 +151,7 @@ func TestGetSessionDetail(t *testing.T) {
 }
 
 func TestCloseSession(t *testing.T) {
+	t.Parallel()
 	var called bool
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -165,6 +169,7 @@ func TestCloseSession(t *testing.T) {
 }
 
 func TestForceCloseSession(t *testing.T) {
+	t.Parallel()
 	var called bool
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -182,6 +187,7 @@ func TestForceCloseSession(t *testing.T) {
 }
 
 func TestConnectToSession(t *testing.T) {
+	t.Parallel()
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodPost, r.Method)
 
@@ -204,6 +210,7 @@ func TestConnectToSession(t *testing.T) {
 }
 
 func TestInviteToSession(t *testing.T) {
+	t.Parallel()
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodPost, r.Method)
 		assert.Contains(t, r.URL.Path, "sess-abc/invite")
@@ -223,6 +230,7 @@ func TestInviteToSession(t *testing.T) {
 }
 
 func TestJoinWebshSession(t *testing.T) {
+	t.Parallel()
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodPost, r.Method)
 		assert.Contains(t, r.URL.Path, "chan-id-123/join")
@@ -244,6 +252,7 @@ func TestJoinWebshSession(t *testing.T) {
 }
 
 func TestJoinWebshSession_InvalidURL(t *testing.T) {
+	t.Parallel()
 	ac := &client.AlpaconClient{}
 	_, err := JoinWebshSession(ac, "https://example.com/no-channel-param", "password")
 	assert.Error(t, err)
@@ -251,6 +260,7 @@ func TestJoinWebshSession_InvalidURL(t *testing.T) {
 }
 
 func TestBuildSessionRequest_OmitsEmptyWorkSession(t *testing.T) {
+	t.Parallel()
 	req := BuildSessionRequest("srv-1", "alice", "ops", 24, 80, "")
 	assert.Empty(t, req.WorkSession)
 	assert.Equal(t, "srv-1", req.Server)
@@ -266,6 +276,7 @@ func TestBuildSessionRequest_OmitsEmptyWorkSession(t *testing.T) {
 }
 
 func TestBuildSessionRequest_IncludesWorkSession(t *testing.T) {
+	t.Parallel()
 	req := BuildSessionRequest("srv-1", "", "", 24, 80, "ses-abc")
 	assert.Equal(t, "ses-abc", req.WorkSession)
 
@@ -275,6 +286,7 @@ func TestBuildSessionRequest_IncludesWorkSession(t *testing.T) {
 }
 
 func TestGetSessionRecords_FollowsCursor(t *testing.T) {
+	t.Parallel()
 	var gotCursors, gotPageSizes []string
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.True(t, strings.HasSuffix(r.URL.Path, "/records/"))
@@ -306,6 +318,7 @@ func TestGetSessionRecords_FollowsCursor(t *testing.T) {
 }
 
 func TestGetSessionRecords_QueryHitsSearchEndpoint(t *testing.T) {
+	t.Parallel()
 	var gotQuery string
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.True(t, strings.HasSuffix(r.URL.Path, "/search/"))
@@ -419,6 +432,7 @@ func TestReadCtrlC_EndsTheSessionOnCtrlC(t *testing.T) {
 }
 
 func TestWriteToServer_ReportsWriteFailure(t *testing.T) {
+	t.Parallel()
 	conn, _ := dialTestServer(t)
 	require.NoError(t, conn.Close()) // every later WriteMessage fails
 
@@ -437,6 +451,7 @@ func TestWriteToServer_ReportsWriteFailure(t *testing.T) {
 }
 
 func TestReadFromServer_ReportsReadFailure(t *testing.T) {
+	t.Parallel()
 	conn, _ := dialTestServer(t)
 	require.NoError(t, conn.Close()) // every later ReadMessage fails
 
@@ -488,6 +503,7 @@ func TestReadUserInput_ForwardsToTheWriter(t *testing.T) {
 }
 
 func TestWriteToServer_FlushesBufferedInput(t *testing.T) {
+	t.Parallel()
 	conn, received := dialTestServer(t)
 
 	wsClient := newWebsocketClient(nil)
@@ -513,6 +529,7 @@ func TestWriteToServer_FlushesBufferedInput(t *testing.T) {
 }
 
 func TestWatchInterrupt_EndsTheSessionOnSignal(t *testing.T) {
+	t.Parallel()
 	wsClient := newWebsocketClient(nil)
 
 	sigChan := make(chan os.Signal, 1)
@@ -527,6 +544,7 @@ func TestWatchInterrupt_EndsTheSessionOnSignal(t *testing.T) {
 }
 
 func TestFinish_KeepsTheFirstOutcome(t *testing.T) {
+	t.Parallel()
 	wsClient := newWebsocketClient(nil)
 
 	first := errors.New("remote closed the session")
@@ -538,6 +556,7 @@ func TestFinish_KeepsTheFirstOutcome(t *testing.T) {
 }
 
 func TestFinish_NormalizesARemoteCloseToASuccess(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name      string
 		reported  error
@@ -638,6 +657,7 @@ func TestRunWsClient_ReportsTerminalSetupFailure(t *testing.T) {
 }
 
 func TestDial_ReportsTheHandshakeStatus(t *testing.T) {
+	t.Parallel()
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "denied", http.StatusUnauthorized)
 	}))

--- a/api/worksession/worksession_test.go
+++ b/api/worksession/worksession_test.go
@@ -22,6 +22,7 @@ func newTestClient(ts *httptest.Server) *client.AlpaconClient {
 }
 
 func TestGetWorkSessionList(t *testing.T) {
+	t.Parallel()
 	now := time.Now().UTC().Truncate(time.Second)
 	sessions := []WorkSession{
 		{
@@ -52,6 +53,7 @@ func TestGetWorkSessionList(t *testing.T) {
 }
 
 func TestGetWorkSessionList_StatusFilter(t *testing.T) {
+	t.Parallel()
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "pending", r.URL.Query().Get("status"))
 		w.Header().Set("Content-Type", "application/json")
@@ -64,6 +66,7 @@ func TestGetWorkSessionList_StatusFilter(t *testing.T) {
 }
 
 func TestGetWorkSessionList_AssignedUserFilter(t *testing.T) {
+	t.Parallel()
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "6eaa827d-616a-4fa9-ad42-4fbb67bb007b", r.URL.Query().Get("assigned_user"))
 		w.Header().Set("Content-Type", "application/json")
@@ -76,6 +79,7 @@ func TestGetWorkSessionList_AssignedUserFilter(t *testing.T) {
 }
 
 func TestCreateWorkSession(t *testing.T) {
+	t.Parallel()
 	now := time.Now().UTC().Add(time.Hour)
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodPost, r.Method)
@@ -106,6 +110,7 @@ func TestCreateWorkSession(t *testing.T) {
 }
 
 func TestGetWorkSession(t *testing.T) {
+	t.Parallel()
 	now := time.Now().UTC().Add(time.Hour)
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.True(t, strings.HasSuffix(r.URL.Path, "ses-abc/"))
@@ -121,6 +126,7 @@ func TestGetWorkSession(t *testing.T) {
 }
 
 func TestActivateWorkSession(t *testing.T) {
+	t.Parallel()
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodPost, r.Method)
 		assert.True(t, strings.HasSuffix(r.URL.Path, "ses-abc/activate/"))
@@ -134,6 +140,7 @@ func TestActivateWorkSession(t *testing.T) {
 }
 
 func TestCompleteWorkSession(t *testing.T) {
+	t.Parallel()
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodPost, r.Method)
 		assert.True(t, strings.HasSuffix(r.URL.Path, "ses-abc/complete/"))
@@ -147,6 +154,7 @@ func TestCompleteWorkSession(t *testing.T) {
 }
 
 func TestExtendWorkSession(t *testing.T) {
+	t.Parallel()
 	newExpiry := time.Now().UTC().Add(4 * time.Hour).Format(time.RFC3339)
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodPost, r.Method)
@@ -166,6 +174,7 @@ func TestExtendWorkSession(t *testing.T) {
 }
 
 func TestGetWorkSessionList_RequesterTypeFilter(t *testing.T) {
+	t.Parallel()
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "agent", r.URL.Query().Get("requester_type"))
 		w.Header().Set("Content-Type", "application/json")
@@ -178,6 +187,7 @@ func TestGetWorkSessionList_RequesterTypeFilter(t *testing.T) {
 }
 
 func TestGetWorkSessionList_ScopesJoined(t *testing.T) {
+	t.Parallel()
 	now := time.Now().UTC().Add(time.Hour)
 	sessions := []WorkSession{
 		{ID: "s1", Scopes: []string{"command", "websh", "webftp"}, ExpiresAt: now},
@@ -194,6 +204,7 @@ func TestGetWorkSessionList_ScopesJoined(t *testing.T) {
 }
 
 func TestRevokeWorkSession(t *testing.T) {
+	t.Parallel()
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodPost, r.Method)
 		assert.True(t, strings.HasSuffix(r.URL.Path, "ses-abc/revoke/"))
@@ -207,6 +218,7 @@ func TestRevokeWorkSession(t *testing.T) {
 }
 
 func TestCancelWorkSession(t *testing.T) {
+	t.Parallel()
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodPost, r.Method)
 		assert.True(t, strings.HasSuffix(r.URL.Path, "ses-abc/cancel/"))
@@ -220,6 +232,7 @@ func TestCancelWorkSession(t *testing.T) {
 }
 
 func TestGetWorkSessionTimeline(t *testing.T) {
+	t.Parallel()
 	ts := newString("2024-01-15T10:30:00Z")
 	items := []TimelineItem{
 		{Type: "command", Timestamp: ts, Line: "ls -la"},
@@ -242,6 +255,7 @@ func TestGetWorkSessionTimeline(t *testing.T) {
 }
 
 func TestGetWorkSessionTimeline_ExcludeRecords(t *testing.T) {
+	t.Parallel()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.True(t, strings.HasSuffix(r.URL.Path, "ses-xyz/timeline/"))
 		assert.Equal(t, "false", r.URL.Query().Get("include_records"))
@@ -256,6 +270,7 @@ func TestGetWorkSessionTimeline_ExcludeRecords(t *testing.T) {
 }
 
 func TestUpdateWorkSession(t *testing.T) {
+	t.Parallel()
 	var gotBody WorkSessionUpdateRequest
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodPatch, r.Method)
@@ -283,6 +298,7 @@ func TestUpdateWorkSession(t *testing.T) {
 func newString(s string) *string { return &s }
 
 func TestWorkSessionUnmarshalAdjustmentsAndRecommendations(t *testing.T) {
+	t.Parallel()
 	body := []byte(`{
 		"id": "ses-1",
 		"status": "approved",
@@ -315,6 +331,7 @@ func TestWorkSessionUnmarshalAdjustmentsAndRecommendations(t *testing.T) {
 }
 
 func TestWorkSessionUnmarshalNoAdjustments(t *testing.T) {
+	t.Parallel()
 	var ws WorkSession
 	assert.NoError(t, json.Unmarshal([]byte(`{"id":"ses-1","adjustments":null,"recommendations":[]}`), &ws))
 	assert.Nil(t, ws.Adjustments)

--- a/api/workspace/access_control_test.go
+++ b/api/workspace/access_control_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 func TestGetAccessControl(t *testing.T) {
+	t.Parallel()
 	expected := map[string]any{
 		"allow_sudo_with_mfa":       true,
 		"allow_direct_root":         false,
@@ -43,6 +44,7 @@ func TestGetAccessControl(t *testing.T) {
 }
 
 func TestGetAccessControl_ServerError(t *testing.T) {
+	t.Parallel()
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusForbidden)
 		_, _ = w.Write([]byte(`{"detail":"permission denied"}`))
@@ -55,6 +57,7 @@ func TestGetAccessControl_ServerError(t *testing.T) {
 }
 
 func TestGetAccessControl_EmptyResponse(t *testing.T) {
+	t.Parallel()
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{}`))

--- a/api/workspace/authentication_test.go
+++ b/api/workspace/authentication_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func TestGetAuthentication(t *testing.T) {
+	t.Parallel()
 	expected := map[string]any{
 		"mfa_required":         true,
 		"mfa_timeout":          300,
@@ -39,6 +40,7 @@ func TestGetAuthentication(t *testing.T) {
 }
 
 func TestGetAuthentication_ServerError(t *testing.T) {
+	t.Parallel()
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusForbidden)
 		_, _ = w.Write([]byte(`{"detail":"permission denied"}`))
@@ -51,6 +53,7 @@ func TestGetAuthentication_ServerError(t *testing.T) {
 }
 
 func TestGetAuthentication_EmptyResponse(t *testing.T) {
+	t.Parallel()
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{}`))

--- a/api/workspace/mfa_methods_test.go
+++ b/api/workspace/mfa_methods_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 func TestGetMFAMethods(t *testing.T) {
+	t.Parallel()
 	expected := map[string]any{
 		"allowed_mfa_methods": []any{"email", "otp"},
 		"passkey_as_mfa":      false,
@@ -37,6 +38,7 @@ func TestGetMFAMethods(t *testing.T) {
 }
 
 func TestGetMFAMethods_ServerError(t *testing.T) {
+	t.Parallel()
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusForbidden)
 		_, _ = w.Write([]byte(`{"detail":"permission denied"}`))
@@ -49,6 +51,7 @@ func TestGetMFAMethods_ServerError(t *testing.T) {
 }
 
 func TestGetMFAMethods_EmptyResponse(t *testing.T) {
+	t.Parallel()
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{}`))

--- a/api/workspace/preferences_test.go
+++ b/api/workspace/preferences_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func TestGetPreferences(t *testing.T) {
+	t.Parallel()
 	expected := map[string]any{
 		"language":              "ko",
 		"timezone":              "Asia/Seoul",
@@ -42,6 +43,7 @@ func TestGetPreferences(t *testing.T) {
 }
 
 func TestGetPreferences_ServerError(t *testing.T) {
+	t.Parallel()
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusForbidden)
 		_, _ = w.Write([]byte(`{"detail":"permission denied"}`))
@@ -54,6 +56,7 @@ func TestGetPreferences_ServerError(t *testing.T) {
 }
 
 func TestGetPreferences_EmptyResponse(t *testing.T) {
+	t.Parallel()
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{}`))

--- a/api/workspace/usage_test.go
+++ b/api/workspace/usage_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 func TestGetPaymentAPIBaseURL(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name         string
 		workspaceURL string
@@ -33,6 +34,7 @@ func TestGetPaymentAPIBaseURL(t *testing.T) {
 }
 
 func TestGetWorkspaceID(t *testing.T) {
+	t.Parallel()
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodGet, r.Method)
 		assert.Equal(t, "/api/workspaces/workspaces/", r.URL.Path)
@@ -55,6 +57,7 @@ func TestGetWorkspaceID(t *testing.T) {
 }
 
 func TestGetWorkspaceID_NotFound(t *testing.T) {
+	t.Parallel()
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(map[string]any{
@@ -73,6 +76,7 @@ func TestGetWorkspaceID_NotFound(t *testing.T) {
 }
 
 func TestGetUsageEstimate(t *testing.T) {
+	t.Parallel()
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodGet, r.Method)
 		assert.Equal(t, "/api/workspaces/workspaces/uuid-123/estimate/", r.URL.Path)
@@ -106,6 +110,7 @@ func TestGetUsageEstimate(t *testing.T) {
 }
 
 func TestGetUsageEstimate_ServerError(t *testing.T) {
+	t.Parallel()
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusForbidden)
 		_, _ = w.Write([]byte(`{"detail":"permission denied"}`))

--- a/api/workspace/workspace_test.go
+++ b/api/workspace/workspace_test.go
@@ -21,6 +21,7 @@ func buildTestJWT(t *testing.T, claims map[string]any) string {
 }
 
 func TestGetWorkspacesFromToken(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name      string
 		claims    map[string]any
@@ -81,6 +82,7 @@ func TestGetWorkspacesFromToken(t *testing.T) {
 }
 
 func TestGetWorkspacesFromToken_FieldValues(t *testing.T) {
+	t.Parallel()
 	token := buildTestJWT(t, map[string]any{
 		"https://alpacon.io/workspaces": []map[string]any{
 			{"schema_name": "production", "auth0_id": "org_123", "region": "ap1"},
@@ -96,6 +98,7 @@ func TestGetWorkspacesFromToken_FieldValues(t *testing.T) {
 }
 
 func TestGetWorkspaceList(t *testing.T) {
+	t.Parallel()
 	token := buildTestJWT(t, map[string]any{
 		"https://alpacon.io/workspaces": []map[string]any{
 			{"schema_name": "ws1", "auth0_id": "org_abc", "region": "ap1"},
@@ -148,6 +151,7 @@ func TestGetWorkspaceList(t *testing.T) {
 }
 
 func TestGetWorkspaceList_SingleWorkspace(t *testing.T) {
+	t.Parallel()
 	token := buildTestJWT(t, map[string]any{
 		"https://alpacon.io/workspaces": []map[string]any{
 			{"schema_name": "only-ws", "auth0_id": "org_abc", "region": "ap1"},
@@ -168,6 +172,7 @@ func TestGetWorkspaceList_SingleWorkspace(t *testing.T) {
 }
 
 func TestResolveWorkspaceURL(t *testing.T) {
+	t.Parallel()
 	token := buildTestJWT(t, map[string]any{
 		"https://alpacon.io/workspaces": []map[string]any{
 			{"schema_name": "ws1", "auth0_id": "org_abc", "region": "ap1"},
@@ -220,6 +225,7 @@ func TestResolveWorkspaceURL(t *testing.T) {
 }
 
 func TestValidateAndBuildWorkspaceURL(t *testing.T) {
+	t.Parallel()
 	token := buildTestJWT(t, map[string]any{
 		"https://alpacon.io/workspaces": []map[string]any{
 			{"schema_name": "ws1", "auth0_id": "org_abc", "region": "ap1"},
@@ -286,6 +292,7 @@ func TestValidateAndBuildWorkspaceURL(t *testing.T) {
 }
 
 func TestValidateAndBuildWorkspaceURL_InvalidToken(t *testing.T) {
+	t.Parallel()
 	cfg := config.Config{
 		AccessToken: "not-a-jwt",
 		BaseDomain:  "alpacon.io",

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -29,6 +29,7 @@ func newTestClient(baseURL string) *AlpaconClient {
 }
 
 func TestSendRequest_401SurfacesServerDetail(t *testing.T) {
+	t.Parallel()
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusUnauthorized)
@@ -43,6 +44,7 @@ func TestSendRequest_401SurfacesServerDetail(t *testing.T) {
 }
 
 func TestSendRequest_401WithoutBodyFallsBackToLoginHint(t *testing.T) {
+	t.Parallel()
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusUnauthorized)
 	}))
@@ -54,6 +56,7 @@ func TestSendRequest_401WithoutBodyFallsBackToLoginHint(t *testing.T) {
 }
 
 func TestSendRequest_401EmptyJSONFallsBackToLoginHint(t *testing.T) {
+	t.Parallel()
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusUnauthorized)
@@ -68,6 +71,7 @@ func TestSendRequest_401EmptyJSONFallsBackToLoginHint(t *testing.T) {
 }
 
 func TestSendRequest_404ExposesStatusCode(t *testing.T) {
+	t.Parallel()
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusNotFound)
@@ -82,6 +86,7 @@ func TestSendRequest_404ExposesStatusCode(t *testing.T) {
 }
 
 func TestSendRequest_404EmptyBodyExposesStatusCode(t *testing.T) {
+	t.Parallel()
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusNotFound)
 	}))
@@ -94,6 +99,7 @@ func TestSendRequest_404EmptyBodyExposesStatusCode(t *testing.T) {
 }
 
 func TestSendRequest_404HTMLBodyExposesStatusCode(t *testing.T) {
+	t.Parallel()
 	// An old server/proxy without the endpoint may answer 404 with an HTML page;
 	// the status must still reach callers so the whoami legacy fallback triggers.
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -110,6 +116,7 @@ func TestSendRequest_404HTMLBodyExposesStatusCode(t *testing.T) {
 }
 
 func TestSendRequest_TruncatedBodyKeepsStatusCode(t *testing.T) {
+	t.Parallel()
 	// A connection cut mid-body through a proxy: the headers already named the
 	// status, so a caller can still tell an unreadable answer from a request that
 	// never went out.
@@ -129,6 +136,7 @@ func TestSendRequest_TruncatedBodyKeepsStatusCode(t *testing.T) {
 }
 
 func TestSendRequest_401ExposesStatusCode(t *testing.T) {
+	t.Parallel()
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusUnauthorized)
@@ -143,11 +151,13 @@ func TestSendRequest_401ExposesStatusCode(t *testing.T) {
 }
 
 func TestHTTPStatusCode_NonAPIErrorIsZero(t *testing.T) {
+	t.Parallel()
 	assert.Equal(t, 0, utils.HTTPStatusCode(errors.New("boom")))
 	assert.Equal(t, 0, utils.HTTPStatusCode(nil))
 }
 
 func TestSendRequest_429ExposesRetryAfter(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name       string
 		retryAfter string
@@ -187,6 +197,7 @@ func TestSendRequest_429ExposesRetryAfter(t *testing.T) {
 // A proxy-level throttle answers with its own HTML, which readJSONResponse rejects
 // before the status check ever runs. The hint has to survive that path too.
 func TestSendRequest_429WithNonJSONBodyExposesRetryAfter(t *testing.T) {
+	t.Parallel()
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/html")
 		w.Header().Set("Retry-After", "29")
@@ -204,6 +215,7 @@ func TestSendRequest_429WithNonJSONBodyExposesRetryAfter(t *testing.T) {
 
 // Upload shares the throttle, so it must tag the hint the same way sendRequest does.
 func TestSendMultipartStreamRequest_429ExposesRetryAfter(t *testing.T) {
+	t.Parallel()
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.Header().Set("Retry-After", "29")
@@ -219,11 +231,13 @@ func TestSendMultipartStreamRequest_429ExposesRetryAfter(t *testing.T) {
 }
 
 func TestRetryAfter_ErrorWithoutHintIsZero(t *testing.T) {
+	t.Parallel()
 	assert.Equal(t, time.Duration(0), utils.RetryAfter(errors.New("boom")))
 	assert.Equal(t, time.Duration(0), utils.RetryAfter(nil))
 }
 
 func TestSendRequest_403SurfacesServerDetail(t *testing.T) {
+	t.Parallel()
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusForbidden)
@@ -237,6 +251,7 @@ func TestSendRequest_403SurfacesServerDetail(t *testing.T) {
 }
 
 func TestSendRequest_403PreservesWorkSessionCodeAndSource(t *testing.T) {
+	t.Parallel()
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusForbidden)
@@ -258,6 +273,7 @@ func TestSendRequest_403PreservesWorkSessionCodeAndSource(t *testing.T) {
 }
 
 func TestSendRequest_403WithoutBodyFallsBackToGenericMessage(t *testing.T) {
+	t.Parallel()
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusForbidden)
 	}))
@@ -269,6 +285,7 @@ func TestSendRequest_403WithoutBodyFallsBackToGenericMessage(t *testing.T) {
 }
 
 func TestSendRequest_403EmptyDetailFallsBackToGenericMessage(t *testing.T) {
+	t.Parallel()
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusForbidden)
@@ -283,6 +300,7 @@ func TestSendRequest_403EmptyDetailFallsBackToGenericMessage(t *testing.T) {
 }
 
 func TestSendRequest_403CodeWithoutDetailKeepsCodeSource(t *testing.T) {
+	t.Parallel()
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusForbidden)
@@ -301,6 +319,7 @@ func TestSendRequest_403CodeWithoutDetailKeepsCodeSource(t *testing.T) {
 }
 
 func TestSendRequest_403ACLDeniedExplainsTokenAccessControl(t *testing.T) {
+	t.Parallel()
 	// An ACL refusal (exec, websh, cp) arrives as a bare {"code": ...} 403—the
 	// server's error handler emits nothing else. Without a mapping the user reads
 	// the generic privileges message and never learns a token rule caused it.
@@ -325,6 +344,7 @@ func TestSendRequest_403ACLDeniedExplainsTokenAccessControl(t *testing.T) {
 }
 
 func TestSendRequest_400ACLDeniedKeepsCodeWithoutAuthStatusMessage(t *testing.T) {
+	t.Parallel()
 	// The server still returns 400 for an ACL denial until alpacax/alpacon-server#2804
 	// lands. checkAuthStatus only handles 401/403, so this body never reaches
 	// authStatusCodeMessage—the code must still survive for callers that route on it.
@@ -345,6 +365,7 @@ func TestSendRequest_400ACLDeniedKeepsCodeWithoutAuthStatusMessage(t *testing.T)
 }
 
 func TestSendRequest_401MFARequiredCodeNoReLoginHint(t *testing.T) {
+	t.Parallel()
 	// Accessing root / a system account requires MFA: the server returns 401
 	// with {"code": "auth_mfa_required"} and no detail string. This must not be
 	// mislabeled as an authentication failure or suggest re-login—the user is
@@ -368,6 +389,7 @@ func TestSendRequest_401MFARequiredCodeNoReLoginHint(t *testing.T) {
 }
 
 func TestSendRequest_401MFARequiredPrefersServerDetail(t *testing.T) {
+	t.Parallel()
 	// When the server also provides a human detail, surface it—still without a
 	// re-login hint, since a coded 401 is not a stale token.
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -387,6 +409,7 @@ func TestSendRequest_401MFARequiredPrefersServerDetail(t *testing.T) {
 }
 
 func TestSendRequest_401CodedDenialNotMislabeledAsAuthFailure(t *testing.T) {
+	t.Parallel()
 	// Any coded 401 without a detail must not become "authentication failed" /
 	// re-login; the code is preserved for downstream handling.
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -407,6 +430,7 @@ func TestSendRequest_401CodedDenialNotMislabeledAsAuthFailure(t *testing.T) {
 }
 
 func TestLoadCurrentUser_PopulatesFieldsAndCaches(t *testing.T) {
+	t.Parallel()
 	callCount := 0
 	var requestedPath string
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -436,6 +460,7 @@ func TestLoadCurrentUser_PopulatesFieldsAndCaches(t *testing.T) {
 }
 
 func TestLoadCurrentUser_SuperuserPrivileges(t *testing.T) {
+	t.Parallel()
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(CurrentUserResponse{
@@ -452,6 +477,7 @@ func TestLoadCurrentUser_SuperuserPrivileges(t *testing.T) {
 }
 
 func TestLoadCurrentUser_GeneralPrivileges(t *testing.T) {
+	t.Parallel()
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(CurrentUserResponse{
@@ -468,6 +494,7 @@ func TestLoadCurrentUser_GeneralPrivileges(t *testing.T) {
 }
 
 func TestLoadCurrentUser_401SurfacesServerDetail(t *testing.T) {
+	t.Parallel()
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusUnauthorized)
@@ -484,6 +511,7 @@ func TestLoadCurrentUser_401SurfacesServerDetail(t *testing.T) {
 }
 
 func TestLoadCurrentUser_403ReturnsForbiddenError(t *testing.T) {
+	t.Parallel()
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusForbidden)
 	}))
@@ -497,6 +525,7 @@ func TestLoadCurrentUser_403ReturnsForbiddenError(t *testing.T) {
 }
 
 func TestLoadCurrentUser_InvalidJSONReturnsError(t *testing.T) {
+	t.Parallel()
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`not valid json`))
@@ -511,6 +540,7 @@ func TestLoadCurrentUser_InvalidJSONReturnsError(t *testing.T) {
 }
 
 func TestSendGetRequestForDownload_401ReturnsAuthError(t *testing.T) {
+	t.Parallel()
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusUnauthorized)
 	}))
@@ -522,6 +552,7 @@ func TestSendGetRequestForDownload_401ReturnsAuthError(t *testing.T) {
 }
 
 func TestSendGetRequestForDownload_403ReturnsForbiddenError(t *testing.T) {
+	t.Parallel()
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusForbidden)
 	}))
@@ -533,6 +564,7 @@ func TestSendGetRequestForDownload_403ReturnsForbiddenError(t *testing.T) {
 }
 
 func TestSendMultipartStreamRequest_401ReturnsAuthError(t *testing.T) {
+	t.Parallel()
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusUnauthorized)
 	}))
@@ -548,6 +580,7 @@ func TestSendMultipartStreamRequest_401ReturnsAuthError(t *testing.T) {
 }
 
 func TestSendMultipartStreamRequest_200IsSuccess(t *testing.T) {
+	t.Parallel()
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
@@ -566,6 +599,7 @@ func TestSendMultipartStreamRequest_200IsSuccess(t *testing.T) {
 }
 
 func TestSendMultipartStreamRequest_ReplaysFileBodyOnTemporaryRedirect(t *testing.T) {
+	t.Parallel()
 	var finalHit bool
 	var uploadedContent string
 	var finalContentLength int64
@@ -628,6 +662,7 @@ func TestSendMultipartStreamRequest_ReplaysFileBodyOnTemporaryRedirect(t *testin
 }
 
 func TestSendPostRequest_204IsSuccess(t *testing.T) {
+	t.Parallel()
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodPost, r.Method)
 		w.WriteHeader(http.StatusNoContent)
@@ -641,6 +676,7 @@ func TestSendPostRequest_204IsSuccess(t *testing.T) {
 }
 
 func TestSendDeleteRequest_200IsSuccess(t *testing.T) {
+	t.Parallel()
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodDelete, r.Method)
 		w.Header().Set("Content-Type", "application/json")
@@ -656,6 +692,7 @@ func TestSendDeleteRequest_200IsSuccess(t *testing.T) {
 }
 
 func TestLoadCurrentUser_ErrorIsCachedOnFailure(t *testing.T) {
+	t.Parallel()
 	callCount := 0
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		callCount++

--- a/cmd/approval/approval_list_test.go
+++ b/cmd/approval/approval_list_test.go
@@ -23,12 +23,14 @@ func TestValidateStatusFilter(t *testing.T) {
 		{"active", true},
 	}
 	for _, tc := range cases {
-		err := validateStatusFilter(tc.input)
-		if tc.wantErr {
-			assert.Error(t, err, "input: %q", tc.input)
-		} else {
-			assert.NoError(t, err, "input: %q", tc.input)
-		}
+		t.Run(tc.input, func(t *testing.T) {
+			err := validateStatusFilter(tc.input)
+			if tc.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
 	}
 }
 
@@ -52,11 +54,13 @@ func TestValidateTypeFilter(t *testing.T) {
 		{"WorkSession", true},
 	}
 	for _, tc := range cases {
-		err := validateTypeFilter(tc.input)
-		if tc.wantErr {
-			assert.Error(t, err, "input: %q", tc.input)
-		} else {
-			assert.NoError(t, err, "input: %q", tc.input)
-		}
+		t.Run(tc.input, func(t *testing.T) {
+			err := validateTypeFilter(tc.input)
+			if tc.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
 	}
 }

--- a/cmd/approval/approval_list_test.go
+++ b/cmd/approval/approval_list_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 func TestValidateStatusFilter(t *testing.T) {
+	t.Parallel()
 	cases := []struct {
 		input   string
 		wantErr bool
@@ -32,6 +33,7 @@ func TestValidateStatusFilter(t *testing.T) {
 }
 
 func TestValidateTypeFilter(t *testing.T) {
+	t.Parallel()
 	cases := []struct {
 		input   string
 		wantErr bool

--- a/cmd/csr/csr_test.go
+++ b/cmd/csr/csr_test.go
@@ -147,6 +147,7 @@ func TestCreateSubcommandFlags(t *testing.T) {
 }
 
 func TestSplitAndTrim(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name  string
 		input string
@@ -168,6 +169,7 @@ func TestSplitAndTrim(t *testing.T) {
 }
 
 func TestFirstOf(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name string
 		a, b []string
@@ -186,6 +188,7 @@ func TestFirstOf(t *testing.T) {
 }
 
 func TestEnsureSecureConnection_HTTPS(t *testing.T) {
+	t.Parallel()
 	ac := &client.AlpaconClient{
 		HTTPClient: &http.Client{},
 		BaseURL:    "https://secure.example.com",

--- a/cmd/edit/edit_test.go
+++ b/cmd/edit/edit_test.go
@@ -29,6 +29,7 @@ func TestResolveEditor(t *testing.T) {
 }
 
 func TestRunLocalEditorSupportsQuotedArguments(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	logPath := filepath.Join(dir, "args.log")
 	scriptPath := filepath.Join(dir, "editor.sh")
@@ -45,18 +46,21 @@ func TestRunLocalEditorSupportsQuotedArguments(t *testing.T) {
 }
 
 func TestSplitEditorCommandPreservesWindowsBackslashes(t *testing.T) {
+	t.Parallel()
 	parts, err := splitEditorCommand(`"C:\Program Files\Vim\vim.exe" --wait`)
 	require.NoError(t, err)
 	assert.Equal(t, []string{`C:\Program Files\Vim\vim.exe`, "--wait"}, parts)
 }
 
 func TestSplitEditorCommandPreservesEmptyQuotedArgument(t *testing.T) {
+	t.Parallel()
 	parts, err := splitEditorCommand(`emacsclient -a "" -c`)
 	require.NoError(t, err)
 	assert.Equal(t, []string{"emacsclient", "-a", "", "-c"}, parts)
 }
 
 func TestGuiEditorWaitWarning(t *testing.T) {
+	t.Parallel()
 	cases := []struct {
 		name  string
 		input string
@@ -84,6 +88,7 @@ func TestGuiEditorWaitWarning(t *testing.T) {
 }
 
 func TestParseEditTarget(t *testing.T) {
+	t.Parallel()
 	target, err := parseEditTarget("root@prod:/etc/nginx/nginx.conf", "")
 	require.NoError(t, err)
 	assert.Equal(t, "prod", target.Server)
@@ -102,6 +107,7 @@ func TestParseEditTarget(t *testing.T) {
 }
 
 func TestParseEditTargetRejectsInvalidTargets(t *testing.T) {
+	t.Parallel()
 	cases := []struct {
 		name  string
 		input string
@@ -120,6 +126,7 @@ func TestParseEditTargetRejectsInvalidTargets(t *testing.T) {
 }
 
 func TestEditTempPathUniquePerInvocation(t *testing.T) {
+	t.Parallel()
 	root := t.TempDir()
 	target := editTarget{Server: "prod", RemotePath: "/etc/app.conf"}
 	first, err := editTempPath(root, target)
@@ -132,6 +139,7 @@ func TestEditTempPathUniquePerInvocation(t *testing.T) {
 }
 
 func TestEditTempPathRejectsInvalidRemoteBasename(t *testing.T) {
+	t.Parallel()
 	for _, remotePath := range []string{"/tmp/..", "/tmp/app.conf/", `/tmp/..\saved`} {
 		t.Run(remotePath, func(t *testing.T) {
 			_, err := editTempPath(t.TempDir(), editTarget{Server: "prod", RemotePath: remotePath})
@@ -142,6 +150,7 @@ func TestEditTempPathRejectsInvalidRemoteBasename(t *testing.T) {
 }
 
 func TestRunEditRestrictsDownloadedFilePermissions(t *testing.T) {
+	t.Parallel()
 	tempRoot := t.TempDir()
 	var editorPerm os.FileMode
 	deps := editDeps{
@@ -176,6 +185,7 @@ func TestRunEditRestrictsDownloadedFilePermissions(t *testing.T) {
 }
 
 func TestRunEditNoChangesSkipsUploadAndRemovesTemp(t *testing.T) {
+	t.Parallel()
 	tempRoot := t.TempDir()
 	var uploadCalled bool
 	deps := editDeps{
@@ -211,6 +221,7 @@ func TestRunEditNoChangesSkipsUploadAndRemovesTemp(t *testing.T) {
 }
 
 func TestRunEditSuccessfulUploadRemovesEditorSidecarFiles(t *testing.T) {
+	t.Parallel()
 	tempRoot := t.TempDir()
 	deps := editDeps{
 		download: func(target editTarget, localPath, workSessionID string) (ftpapi.DownloadedFile, error) {
@@ -244,6 +255,7 @@ func TestRunEditSuccessfulUploadRemovesEditorSidecarFiles(t *testing.T) {
 }
 
 func TestRunEditUploadFailurePreservesTempPath(t *testing.T) {
+	t.Parallel()
 	tempRoot := t.TempDir()
 	uploadErr := errors.New("upload failed")
 	deps := editDeps{
@@ -276,6 +288,7 @@ func TestRunEditUploadFailurePreservesTempPath(t *testing.T) {
 }
 
 func TestRunEditEditorFailureWithoutChangeRemovesTemp(t *testing.T) {
+	t.Parallel()
 	tempRoot := t.TempDir()
 	editorErr := errors.New("editor exited 1")
 	deps := editDeps{
@@ -306,6 +319,7 @@ func TestRunEditEditorFailureWithoutChangeRemovesTemp(t *testing.T) {
 }
 
 func TestRunEditEditorFailureAfterChangePreservesTemp(t *testing.T) {
+	t.Parallel()
 	tempRoot := t.TempDir()
 	editorErr := errors.New("editor exited 1")
 	deps := editDeps{
@@ -338,6 +352,7 @@ func TestRunEditEditorFailureAfterChangePreservesTemp(t *testing.T) {
 }
 
 func TestRunEditLargeFileDeclineRemovesTempAndSkipsEditor(t *testing.T) {
+	t.Parallel()
 	tempRoot := t.TempDir()
 	var editorCalled bool
 	deps := editDeps{

--- a/cmd/event/render_test.go
+++ b/cmd/event/render_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func TestRenderEvent_JSONIsOneLinePerFrameAndPreservesUnknownFields(t *testing.T) {
+	t.Parallel()
 	raw := []byte("{\n  \"event_type\": \"work_session\",\n  \"payload\": {\n    \"sub_type\": \"approved\",\n    \"brand_new_field\": 7\n  }\n}")
 
 	var buf bytes.Buffer
@@ -30,6 +31,7 @@ func TestRenderEvent_JSONIsOneLinePerFrameAndPreservesUnknownFields(t *testing.T
 }
 
 func TestRenderEvent_TableHasFourFixedFields(t *testing.T) {
+	t.Parallel()
 	now := time.Date(2026, 7, 29, 13, 4, 5, 0, time.UTC)
 
 	tests := []struct {
@@ -87,6 +89,7 @@ func TestRenderEvent_TableHasFourFixedFields(t *testing.T) {
 }
 
 func TestRenderEvent_InvalidJSONWritesNothing(t *testing.T) {
+	t.Parallel()
 	for _, format := range []string{utils.OutputFormatTable, utils.OutputFormatJSON} {
 		t.Run(format, func(t *testing.T) {
 			var buf bytes.Buffer
@@ -102,6 +105,7 @@ func TestRenderEvent_InvalidJSONWritesNothing(t *testing.T) {
 // A bare JSON null unmarshals into the zero struct without error, so without the check
 // the table path would print it as a legitimate-looking row of dashes.
 func TestRenderEvent_TableRejectsAFrameWithNoEventType(t *testing.T) {
+	t.Parallel()
 	// The escape-only case pins that the check runs after stripping, not before.
 	for _, raw := range []string{
 		`null`,

--- a/cmd/event/wait_adapter_test.go
+++ b/cmd/event/wait_adapter_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 func TestWorkSessionStatusSubType(t *testing.T) {
+	t.Parallel()
 	// The event channel and the REST projection agree everywhere except active.
 	// Reusing the REST status verbatim would silently never match an approval.
 	tests := []struct {
@@ -34,6 +35,7 @@ func TestWorkSessionStatusSubType(t *testing.T) {
 }
 
 func TestResolveWaitOptions_RegisteredTypeGetsItsDefaults(t *testing.T) {
+	t.Parallel()
 	opts, err := resolveWaitOptions(nil, "work_session", "ws-uuid", nil, time.Minute)
 
 	require.NoError(t, err)
@@ -44,6 +46,7 @@ func TestResolveWaitOptions_RegisteredTypeGetsItsDefaults(t *testing.T) {
 }
 
 func TestResolveWaitOptions_NoTargetMeansNoCatchUp(t *testing.T) {
+	t.Parallel()
 	// Catch-up reads one resource by id; without a target there is nothing to read.
 	opts, err := resolveWaitOptions(nil, "work_session", "", nil, time.Minute)
 
@@ -52,6 +55,7 @@ func TestResolveWaitOptions_NoTargetMeansNoCatchUp(t *testing.T) {
 }
 
 func TestResolveWaitOptions_UntilOverridesButKeepsCatchUp(t *testing.T) {
+	t.Parallel()
 	opts, err := resolveWaitOptions(nil, "work_session", "ws-uuid", []string{"activated"}, time.Minute)
 
 	require.NoError(t, err)
@@ -61,6 +65,7 @@ func TestResolveWaitOptions_UntilOverridesButKeepsCatchUp(t *testing.T) {
 }
 
 func TestResolveWaitOptions_UnregisteredTypeNeedsUntil(t *testing.T) {
+	t.Parallel()
 	opts, err := resolveWaitOptions(nil, "notification", "", []string{"created"}, time.Minute)
 
 	require.NoError(t, err)
@@ -74,6 +79,7 @@ func TestResolveWaitOptions_UnregisteredTypeNeedsUntil(t *testing.T) {
 }
 
 func TestResolveWaitOptions_OptionsAreEventAPITyped(t *testing.T) {
+	t.Parallel()
 	// Guards the seam: cmd owns the domain knowledge, api/event stays type-ignorant.
 	var opts eventapi.WaitOptions
 	opts, err := resolveWaitOptions(nil, "work_session", "ws-uuid", nil, time.Minute)

--- a/cmd/exec/credential_hint_test.go
+++ b/cmd/exec/credential_hint_test.go
@@ -19,6 +19,7 @@ import (
 // must fire only on utils.CommandInlineCredential, never on other codes, a nil
 // err, or a plain error without a code.
 func TestIsCommandInlineCredentialError(t *testing.T) {
+	t.Parallel()
 	t.Run("true when the error carries the inline-credential code", func(t *testing.T) {
 		err := errors.New("code: " + utils.CommandInlineCredential + "; source: command")
 		assert.True(t, isCommandInlineCredentialError(err))
@@ -43,6 +44,7 @@ func TestIsCommandInlineCredentialError(t *testing.T) {
 // to echo—the example is fixed—but this guards against a future edit that starts
 // interpolating the rejected line).
 func TestCredentialInlineHint(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name      string
 		invokedAs Invocation
@@ -86,6 +88,7 @@ func newInlineCredentialDenialServer() *httptest.Server {
 // the envelope carries the server's error_code with a plain (non-special)
 // exit code 1—this refusal is not a WorkSession gate or a pending approval.
 func TestExecInlineCredentialDenialExits1WithJSONErrorCode(t *testing.T) {
+	t.Parallel()
 	ts := newInlineCredentialDenialServer()
 	defer ts.Close()
 
@@ -137,6 +140,7 @@ func TestExecInlineCredentialDenialExits1WithJSONErrorCode(t *testing.T) {
 // default table output and asserts the human-facing error + hint, and that the
 // rejected command line is never echoed.
 func TestExecInlineCredentialDenialTablePrintsHint(t *testing.T) {
+	t.Parallel()
 	ts := newInlineCredentialDenialServer()
 	defer ts.Close()
 
@@ -181,6 +185,7 @@ func TestExecInlineCredentialDenialTablePrintsHint(t *testing.T) {
 // hit the pre-existing generic failure path (plain "Error: ..." line, no
 // credential hint), not the new branch.
 func TestExecNonInlineCredentialErrorFallsThroughUnchanged(t *testing.T) {
+	t.Parallel()
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		switch {

--- a/cmd/exec/exec_test.go
+++ b/cmd/exec/exec_test.go
@@ -9,6 +9,7 @@ import (
 // TestExecCommandParsing validates backward compatibility with the original
 // parsing behavior using the new ParseRemoteExecArgs implementation.
 func TestExecCommandParsing(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name              string
 		args              []string
@@ -72,6 +73,7 @@ func TestExecCommandParsing(t *testing.T) {
 }
 
 func TestExecCommandParsingWithFlags(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name              string
 		args              []string
@@ -119,6 +121,7 @@ func TestExecCommandParsingWithFlags(t *testing.T) {
 
 // TestRequiredExecPattern validates the exact pattern from the issue description.
 func TestRequiredExecPattern(t *testing.T) {
+	t.Parallel()
 	args := []string{"root@prod-docker", "docker", "ps"}
 	result := ParseRemoteExecArgs(args)
 

--- a/cmd/exec/logs_test.go
+++ b/cmd/exec/logs_test.go
@@ -14,6 +14,7 @@ func intPtr(i int) *int       { return &i }
 func strPtr(s string) *string { return &s }
 
 func TestIsRunningStatus(t *testing.T) {
+	t.Parallel()
 	running := []string{"queued", "scheduled", "delivered", "verifying", "running", "acked"}
 	for _, s := range running {
 		assert.True(t, event.IsRunningStatus(s), "expected %q to be running", s)
@@ -25,6 +26,7 @@ func TestIsRunningStatus(t *testing.T) {
 }
 
 func TestLogsCommandOutcome(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name               string
 		details            event.EventDetails
@@ -180,6 +182,7 @@ func TestLogsCommandOutcome(t *testing.T) {
 // reach the running and failed branches, so ID and ErrorPhase carry the payload
 // there, while the unrecognised-status fallback renders Status itself (#364).
 func TestLogsCommandOutcomeSanitizesServerText(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name       string
 		details    event.EventDetails

--- a/cmd/exec/parse_test.go
+++ b/cmd/exec/parse_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 func TestParseRemoteExecArgs(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		args     []string
@@ -517,6 +518,7 @@ func TestParseRemoteExecArgs(t *testing.T) {
 }
 
 func TestWaitTimeout(t *testing.T) {
+	t.Parallel()
 	assert.Equal(t, time.Duration(0), RemoteExecArgs{}.WaitTimeout())
 	assert.Equal(t, 5*time.Minute, RemoteExecArgs{Wait: true}.WaitTimeout())
 	assert.Equal(t, 10*time.Minute, RemoteExecArgs{WaitApproval: 10 * time.Minute}.WaitTimeout())
@@ -525,6 +527,7 @@ func TestWaitTimeout(t *testing.T) {
 }
 
 func TestParseRemoteExecArgs_HelpFlag(t *testing.T) {
+	t.Parallel()
 	for _, flag := range []string{"-h", "--help"} {
 		t.Run(flag, func(t *testing.T) {
 			result := ParseRemoteExecArgs([]string{flag, "server", "ls"})
@@ -535,6 +538,7 @@ func TestParseRemoteExecArgs_HelpFlag(t *testing.T) {
 }
 
 func TestParseRemoteExecArgs_WorkSessionFlag(t *testing.T) {
+	t.Parallel()
 	parsed := ParseRemoteExecArgs([]string{"--work-session", "ses-abc", "my-server", "ls"})
 	assert.Equal(t, "ses-abc", parsed.WorkSessionID)
 	assert.Equal(t, "my-server", parsed.Server)
@@ -542,6 +546,7 @@ func TestParseRemoteExecArgs_WorkSessionFlag(t *testing.T) {
 }
 
 func TestParseRemoteExecArgs_WorkSessionEqualForm(t *testing.T) {
+	t.Parallel()
 	parsed := ParseRemoteExecArgs([]string{"--work-session=ses-abc", "my-server", "ls"})
 	assert.Equal(t, "ses-abc", parsed.WorkSessionID)
 	assert.Equal(t, "my-server", parsed.Server)
@@ -549,6 +554,7 @@ func TestParseRemoteExecArgs_WorkSessionEqualForm(t *testing.T) {
 }
 
 func TestParseRemoteExecArgs_DoubleDashIgnoresWorkSession(t *testing.T) {
+	t.Parallel()
 	parsed := ParseRemoteExecArgs([]string{"my-server", "--", "ls", "--work-session", "fake"})
 	assert.Equal(t, "", parsed.WorkSessionID)
 	assert.Equal(t, "my-server", parsed.Server)
@@ -560,6 +566,7 @@ func TestParseRemoteExecArgs_DoubleDashIgnoresWorkSession(t *testing.T) {
 // strips the surrounding quotes during tokenization. Without this, strings.Join
 // loses the arg boundary and the server's sh fails with a syntax error (issue #164).
 func TestParseRemoteExecArgs_ShellQuoting(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name             string
 		args             []string
@@ -670,16 +677,19 @@ func TestParseRemoteExecArgs_OutputFlag(t *testing.T) {
 }
 
 func TestParseRemoteExecArgs_OutputFlagMissingValue(t *testing.T) {
+	t.Parallel()
 	result := ParseRemoteExecArgs([]string{"--output"})
 	assert.NotEmpty(t, result.Err)
 }
 
 func TestParseRemoteExecArgs_OutputFlagEmptyValue(t *testing.T) {
+	t.Parallel()
 	result := ParseRemoteExecArgs([]string{"--output="})
 	assert.NotEmpty(t, result.Err)
 }
 
 func TestParseRemoteExecArgs_DetachFlag(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name        string
 		args        []string
@@ -844,18 +854,21 @@ func TestParseRemoteExecArgs_EnvFlag(t *testing.T) {
 }
 
 func TestParseRemoteExecArgs_EnvErrorHidesSecret(t *testing.T) {
+	t.Parallel()
 	result := ParseRemoteExecArgs([]string{"--env=\"=hunter2\"", "server", "ls"})
 	assert.NotEmpty(t, result.Err)
 	assert.NotContains(t, result.Err, "hunter2", "malformed --env error must not echo the value")
 }
 
 func TestParseRemoteExecArgs_EnvPrefixIsExact(t *testing.T) {
+	t.Parallel()
 	// --env-file must not be swallowed by --env matching; it is an unknown flag.
 	result := ParseRemoteExecArgs([]string{"--env-file=secrets", "server", "ls"})
 	assert.Contains(t, result.Err, "unknown flag")
 }
 
 func TestParseRemoteExecArgs_Errors(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name        string
 		args        []string
@@ -916,6 +929,7 @@ func TestParseRemoteExecArgs_Errors(t *testing.T) {
 // validates with DRF's CharField(max_length=...), which counts characters, so a
 // byte count would refuse a Korean purpose at roughly a third of the limit.
 func TestParseRemoteExecArgsPurpose(t *testing.T) {
+	t.Parallel()
 	koreanAtCeiling := make([]rune, PurposeMaxLength)
 	for i := range koreanAtCeiling {
 		koreanAtCeiling[i] = '한'

--- a/cmd/exec/pending_approval_test.go
+++ b/cmd/exec/pending_approval_test.go
@@ -129,6 +129,7 @@ func runHelperProcess(t *testing.T, workspaceURL, testName, marker string, env, 
 // command and asserts it converges on the same pending-approval contract as the
 // denial-code path: exit 4 and a {"status":"pending_approval", ...} envelope.
 func TestExecStatusAwaitingApprovalExits4WithJSONSignal(t *testing.T) {
+	t.Parallel()
 	ts := newAwaitingApprovalServer()
 	defer ts.Close()
 
@@ -145,6 +146,7 @@ func TestExecStatusAwaitingApprovalExits4WithJSONSignal(t *testing.T) {
 }
 
 func TestExecPendingApprovalExits4WithJSONSignal(t *testing.T) {
+	t.Parallel()
 	ts := newApprovalDenialServer(denialLine("SUDO_APPROVAL_REQUIRED"))
 	defer ts.Close()
 
@@ -234,6 +236,7 @@ func TestExecLogsHelperProcess(t *testing.T) {
 
 // Exit 0 would tell a consumer reading the code alone that the command finished.
 func TestExecLogsAwaitingApprovalExits4(t *testing.T) {
+	t.Parallel()
 	const jobID = "a1b2c3d4-5678-abcd-ef01-234567890abc"
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
@@ -268,6 +271,7 @@ func TestExecLogsAwaitingApprovalExits4(t *testing.T) {
 // The sibling exit-6 paths (exec, work-session create) answer --output json with
 // an error envelope, so prose here would break a consumer polling exec logs.
 func TestExecLogsRejectedExits6(t *testing.T) {
+	t.Parallel()
 	const jobID = "a1b2c3d4-5678-abcd-ef01-234567890abc"
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
@@ -303,6 +307,7 @@ func TestExecLogsRejectedExits6(t *testing.T) {
 
 // Exit 1 reads as transient, so an agent re-runs a rejected command forever.
 func TestExecRejectedExits6(t *testing.T) {
+	t.Parallel()
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		switch {
@@ -327,6 +332,7 @@ func TestExecRejectedExits6(t *testing.T) {
 // process exit: TestRunExecWithApprovalWait_RejectionMidWaitEndsTheWait stops at
 // the returned error, and TestExecRejectedExits6 enters through the no-wait path.
 func TestExecRejectedMidWaitExits6(t *testing.T) {
+	t.Parallel()
 	var submissions atomic.Int64
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")

--- a/cmd/exec/purpose_demand_test.go
+++ b/cmd/exec/purpose_demand_test.go
@@ -66,6 +66,7 @@ func newAwaitingPurposeServer(submitted *atomic.Value) *httptest.Server {
 // this as a pending approval waits for a human who was never asked, and the
 // demand expires while it waits.
 func TestExecAwaitingPurposeExits7WithJSONSignal(t *testing.T) {
+	t.Parallel()
 	ts := newAwaitingPurposeServer(nil)
 	defer ts.Close()
 
@@ -92,6 +93,7 @@ func TestExecAwaitingPurposeExits7WithJSONSignal(t *testing.T) {
 // it the server feature is unreachable from the CLI, however complete the rest
 // of this file is.
 func TestExecDeclaresPurposeDemandSupport(t *testing.T) {
+	t.Parallel()
 	var submitted atomic.Value
 	ts := newAwaitingPurposeServer(&submitted)
 	defer ts.Close()
@@ -111,6 +113,7 @@ func TestExecDeclaresPurposeDemandSupport(t *testing.T) {
 // TestExecSendsTheStatedPurpose covers the path the ADR actually intends: with a
 // purpose in hand the assessor judges on the first pass and no demand is issued.
 func TestExecSendsTheStatedPurpose(t *testing.T) {
+	t.Parallel()
 	var submitted atomic.Value
 	ts := newAwaitingPurposeServer(&submitted)
 	defer ts.Close()
@@ -131,6 +134,7 @@ func TestExecSendsTheStatedPurpose(t *testing.T) {
 // demand: SubmitCommand returns before the verdict, so the status is first
 // visible when the result is retrieved.
 func TestExecLogsAwaitingPurposeExits7(t *testing.T) {
+	t.Parallel()
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		if r.Method == http.MethodGet && r.URL.Path == "/api/events/commands/"+purposeJobID+"/" {
@@ -183,6 +187,7 @@ func TestRunExecWithApprovalWait_DoesNotWaitOnAPurposeDemand(t *testing.T) {
 // TestAwaitingPurposeStatusIsNotAnApproval keeps the two holds apart at the
 // status predicates, which is where a rename would collapse them.
 func TestAwaitingPurposeStatusIsNotAnApproval(t *testing.T) {
+	t.Parallel()
 	assert.True(t, event.IsAwaitingPurposeStatus("awaiting_purpose"))
 	assert.False(t, event.IsAwaitingApprovalStatus("awaiting_purpose"))
 	assert.False(t, event.IsAwaitingPurposeStatus("awaiting_approval"))

--- a/cmd/exec/purpose_test.go
+++ b/cmd/exec/purpose_test.go
@@ -69,6 +69,7 @@ func longPurpose() string {
 // command exits 1, `exec logs` included. Exiting 2 here would tell a script this
 // is a usage-error-only surface, which it is not.
 func TestExecPurposeRejectsBadArgsWithExit1(t *testing.T) {
+	t.Parallel()
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		http.NotFound(w, r)
 	}))
@@ -96,6 +97,7 @@ func TestExecPurposeRejectsBadArgsWithExit1(t *testing.T) {
 // byte count refuses a Korean purpose at roughly 666 of them, while claiming the
 // server would refuse it.
 func TestExecPurposeAcceptsAMultibytePurposeAtTheCeiling(t *testing.T) {
+	t.Parallel()
 	korean := make([]rune, PurposeMaxLength)
 	for i := range korean {
 		korean[i] = '한'
@@ -126,6 +128,7 @@ func TestExecPurposeAcceptsAMultibytePurposeAtTheCeiling(t *testing.T) {
 // TestExecPurposeAnswersTheDemand covers the happy path: a 202 and a pointer at
 // where to read the outcome, never at a resubmit.
 func TestExecPurposeAnswersTheDemand(t *testing.T) {
+	t.Parallel()
 	var body atomic.Value
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodPost && r.URL.Path == "/api/events/commands/"+purposeJobID+"/purpose/" {
@@ -155,6 +158,7 @@ func TestExecPurposeAnswersTheDemand(t *testing.T) {
 // sent: `--purpose '  x  '` must not be stored, judged, and written to the
 // approver's card with the padding intact.
 func TestExecPurposeTrimsBeforeSending(t *testing.T) {
+	t.Parallel()
 	var body atomic.Value
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodPost && r.URL.Path == "/api/events/commands/"+purposeJobID+"/purpose/" {
@@ -180,6 +184,7 @@ func TestExecPurposeTrimsBeforeSending(t *testing.T) {
 // TestExecLogsShowsTheStatedPurpose gives EventDetails.Purpose its reader. A
 // field parsed into nothing is a promise no surface keeps.
 func TestExecLogsShowsTheStatedPurpose(t *testing.T) {
+	t.Parallel()
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		if r.Method == http.MethodGet && r.URL.Path == "/api/events/commands/"+purposeJobID+"/" {

--- a/cmd/exec/run_test.go
+++ b/cmd/exec/run_test.go
@@ -20,6 +20,7 @@ import (
 )
 
 func TestClientTimeoutLine(t *testing.T) {
+	t.Parallel()
 	line := clientTimeoutLine()
 	assert.Contains(t, line, "[client_timeout]", "stderr should carry the phase id in brackets")
 	assert.Contains(t, line, event.DescribePhase("client_timeout"),
@@ -28,6 +29,7 @@ func TestClientTimeoutLine(t *testing.T) {
 }
 
 func TestAsPhasedError(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name    string
 		err     error
@@ -54,6 +56,7 @@ func TestAsPhasedError(t *testing.T) {
 }
 
 func TestRemoteCommandOutcome(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name             string
 		remoteErr        *event.RemoteCommandError
@@ -127,6 +130,7 @@ func TestRemoteCommandOutcome(t *testing.T) {
 // the raw phase, so a payload that only becomes a known phase after sanitizing
 // still renders as an identifier and cannot borrow that phase's description.
 func TestRemoteCommandOutcomeSanitizesPhase(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name       string
 		phase      string
@@ -160,6 +164,7 @@ func TestRemoteCommandOutcomeSanitizesPhase(t *testing.T) {
 }
 
 func TestDetachResultLines(t *testing.T) {
+	t.Parallel()
 	line1, line2 := detachResultLines("a1b2c3d4-1234-5678-abcd-000000000000")
 	assert.Equal(t, "Job submitted: a1b2c3d4-1234-5678-abcd-000000000000", line1)
 	assert.Equal(t, "Run `alpacon exec logs a1b2c3d4-1234-5678-abcd-000000000000` to check the result.", line2)
@@ -168,6 +173,7 @@ func TestDetachResultLines(t *testing.T) {
 // The job id comes from the server's submit response and both lines are written
 // raw (stdout and stderr), outside the Cli* helpers—same class as #364.
 func TestDetachResultLinesSanitizesJobID(t *testing.T) {
+	t.Parallel()
 	line1, line2 := detachResultLines("job-1\x1b[2K\u202e")
 
 	assert.Equal(t, "Job submitted: job-1", line1)
@@ -264,6 +270,7 @@ func (e *statusError) Error() string       { return fmt.Sprintf("server said %d"
 func (e *statusError) HTTPStatusCode() int { return e.status }
 
 func TestIsPollFailure(t *testing.T) {
+	t.Parallel()
 	// What a proxy error page under a JSON content type leaves the caller with.
 	unparseableBody := json.Unmarshal([]byte(`<html>502 Bad Gateway</html>`), &struct{}{})
 	// A body that is JSON but not the response shape: parses, answers nothing.

--- a/cmd/exec/sudo_hint_test.go
+++ b/cmd/exec/sudo_hint_test.go
@@ -18,6 +18,7 @@ func denialLine(code string) string {
 }
 
 func TestSudoDenialHint(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name            string
 		code            string
@@ -116,12 +117,14 @@ func TestSudoDenialHint(t *testing.T) {
 // `work-session update --sudo`, so identical wording would leave the user unable
 // to tell which of the two they hit.
 func TestSudoDenialHintSeparatesTheTwoPolicyDenials(t *testing.T) {
+	t.Parallel()
 	assert.NotEqual(t,
 		sudoDenialHint(denialLine("SUDO_NO_WORKSESSION_POLICY")),
 		sudoDenialHint(denialLine("SUDO_POLICY_MFA_REQUIRED")))
 }
 
 func TestHasSudoPresenceDenial(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name   string
 		output string
@@ -163,6 +166,7 @@ func TestHasSudoPresenceDenial(t *testing.T) {
 }
 
 func TestHasSudoApprovalDenial(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name   string
 		output string
@@ -209,6 +213,7 @@ func TestHasSudoApprovalDenial(t *testing.T) {
 }
 
 func TestPendingSudoDenial(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name             string
 		output           string
@@ -270,6 +275,7 @@ func TestPendingSudoDenial(t *testing.T) {
 }
 
 func TestSudoDenialHintFallsBackToTheRawCode(t *testing.T) {
+	t.Parallel()
 	// The server adds denial codes on its own release train and nothing enforces
 	// this table's sync with it, so an unknown code must still leave the user
 	// something to act on instead of a bare denial line.
@@ -335,6 +341,7 @@ func TestSudoDenialHintFallsBackToTheRawCode(t *testing.T) {
 }
 
 func TestSudoDenialHintCodelessDenial(t *testing.T) {
+	t.Parallel()
 	// Spelled out, not reused from sudoDenialCodelessLine, so changing that constant
 	// fails these tests instead of moving along with them.
 	const codelessLine = "Alpacon denied this sudo command.\n"
@@ -385,6 +392,7 @@ func TestSudoDenialHintCodelessDenial(t *testing.T) {
 }
 
 func TestIsApprovalDenial(t *testing.T) {
+	t.Parallel()
 	approvalDenial := &event.RemoteCommandError{ExitCode: 1, Output: denialLine("SUDO_APPROVAL_REQUIRED")}
 
 	tests := []struct {
@@ -422,6 +430,7 @@ func TestIsApprovalDenial(t *testing.T) {
 }
 
 func TestReRunHint(t *testing.T) {
+	t.Parallel()
 	t.Run("minimal: server and command only", func(t *testing.T) {
 		got := reRunHint(RemoteExecArgs{Server: "web-01", Command: "sudo reboot"})
 		assert.Equal(t, "alpacon exec web-01 -- sudo reboot", got.Command)

--- a/cmd/exec/worksession_command_test.go
+++ b/cmd/exec/worksession_command_test.go
@@ -19,6 +19,7 @@ import (
 )
 
 func TestExecCommandWorkSessionGateExits3WithJSONDiagnostic(t *testing.T) {
+	t.Parallel()
 	var sawCommandPost atomic.Bool
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")

--- a/cmd/ftp/cp_test.go
+++ b/cmd/ftp/cp_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 func TestIsRemotePath(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		path     string
@@ -63,6 +64,7 @@ func TestIsRemotePath(t *testing.T) {
 }
 
 func TestIsLocalPath(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		path     string
@@ -104,6 +106,7 @@ func TestIsLocalPath(t *testing.T) {
 }
 
 func TestIsLocalPaths(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		paths    []string
@@ -145,6 +148,7 @@ func TestIsLocalPaths(t *testing.T) {
 }
 
 func TestValidatePaths(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name       string
 		sources    []string
@@ -202,6 +206,7 @@ func TestValidatePaths(t *testing.T) {
 
 // Test the SSH parsing logic used in the cp command
 func TestCpCommandSSHParsing(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name         string
 		args         []string
@@ -283,6 +288,7 @@ func TestCpCommandSSHParsing(t *testing.T) {
 
 // Test scenarios covering the required patterns from the issue
 func TestRequiredCpPatterns(t *testing.T) {
+	t.Parallel()
 	patterns := []struct {
 		description    string
 		command        string
@@ -343,6 +349,7 @@ func TestRequiredCpPatterns(t *testing.T) {
 }
 
 func TestStripUserPrefix(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name          string
 		arg           string
@@ -371,6 +378,7 @@ func TestStripUserPrefix(t *testing.T) {
 }
 
 func TestNormalizeArgsUsername(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name         string
 		args         []string

--- a/cmd/login_test.go
+++ b/cmd/login_test.go
@@ -23,6 +23,7 @@ type promptCall struct {
 }
 
 func TestFormatHostURL(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		host     string
@@ -114,6 +115,7 @@ func TestFormatHostURL(t *testing.T) {
 }
 
 func TestValidateHostTarget(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name    string
 		host    string
@@ -148,6 +150,7 @@ func TestValidateHostTarget(t *testing.T) {
 }
 
 func TestBuildCloudWorkspaceURL(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name      string
 		workspace string
@@ -177,6 +180,7 @@ func TestBuildCloudWorkspaceURL(t *testing.T) {
 }
 
 func TestParseCloudWorkspaceURL(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name          string
 		workspaceURL  string
@@ -237,6 +241,7 @@ func TestParseCloudWorkspaceURL(t *testing.T) {
 }
 
 func TestCloudLoginDefaults(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name          string
 		cfg           config.Config
@@ -278,6 +283,7 @@ func TestCloudLoginDefaults(t *testing.T) {
 }
 
 func TestIsCloudWorkspaceURL(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name         string
 		workspaceURL string
@@ -334,6 +340,7 @@ func TestIsCloudWorkspaceURL(t *testing.T) {
 }
 
 func TestPromptForLoginTarget(t *testing.T) {
+	t.Parallel()
 	t.Run("saved cloud target prompts with workspace and region defaults", func(t *testing.T) {
 		workspaceURL, workspaceName, baseDomain, calls, err := runPromptForLoginTarget(t, config.Config{
 			WorkspaceURL: "https://demo.ap1.alpacon.io",
@@ -521,6 +528,7 @@ func TestPromptForLoginTarget(t *testing.T) {
 }
 
 func TestValidateInteractiveLoginTargetPrompt(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name          string
 		isInteractive bool
@@ -547,6 +555,7 @@ func TestValidateInteractiveLoginTargetPrompt(t *testing.T) {
 }
 
 func TestLoginNonInteractiveNoTargetCommand(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name string
 		args []string
@@ -571,6 +580,7 @@ func TestLoginNonInteractiveNoTargetCommand(t *testing.T) {
 }
 
 func TestNormalizeCloudFlags(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name          string
 		workspace     string
@@ -597,6 +607,7 @@ func TestNormalizeCloudFlags(t *testing.T) {
 }
 
 func TestResolveLoginTarget(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name       string
 		args       []string
@@ -654,6 +665,7 @@ func TestResolveLoginTarget(t *testing.T) {
 }
 
 func TestValidateCloudFlags(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name      string
 		workspace string
@@ -725,6 +737,7 @@ func (e stubStatusErr) Error() string       { return "stub" }
 func (e stubStatusErr) HTTPStatusCode() int { return e.code }
 
 func TestClassifyWhoamiVerification(t *testing.T) {
+	t.Parallel()
 	assert.Equal(t, whoamiVerified, classifyWhoamiVerification(nil))
 	assert.Equal(t, whoamiFallback, classifyWhoamiVerification(stubStatusErr{code: http.StatusNotFound}))
 	// 401 must fail, never fall back, so an invalid token cannot slip through.
@@ -733,6 +746,7 @@ func TestClassifyWhoamiVerification(t *testing.T) {
 }
 
 func TestShouldFailOnProfileError(t *testing.T) {
+	t.Parallel()
 	// Browser/password login (no token) → profile failure is fatal.
 	assert.True(t, shouldFailOnProfileError(""))
 	// Any token login → profile failure is non-fatal (credential already validated via
@@ -848,6 +862,7 @@ func writeLoginCommandTestConfig(t *testing.T, home string) {
 }
 
 func TestPrintDeviceCodePrompt(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name            string
 		verificationURI string

--- a/cmd/note/note_list_test.go
+++ b/cmd/note/note_list_test.go
@@ -72,6 +72,7 @@ func TestNoteLsParsesFlags(t *testing.T) {
 }
 
 func TestNoteLsTailZeroExitsWithUsageErrorCode(t *testing.T) {
+	t.Parallel()
 	helper := osexec.Command(os.Args[0], "-test.run=^TestNoteLsTailZeroHelperProcess$")
 	helper.Env = append(os.Environ(), "GO_WANT_NOTE_LS_TAIL_HELPER=1")
 
@@ -83,6 +84,7 @@ func TestNoteLsTailZeroExitsWithUsageErrorCode(t *testing.T) {
 }
 
 func TestNoteLsTailZeroHelperProcess(t *testing.T) {
+	t.Parallel()
 	if os.Getenv("GO_WANT_NOTE_LS_TAIL_HELPER") != "1" {
 		return
 	}

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -70,6 +70,7 @@ func TestBuildWelcomeLines(t *testing.T) {
 }
 
 func TestHostFromURL(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		input    string

--- a/cmd/server/server_action_test.go
+++ b/cmd/server/server_action_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 func TestBusyGuardMessage(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name        string
 		force       bool

--- a/cmd/server/server_create_test.go
+++ b/cmd/server/server_create_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 func TestPrintTokenChoices_StripsControlSequences(t *testing.T) {
+	t.Parallel()
 	var buf bytes.Buffer
 	printTokenChoices(&buf, []server.RegistrationTokenDetails{
 		{Name: "staging\n  [2] production"},
@@ -27,6 +28,7 @@ func TestPrintTokenChoices_StripsControlSequences(t *testing.T) {
 }
 
 func TestPrintGuideFields_StripsControlSequences(t *testing.T) {
+	t.Parallel()
 	var buf bytes.Buffer
 	printGuideFields(&buf, "Debian\x1b[2K", "web-01\nURL      : https://evil.example.com", "https://demo.alpacon.io")
 
@@ -46,6 +48,7 @@ func captureGuideStderr(t *testing.T, fn func()) string {
 // The guide strings are what the operator pastes into a root shell, so the
 // warning has to name the command it is about—one banner at the top would not.
 func TestPrintGuideCommand(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name        string
 		input       string

--- a/cmd/server/token_create_test.go
+++ b/cmd/server/token_create_test.go
@@ -17,6 +17,7 @@ type groupListItem struct {
 }
 
 func TestResolveGroupIDs_UUID_PassThrough(t *testing.T) {
+	t.Parallel()
 	// UUIDs should pass through without any HTTP call.
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		t.Errorf("unexpected HTTP request: %s %s", r.Method, r.URL.Path)
@@ -44,6 +45,7 @@ func TestResolveGroupIDs_UUID_PassThrough(t *testing.T) {
 }
 
 func TestResolveGroupIDs_NameResolved(t *testing.T) {
+	t.Parallel()
 	const wantID = "aaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -71,6 +73,7 @@ func TestResolveGroupIDs_NameResolved(t *testing.T) {
 }
 
 func TestResolveGroupIDs_NameNotFound(t *testing.T) {
+	t.Parallel()
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := api.ListResponse[groupListItem]{Count: 0, Results: []groupListItem{}}
 		w.Header().Set("Content-Type", "application/json")
@@ -87,6 +90,7 @@ func TestResolveGroupIDs_NameNotFound(t *testing.T) {
 }
 
 func TestResolveGroupIDs_Empty(t *testing.T) {
+	t.Parallel()
 	// Empty input should return empty slice without any HTTP call.
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		t.Errorf("unexpected HTTP request: %s %s", r.Method, r.URL.Path)

--- a/cmd/tunnel/run_test.go
+++ b/cmd/tunnel/run_test.go
@@ -154,6 +154,7 @@ func TestExtractRunInvocation(t *testing.T) {
 }
 
 func TestExtractRunInvocationLegacyRunSubcommandRemoved(t *testing.T) {
+	t.Parallel()
 	_, _, err := extractRunInvocation([]string{"run", "prod-db", "psql"}, 2)
 	if err == nil {
 		t.Fatal("expected error, got nil")
@@ -164,6 +165,7 @@ func TestExtractRunInvocationLegacyRunSubcommandRemoved(t *testing.T) {
 }
 
 func TestExitCodeFromProcessError(t *testing.T) {
+	t.Parallel()
 	if code := exitCodeFromProcessError(nil); code != 0 {
 		t.Fatalf("nil error exit code = %d, want 0", code)
 	}
@@ -181,6 +183,7 @@ func TestExitCodeFromProcessError(t *testing.T) {
 }
 
 func TestExitCodeFromProcessErrorHelperProcess(t *testing.T) {
+	t.Parallel()
 	if os.Getenv("GO_WANT_HELPER_PROCESS") != "1" {
 		return
 	}
@@ -258,6 +261,7 @@ func TestExecuteTunnelRunWithInvocationInvalidRemotePort(t *testing.T) {
 }
 
 func TestRunHelperProcess(t *testing.T) {
+	t.Parallel()
 	mode, ok := parseRunHelperInvocation(os.Args)
 	if !ok {
 		return

--- a/cmd/username/username_test.go
+++ b/cmd/username/username_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 func TestSetUsernameErrorText(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name       string
 		err        error

--- a/cmd/webhook/webhook_create_test.go
+++ b/cmd/webhook/webhook_create_test.go
@@ -3,6 +3,7 @@ package webhook
 import "testing"
 
 func TestDetectProviderFromURL(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		url      string

--- a/cmd/websh/websh_list_test.go
+++ b/cmd/websh/websh_list_test.go
@@ -59,6 +59,7 @@ func TestWebshLsRoutesAndParsesFlags(t *testing.T) {
 }
 
 func TestWebshLsTailZeroExitsWithUsageErrorCode(t *testing.T) {
+	t.Parallel()
 	helper := osexec.Command(os.Args[0], "-test.run=^TestWebshLsTailZeroHelperProcess$")
 	helper.Env = append(os.Environ(), "GO_WANT_WEBSH_LS_TAIL_HELPER=1")
 
@@ -70,6 +71,7 @@ func TestWebshLsTailZeroExitsWithUsageErrorCode(t *testing.T) {
 }
 
 func TestWebshLsTailZeroHelperProcess(t *testing.T) {
+	t.Parallel()
 	if os.Getenv("GO_WANT_WEBSH_LS_TAIL_HELPER") != "1" {
 		return
 	}

--- a/cmd/websh/websh_test.go
+++ b/cmd/websh/websh_test.go
@@ -30,6 +30,7 @@ func (e statusErr) Error() string       { return fmt.Sprintf("server said %d", e
 func (e statusErr) HTTPStatusCode() int { return e.status }
 
 func TestCommandParsing(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		testName          string
 		args              []string
@@ -280,6 +281,7 @@ func TestCommandParsing(t *testing.T) {
 }
 
 func TestSudoListenerWarning(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name  string
 		cause error
@@ -334,6 +336,7 @@ func executeTestCommand(t *testing.T, args []string) (string, string, string, []
 }
 
 func TestParseWebshArgs_WorkSessionFlag(t *testing.T) {
+	t.Parallel()
 	got, err := ParseWebshArgs([]string{"--work-session", "ses-abc", "my-server"})
 	require.NoError(t, err)
 	assert.Equal(t, "ses-abc", got.WorkSessionID)
@@ -341,6 +344,7 @@ func TestParseWebshArgs_WorkSessionFlag(t *testing.T) {
 }
 
 func TestParseWebshArgs_WorkSessionEqualForm(t *testing.T) {
+	t.Parallel()
 	got, err := ParseWebshArgs([]string{"--work-session=ses-abc", "my-server"})
 	require.NoError(t, err)
 	assert.Equal(t, "ses-abc", got.WorkSessionID)
@@ -348,12 +352,14 @@ func TestParseWebshArgs_WorkSessionEqualForm(t *testing.T) {
 }
 
 func TestParseWebshArgs_EnvErrorHidesSecret(t *testing.T) {
+	t.Parallel()
 	_, err := ParseWebshArgs([]string{"--env=\"=hunter2\"", "my-server", "ls"})
 	require.Error(t, err)
 	assert.NotContains(t, err.Error(), "hunter2", "malformed --env error must not echo the value")
 }
 
 func TestParseWebshArgs_EnvPrefixIsExact(t *testing.T) {
+	t.Parallel()
 	// --env-file must not be swallowed by --env matching; websh has no
 	// unknown-flag rejection, so it falls through to the server-name slot.
 	got, err := ParseWebshArgs([]string{"--env-file=secrets", "ls"})
@@ -362,6 +368,7 @@ func TestParseWebshArgs_EnvPrefixIsExact(t *testing.T) {
 }
 
 func TestParseWebshArgs_CommandAfterServerNotConsumed(t *testing.T) {
+	t.Parallel()
 	got, err := ParseWebshArgs([]string{"my-server", "ls", "--work-session", "fake"})
 	require.NoError(t, err)
 	assert.Equal(t, "my-server", got.ServerName)
@@ -370,6 +377,7 @@ func TestParseWebshArgs_CommandAfterServerNotConsumed(t *testing.T) {
 }
 
 func TestSanitizeRecord(t *testing.T) {
+	t.Parallel()
 	// ANSI color codes stripped, newlines collapsed to single spaces.
 	in := "\x1b[31mdocker\x1b[0m ps\n  -a\tfoo"
 	assert.Equal(t, "docker ps -a foo", sanitizeRecord(in, 100))
@@ -397,6 +405,7 @@ func TestSanitizeRecord(t *testing.T) {
 }
 
 func TestPrintWatchHeader_StripsControlSequences(t *testing.T) {
+	t.Parallel()
 	var buf bytes.Buffer
 	printWatchHeader(&buf, websh.SessionDetailResponse{
 		ID:       "abc123",
@@ -483,6 +492,7 @@ func TestSetupSudoListener_WarnsOnOtherFailures(t *testing.T) {
 }
 
 func TestSudoListenerWarning_SanitizesTheServersText(t *testing.T) {
+	t.Parallel()
 	warning := sudoListenerWarning(errors.New("boom \x1b[31mred\x1b[0m"))
 
 	assert.NotContains(t, warning, "\x1b")

--- a/cmd/whoami_test.go
+++ b/cmd/whoami_test.go
@@ -15,6 +15,7 @@ import (
 )
 
 func TestApplyApplicationPrincipal(t *testing.T) {
+	t.Parallel()
 	who := &auth.WhoamiResponse{
 		PrincipalType: "application",
 		Auth:          auth.WhoamiAuth{Scopes: []string{"server:read", "command:create"}},
@@ -31,6 +32,7 @@ func TestApplyApplicationPrincipal(t *testing.T) {
 }
 
 func TestApplicationFieldsOmittedForUserPrincipal(t *testing.T) {
+	t.Parallel()
 	// A user principal's JSON must not carry application keys (output unchanged).
 	body, err := json.Marshal(whoamiOutput{Username: "alice", AuthMethod: "Browser login"})
 	assert.NoError(t, err)
@@ -44,6 +46,7 @@ func TestApplicationFieldsOmittedForUserPrincipal(t *testing.T) {
 }
 
 func TestGetAuthMethod(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		token    string
@@ -66,6 +69,7 @@ func TestGetAuthMethod(t *testing.T) {
 }
 
 func TestGetAuthClassification(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		cfg      config.Config
@@ -86,6 +90,7 @@ func TestGetAuthClassification(t *testing.T) {
 }
 
 func TestAuthClassificationFromMethod(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		method   string
@@ -105,6 +110,7 @@ func TestAuthClassificationFromMethod(t *testing.T) {
 }
 
 func TestGetRole(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name        string
 		isStaff     bool
@@ -125,6 +131,7 @@ func TestGetRole(t *testing.T) {
 }
 
 func TestFormatDuration(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		d        time.Duration
@@ -144,6 +151,7 @@ func TestFormatDuration(t *testing.T) {
 }
 
 func TestFormatExpiresHuman(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		input    string
@@ -169,6 +177,7 @@ func TestFormatExpiresHuman(t *testing.T) {
 }
 
 func TestFormatGroups(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		groups   []iam.GroupMembership
@@ -190,6 +199,7 @@ func TestFormatGroups(t *testing.T) {
 }
 
 func TestFormatWSRequired(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		required bool
@@ -224,6 +234,7 @@ func TestFormatWSRequired(t *testing.T) {
 }
 
 func TestPrintWhoamiJSON_PreflightFields(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name                string
 		worksessionRequired bool
@@ -291,6 +302,7 @@ func TestPrintWhoamiJSON_PreflightFields(t *testing.T) {
 }
 
 func TestIsWorksessionRequired(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name string
 		cfg  config.Config

--- a/cmd/worksession/sudo_policies_test.go
+++ b/cmd/worksession/sudo_policies_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 func TestBuildSudoPolicies(t *testing.T) {
+	t.Parallel()
 	t.Run("one policy per --sudo value, commands split on comma", func(t *testing.T) {
 		policies := buildSudoPolicies(
 			[]string{"systemctl restart nginx,systemctl reload nginx", "tail -f /var/log/nginx/*.log"},

--- a/cmd/worksession/worksession_create_test.go
+++ b/cmd/worksession/worksession_create_test.go
@@ -16,6 +16,7 @@ import (
 )
 
 func TestPollForApproval_TerminalStatusesAreDistinguishable(t *testing.T) {
+	t.Parallel()
 	// A rejection and a network failure must not collapse into the same exit code:
 	// an agent reading only $? would retry a rejected request forever.
 	tests := []struct {
@@ -51,6 +52,7 @@ func TestPollForApproval_TerminalStatusesAreDistinguishable(t *testing.T) {
 }
 
 func TestPollForApproval_APIFailureIsNotTerminal(t *testing.T) {
+	t.Parallel()
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
 	}))
@@ -92,6 +94,7 @@ func TestPollForApproval_GivingUpIsPending(t *testing.T) {
 }
 
 func TestPollForApproval_RidesThroughATransientFailure(t *testing.T) {
+	t.Parallel()
 	requests := 0
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requests++
@@ -145,6 +148,7 @@ func TestPollForApproval_WarningSanitizesServerText(t *testing.T) {
 }
 
 func TestPollForApproval_FatalClientErrorEndsTheWaitAtOnce(t *testing.T) {
+	t.Parallel()
 	requests := 0
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requests++
@@ -161,6 +165,7 @@ func TestPollForApproval_FatalClientErrorEndsTheWaitAtOnce(t *testing.T) {
 }
 
 func TestPollForApproval_TimeoutIsNotTerminal(t *testing.T) {
+	t.Parallel()
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"id":"ws-uuid","status":"pending"}`))
@@ -182,6 +187,7 @@ func TestPollForApproval_TimeoutIsNotTerminal(t *testing.T) {
 // Guards the attempt-count regression: at interval=10ms the old logic returned
 // after ~20ms (no sleep after the final attempt) instead of the full 30ms.
 func TestPollForApproval_WaitsFullTimeout(t *testing.T) {
+	t.Parallel()
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"id":"ses-p","status":"pending"}`))
@@ -200,6 +206,7 @@ func TestPollForApproval_WaitsFullTimeout(t *testing.T) {
 }
 
 func TestParseExpiryFlag_ExpiresIn(t *testing.T) {
+	t.Parallel()
 	before := time.Now()
 	result, err := parseExpiryFlag("2h", "")
 	after := time.Now()
@@ -212,6 +219,7 @@ func TestParseExpiryFlag_ExpiresIn(t *testing.T) {
 }
 
 func TestParseExpiryFlag_ExpiresAt(t *testing.T) {
+	t.Parallel()
 	ts := "2026-12-31T23:59:59Z"
 	result, err := parseExpiryFlag("", ts)
 	assert.NoError(t, err)
@@ -219,35 +227,41 @@ func TestParseExpiryFlag_ExpiresAt(t *testing.T) {
 }
 
 func TestParseExpiryFlag_BothProvided(t *testing.T) {
+	t.Parallel()
 	_, err := parseExpiryFlag("2h", "2026-12-31T23:59:59Z")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "mutually exclusive")
 }
 
 func TestParseExpiryFlag_NeitherProvided(t *testing.T) {
+	t.Parallel()
 	_, err := parseExpiryFlag("", "")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "required")
 }
 
 func TestParseExpiryFlag_InvalidDuration(t *testing.T) {
+	t.Parallel()
 	_, err := parseExpiryFlag("2hours", "")
 	assert.Error(t, err)
 }
 
 func TestParseExpiryFlag_ZeroDuration(t *testing.T) {
+	t.Parallel()
 	_, err := parseExpiryFlag("0s", "")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "positive duration")
 }
 
 func TestParseExpiryFlag_NegativeDuration(t *testing.T) {
+	t.Parallel()
 	_, err := parseExpiryFlag("-1h", "")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "positive duration")
 }
 
 func TestResolveWaitTimeout(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name            string
 		wait            bool
@@ -283,22 +297,26 @@ func TestResolveWaitTimeout(t *testing.T) {
 }
 
 func TestValidateAgentScopes_AgentWithWebsh(t *testing.T) {
+	t.Parallel()
 	err := validateAgentScopes("agent", []string{"command", "websh"})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "\"websh\" is not allowed")
 }
 
 func TestValidateAgentScopes_AgentWithoutWebsh(t *testing.T) {
+	t.Parallel()
 	err := validateAgentScopes("agent", []string{"command", "webftp"})
 	assert.NoError(t, err)
 }
 
 func TestValidateAgentScopes_UserWithWebsh(t *testing.T) {
+	t.Parallel()
 	err := validateAgentScopes("user", []string{"command", "websh"})
 	assert.NoError(t, err)
 }
 
 func TestValidateScopeEnum(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name        string
 		scopes      []string
@@ -355,6 +373,7 @@ func TestValidateScopeEnum(t *testing.T) {
 }
 
 func TestDecideUseAction(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name       string
 		status     string

--- a/cmd/worksession/worksession_error_test.go
+++ b/cmd/worksession/worksession_error_test.go
@@ -32,6 +32,7 @@ type errorEnvelope struct {
 }
 
 func TestExtendJSONErrorEnvelope_ServerCode(t *testing.T) {
+	t.Parallel()
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		if r.Method == http.MethodPost && r.URL.Path == "/api/work-sessions/sessions/ses-1/extend/" {
@@ -59,6 +60,7 @@ func TestExtendJSONErrorEnvelope_ServerCode(t *testing.T) {
 }
 
 func TestExtendJSONErrorEnvelope_UsageError(t *testing.T) {
+	t.Parallel()
 	// Flag validation fails before any HTTP call; no live server needed.
 	// The subprocess has no TTY, so IsInteractiveShell() is false.
 	stdout, stderr, exitCode := runWorkSessionHelper(t, utils.OutputFormatJSON, "http://127.0.0.1:1",
@@ -76,6 +78,7 @@ func TestExtendJSONErrorEnvelope_UsageError(t *testing.T) {
 }
 
 func TestExtendTableUsageError_ExitsTwo(t *testing.T) {
+	t.Parallel()
 	// Table is the default output mode, so this is the branch of
 	// CliUsageErrorEnvelopeWithExit most callers reach.
 	stdout, stderr, exitCode := runWorkSessionHelper(t, utils.OutputFormatTable, "http://127.0.0.1:1",
@@ -88,6 +91,7 @@ func TestExtendTableUsageError_ExitsTwo(t *testing.T) {
 }
 
 func TestUseJSONErrorEnvelope_LocalStateError(t *testing.T) {
+	t.Parallel()
 	// GET succeeds but the session is expired — local validation error with err,
 	// no server code: error_code must be omitted.
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/cmd/worksession/worksession_list_filter_test.go
+++ b/cmd/worksession/worksession_list_filter_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestResolveStatusFilter(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name  string
 		input string
@@ -31,6 +32,7 @@ func TestResolveStatusFilter(t *testing.T) {
 }
 
 func TestResolveAssignedUser(t *testing.T) {
+	t.Parallel()
 	const myID = "6eaa827d-616a-4fa9-ad42-4fbb67bb007b"
 
 	t.Run("all lists everyone without resolving current user", func(t *testing.T) {

--- a/cmd/worksession/worksession_list_test.go
+++ b/cmd/worksession/worksession_list_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestMarkActive_DecoratesMatchingRow(t *testing.T) {
+	t.Parallel()
 	rows := []wsapi.WorkSessionAttributes{
 		{ID: "ses-1", Description: "alpha", Status: "active"},
 		{ID: "ses-2", Description: "beta", Status: "active"},
@@ -19,6 +20,7 @@ func TestMarkActive_DecoratesMatchingRow(t *testing.T) {
 }
 
 func TestMarkActive_EmptyActiveUUID_NoChange(t *testing.T) {
+	t.Parallel()
 	rows := []wsapi.WorkSessionAttributes{
 		{ID: "ses-1", Description: "alpha"},
 		{ID: "ses-2", Description: "beta"},
@@ -29,6 +31,7 @@ func TestMarkActive_EmptyActiveUUID_NoChange(t *testing.T) {
 }
 
 func TestMarkActive_NoMatch_NoChange(t *testing.T) {
+	t.Parallel()
 	rows := []wsapi.WorkSessionAttributes{
 		{ID: "ses-1", Description: "alpha"},
 	}
@@ -37,6 +40,7 @@ func TestMarkActive_NoMatch_NoChange(t *testing.T) {
 }
 
 func TestMarkActive_EmptySlice_NoPanic(t *testing.T) {
+	t.Parallel()
 	var rows []wsapi.WorkSessionAttributes
 	assert.NotPanics(t, func() {
 		worksession.MarkActive(rows, "ses-anything")

--- a/cmd/worksession/worksession_output_test.go
+++ b/cmd/worksession/worksession_output_test.go
@@ -18,6 +18,7 @@ import (
 )
 
 func TestWorkSessionMutationOutputWrapsSession(t *testing.T) {
+	t.Parallel()
 	expiresAt := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
 	session := &wsapi.WorkSession{
 		ID:                "ses-abc",
@@ -62,6 +63,7 @@ func TestWorkSessionMutationOutputWrapsSession(t *testing.T) {
 }
 
 func TestWorkSessionExtendOutput(t *testing.T) {
+	t.Parallel()
 	output := newWorkSessionExtendOutput("ses-abc", "2026-06-01T12:00:00Z")
 	body, err := json.Marshal(output)
 	require.NoError(t, err)
@@ -77,6 +79,7 @@ func TestWorkSessionExtendOutput(t *testing.T) {
 }
 
 func TestWorkSessionCancelOutput(t *testing.T) {
+	t.Parallel()
 	output := newWorkSessionCancelOutput("ses-abc")
 	body, err := json.Marshal(output)
 	require.NoError(t, err)
@@ -301,6 +304,7 @@ func TestWorkSessionCancelCommandJSONOutput_NoHumanSuccessText(t *testing.T) {
 }
 
 func TestSuccessMessages_StripControlSequences(t *testing.T) {
+	t.Parallel()
 	session := &wsapi.WorkSession{
 		ID:                "ses-abc\x1b[2K\rses-evil",
 		Status:            "active\nWork session ses-evil created",
@@ -321,6 +325,7 @@ func TestSuccessMessages_StripControlSequences(t *testing.T) {
 }
 
 func TestActiveWorkSessionSetMessage_StripsControlSequences(t *testing.T) {
+	t.Parallel()
 	got := activeWorkSessionSetMessage("Work session ses-abc\x1b[2K approved. ", "ses-abc",
 		"db work\nActive work-session set to ses-evil")
 
@@ -330,12 +335,14 @@ func TestActiveWorkSessionSetMessage_StripsControlSequences(t *testing.T) {
 }
 
 func TestActiveWorkSessionSetMessage_DropsDescriptionLeftEmpty(t *testing.T) {
+	t.Parallel()
 	// Stripping can empty the description; the parentheses go with it.
 	assert.Equal(t, "Active work-session set to ses-abc.",
 		activeWorkSessionSetMessage("", "ses-abc", "\x1b[2K\r"))
 }
 
 func TestFormatAdjustments(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name string
 		adj  *wsapi.Adjustments
@@ -372,6 +379,7 @@ func TestFormatAdjustments(t *testing.T) {
 }
 
 func TestFormatRecommendations(t *testing.T) {
+	t.Parallel()
 	assert.Equal(t, "", formatRecommendations(nil))
 	assert.Equal(t, "", formatRecommendations([]wsapi.Recommendation{}))
 
@@ -385,6 +393,7 @@ func TestFormatRecommendations(t *testing.T) {
 }
 
 func TestFormatAdvisories_StripsControlSequences(t *testing.T) {
+	t.Parallel()
 	// This block is where a requester reads what was granted, so a control
 	// sequence in any interpolated field can hide it.
 	const payload = "reboot db-01\x1b[2K\rapproved: read-only access"
@@ -444,6 +453,7 @@ func TestFormatAdvisories_StripsControlSequences(t *testing.T) {
 }
 
 func TestFormatAdvisories_KeepsOneLinePerEntry(t *testing.T) {
+	t.Parallel()
 	// The formatters join entries with \n, so a newline inside a value forges an
 	// extra advisory line.
 	got := formatRecommendations([]wsapi.Recommendation{{Severity: "high", Text: "granted\n  [HIGH] full root access"}})

--- a/cmd/worksession/worksession_recording_test.go
+++ b/cmd/worksession/worksession_recording_test.go
@@ -16,6 +16,7 @@ func makeRecording(id, sessionID string) wsapi.TimelineItem {
 // findRecording
 
 func TestFindRecording_DefaultFirst(t *testing.T) {
+	t.Parallel()
 	recs := []wsapi.TimelineItem{makeRecording("r1", "s1"), makeRecording("r2", "s1")}
 	target, idx := findRecording(recs, 1)
 	assert.Equal(t, "r1", target.ID)
@@ -23,6 +24,7 @@ func TestFindRecording_DefaultFirst(t *testing.T) {
 }
 
 func TestFindRecording_ByIndex(t *testing.T) {
+	t.Parallel()
 	recs := []wsapi.TimelineItem{makeRecording("r1", "s1"), makeRecording("r2", "s1"), makeRecording("r3", "s1")}
 	target, idx := findRecording(recs, 3)
 	assert.Equal(t, "r3", target.ID)
@@ -30,6 +32,7 @@ func TestFindRecording_ByIndex(t *testing.T) {
 }
 
 func TestFindRecording_IndexOutOfRange(t *testing.T) {
+	t.Parallel()
 	recs := []wsapi.TimelineItem{makeRecording("r1", "s1")}
 	target, idx := findRecording(recs, 2)
 	assert.Nil(t, target)
@@ -37,6 +40,7 @@ func TestFindRecording_IndexOutOfRange(t *testing.T) {
 }
 
 func TestFindRecording_IndexZero(t *testing.T) {
+	t.Parallel()
 	recs := []wsapi.TimelineItem{makeRecording("r1", "s1")}
 	target, idx := findRecording(recs, 0)
 	assert.Nil(t, target)
@@ -44,6 +48,7 @@ func TestFindRecording_IndexZero(t *testing.T) {
 }
 
 func TestFindRecording_NegativeIndex(t *testing.T) {
+	t.Parallel()
 	recs := []wsapi.TimelineItem{makeRecording("r1", "s1")}
 	target, idx := findRecording(recs, -1)
 	assert.Nil(t, target)
@@ -53,6 +58,7 @@ func TestFindRecording_NegativeIndex(t *testing.T) {
 // buildRecordingIndex
 
 func TestBuildRecordingIndex_GroupsBySessionID(t *testing.T) {
+	t.Parallel()
 	items := []wsapi.TimelineItem{
 		{Type: "websh_session", ID: "s1"},
 		{Type: "websh_record", ID: "r1", SessionID: "s1"},
@@ -69,6 +75,7 @@ func TestBuildRecordingIndex_GroupsBySessionID(t *testing.T) {
 }
 
 func TestBuildRecordingIndex_NoRecordings(t *testing.T) {
+	t.Parallel()
 	items := []wsapi.TimelineItem{
 		{Type: "websh_session", ID: "s1"},
 		{Type: "ftp_session", ID: "f1"},
@@ -79,6 +86,7 @@ func TestBuildRecordingIndex_NoRecordings(t *testing.T) {
 }
 
 func TestBuildRecordingIndex_Empty(t *testing.T) {
+	t.Parallel()
 	bySession, flat := buildRecordingIndex(nil)
 	assert.Empty(t, bySession)
 	assert.Empty(t, flat)
@@ -87,43 +95,52 @@ func TestBuildRecordingIndex_Empty(t *testing.T) {
 // recordingBadge
 
 func TestRecordingBadge_Single(t *testing.T) {
+	t.Parallel()
 	assert.Equal(t, "• 1 recording", recordingBadge(1))
 }
 
 func TestRecordingBadge_Multiple(t *testing.T) {
+	t.Parallel()
 	assert.Equal(t, "• 3 recordings", recordingBadge(3))
 }
 
 // recordingPreview
 
 func TestRecordingPreview_StripsANSI(t *testing.T) {
+	t.Parallel()
 	raw := "\x1b]0;user@host:~\x07\x1b[?2004h[user@host:~]$ ls -la"
 	assert.Equal(t, "[user@host:~]$ ls -la", recordingPreview(raw))
 }
 
 func TestRecordingPreview_StripsCarriageReturns(t *testing.T) {
+	t.Parallel()
 	raw := "[user@host:~]$ \r\r[user@host:~]$ ls -la"
 	assert.Equal(t, "[user@host:~]$ ls -la", recordingPreview(raw))
 }
 
 func TestRecordingPreview_SkipsEmptyLines(t *testing.T) {
+	t.Parallel()
 	assert.Equal(t, "actual content here", recordingPreview("\n\n  \nactual content here"))
 }
 
 func TestRecordingPreview_Truncates(t *testing.T) {
+	t.Parallel()
 	raw := strings.Repeat("a", 80)
 	assert.LessOrEqual(t, len(recordingPreview(raw)), 63) // 60 chars + possible "..."
 }
 
 func TestRecordingPreview_EmptyRaw(t *testing.T) {
+	t.Parallel()
 	assert.Equal(t, "", recordingPreview(""))
 }
 
 func TestRecordingPreview_OnlyANSI(t *testing.T) {
+	t.Parallel()
 	assert.Equal(t, "", recordingPreview("\x1b[?2004h\x1b[2J\x1b[H"))
 }
 
 func TestRecordingPreview_StripsBidiOverride(t *testing.T) {
+	t.Parallel()
 	// A bidi override carries no control byte, so the control pass alone leaves
 	// it free to reorder the preview a reviewer reads back.
 	raw := "[user@host:~]$ echo \u202esafe"
@@ -131,6 +148,7 @@ func TestRecordingPreview_StripsBidiOverride(t *testing.T) {
 }
 
 func TestRecordingPreview_StripsFormatCharBuriedInSequence(t *testing.T) {
+	t.Parallel()
 	// Format chars go before the escape strip, or the match breaks and the
 	// sequence's tail lands on screen as text.
 	assert.Equal(t, "ls", recordingPreview("\x1b[2\u200dKls"))
@@ -139,6 +157,7 @@ func TestRecordingPreview_StripsFormatCharBuriedInSequence(t *testing.T) {
 // printRecordingHeader
 
 func TestPrintRecordingHeader_SanitizesTimestamp(t *testing.T) {
+	t.Parallel()
 	// formatTimestamp returns the server's string as-is when it does not parse, so
 	// the header is a sink for an escape sequence that clears the reviewer's screen.
 	ts := "\x1b[2J\x1b[H\u202eSPOOFED"
@@ -150,12 +169,14 @@ func TestPrintRecordingHeader_SanitizesTimestamp(t *testing.T) {
 // printRecordingContent
 
 func TestPrintRecordingContent_StripsFormatChars(t *testing.T) {
+	t.Parallel()
 	var buf bytes.Buffer
 	printRecordingContent(&buf, "echo \u202esafe\n")
 	assert.Equal(t, "echo safe\n", buf.String())
 }
 
 func TestPrintRecordingContent_StripsC1Controls(t *testing.T) {
+	t.Parallel()
 	// U+009B is an 8-bit CSI: left in, it erases the recorded line and the reviewer
 	// reads what follows instead.
 	var buf bytes.Buffer
@@ -164,6 +185,7 @@ func TestPrintRecordingContent_StripsC1Controls(t *testing.T) {
 }
 
 func TestPrintRecordingContent_StripsRawC1Byte(t *testing.T) {
+	t.Parallel()
 	// A recording of an 8-bit program carries CSI as the raw byte 0x9b, which is
 	// invalid UTF-8, so IsC1OrDEL never sees it. What keeps it off the terminal is
 	// strings.Map substituting U+FFFD, so a rewrite into a byte loop reopens this.
@@ -173,6 +195,7 @@ func TestPrintRecordingContent_StripsRawC1Byte(t *testing.T) {
 }
 
 func TestPrintRecordingContent_StripsShiftFunctions(t *testing.T) {
+	t.Parallel()
 	// SO invokes G1 into GL and holds until SI or a reset: the same charset switch
 	// as "ESC ( 0", reached without an ESC.
 	var buf bytes.Buffer
@@ -181,6 +204,7 @@ func TestPrintRecordingContent_StripsShiftFunctions(t *testing.T) {
 }
 
 func TestPrintRecordingContent_StripsUnmatchedEscapeIntroducers(t *testing.T) {
+	t.Parallel()
 	// ansiEscapeRE ends an ESC-led form at \x40-\x7e, so these three get past it.
 	// "ESC 7"/"ESC 8" restore the cursor onto an earlier line, which lets the
 	// recording overwrite what the reviewer already read.
@@ -192,6 +216,7 @@ func TestPrintRecordingContent_StripsUnmatchedEscapeIntroducers(t *testing.T) {
 }
 
 func TestPrintRecordingContent_KeepsControlBytes(t *testing.T) {
+	t.Parallel()
 	// The C0 pass is deliberately absent here: a recording shown as it was keeps
 	// \r and its line endings.
 	var buf bytes.Buffer

--- a/cmd/worksession/worksession_timeline_test.go
+++ b/cmd/worksession/worksession_timeline_test.go
@@ -19,6 +19,7 @@ func mustParseTime(ts string) time.Time {
 }
 
 func TestFormatTimestamp(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		input string
 		want  string
@@ -38,6 +39,7 @@ func TestFormatTimestamp(t *testing.T) {
 }
 
 func TestFormatType(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		input string
 		want  string
@@ -58,6 +60,7 @@ func TestFormatType(t *testing.T) {
 }
 
 func TestFormatSize(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		bytes int64
 		want  string
@@ -76,12 +79,14 @@ func TestFormatSize(t *testing.T) {
 }
 
 func TestSessionState(t *testing.T) {
+	t.Parallel()
 	closed := "2024-01-15T10:30:00Z"
 	assert.Equal(t, "closed", sessionState(&closed))
 	assert.Equal(t, "opened", sessionState(nil))
 }
 
 func TestFormatDetails_Command(t *testing.T) {
+	t.Parallel()
 	success := true
 	failure := false
 
@@ -117,6 +122,7 @@ func TestFormatDetails_Command(t *testing.T) {
 }
 
 func TestFormatDetails_Sessions(t *testing.T) {
+	t.Parallel()
 	closed := "2024-01-15T10:30:00Z"
 	port := 8080
 
@@ -157,6 +163,7 @@ func TestFormatDetails_Sessions(t *testing.T) {
 }
 
 func TestFormatDetails_Files(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name string
 		item wsapi.TimelineItem
@@ -209,11 +216,13 @@ func TestFormatDetails_SudoGrant(t *testing.T) {
 }
 
 func TestFormatDetails_WebshRecord(t *testing.T) {
+	t.Parallel()
 	item := wsapi.TimelineItem{Type: "websh_record", MaskedRecord: "ls -la /home/user"}
 	assert.Equal(t, "ls -la /home/user", formatDetails(&item))
 }
 
 func TestFormatDetails_WebshRecord_SanitizesBeforeTruncating(t *testing.T) {
+	t.Parallel()
 	// The escape has to go before the 60-char cut, or it eats the budget the command
 	// text needs and the cell shows less than the rows beside it.
 	item := wsapi.TimelineItem{Type: "websh_record", MaskedRecord: "\x1b[2K\u202els -la"}
@@ -221,11 +230,13 @@ func TestFormatDetails_WebshRecord_SanitizesBeforeTruncating(t *testing.T) {
 }
 
 func TestFormatDetails_Unknown(t *testing.T) {
+	t.Parallel()
 	item := wsapi.TimelineItem{Type: "unknown_event"}
 	assert.Equal(t, "", formatDetails(&item))
 }
 
 func TestPrintTimelineTableTo_StripsControlSequences(t *testing.T) {
+	t.Parallel()
 	var buf bytes.Buffer
 	printTimelineTableTo(&buf, []wsapi.TimelineAttributes{{
 		Time:    "2024-01-15 10:30:00",
@@ -244,6 +255,7 @@ func TestPrintTimelineTableTo_StripsControlSequences(t *testing.T) {
 }
 
 func TestPrintRecordingsSectionTo_StripsControlSequences(t *testing.T) {
+	t.Parallel()
 	serverID := "srv-1"
 	timestamp := "2024-01-15T10:30:00Z"
 	var buf bytes.Buffer

--- a/cmd/worksession/worksession_timeline_test.go
+++ b/cmd/worksession/worksession_timeline_test.go
@@ -3,6 +3,7 @@ package worksession
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -34,7 +35,9 @@ func TestFormatTimestamp(t *testing.T) {
 		{"2024-01-15 10:30:00", "2024-01-15 10:30:00"},
 	}
 	for _, tc := range tests {
-		assert.Equal(t, tc.want, formatTimestamp(tc.input), tc.input)
+		t.Run(tc.input, func(t *testing.T) {
+			assert.Equal(t, tc.want, formatTimestamp(tc.input))
+		})
 	}
 }
 
@@ -55,7 +58,9 @@ func TestFormatType(t *testing.T) {
 		{"unknown_type", "unknown_type"},
 	}
 	for _, tc := range tests {
-		assert.Equal(t, tc.want, formatType(tc.input), tc.input)
+		t.Run(tc.input, func(t *testing.T) {
+			assert.Equal(t, tc.want, formatType(tc.input))
+		})
 	}
 }
 
@@ -74,7 +79,9 @@ func TestFormatSize(t *testing.T) {
 		{1073741824, "1.0 GB"},
 	}
 	for _, tc := range tests {
-		assert.Equal(t, tc.want, formatSize(tc.bytes), "%d bytes", tc.bytes)
+		t.Run(fmt.Sprintf("%d bytes", tc.bytes), func(t *testing.T) {
+			assert.Equal(t, tc.want, formatSize(tc.bytes))
+		})
 	}
 }
 
@@ -117,7 +124,9 @@ func TestFormatDetails_Command(t *testing.T) {
 		},
 	}
 	for _, tc := range tests {
-		assert.Equal(t, tc.want, formatDetails(&tc.item), tc.name)
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, formatDetails(&tc.item))
+		})
 	}
 }
 
@@ -158,7 +167,9 @@ func TestFormatDetails_Sessions(t *testing.T) {
 		},
 	}
 	for _, tc := range tests {
-		assert.Equal(t, tc.want, formatDetails(&tc.item), tc.name)
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, formatDetails(&tc.item))
+		})
 	}
 }
 
@@ -181,7 +192,9 @@ func TestFormatDetails_Files(t *testing.T) {
 		},
 	}
 	for _, tc := range tests {
-		assert.Equal(t, tc.want, formatDetails(&tc.item), tc.name)
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, formatDetails(&tc.item))
+		})
 	}
 }
 
@@ -211,7 +224,9 @@ func TestFormatDetails_SudoGrant(t *testing.T) {
 		},
 	}
 	for _, tc := range tests {
-		assert.Equal(t, tc.want, formatDetails(&tc.item), tc.name)
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, formatDetails(&tc.item))
+		})
 	}
 }
 

--- a/cmd/worksession/worksession_update_test.go
+++ b/cmd/worksession/worksession_update_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func TestValidateSessionForSudoUpdate(t *testing.T) {
+	t.Parallel()
 	t.Run("pending session is rejected with actionable message", func(t *testing.T) {
 		session := &wsapi.WorkSession{
 			ID:     "ses-pending",
@@ -70,6 +71,7 @@ func TestValidateSessionForSudoUpdate(t *testing.T) {
 }
 
 func TestApplyWorkSessionUpdate_PreservesExistingSudoPolicies(t *testing.T) {
+	t.Parallel()
 	var gotPATCH wsapi.WorkSessionUpdateRequest
 	patchCalled := false
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -109,6 +111,7 @@ func TestApplyWorkSessionUpdate_PreservesExistingSudoPolicies(t *testing.T) {
 }
 
 func TestApplyWorkSessionUpdate_PendingSessionAbortsBeforePATCH(t *testing.T) {
+	t.Parallel()
 	patchCalled := false
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodPatch {
@@ -132,6 +135,7 @@ func TestApplyWorkSessionUpdate_PendingSessionAbortsBeforePATCH(t *testing.T) {
 }
 
 func TestApplyWorkSessionUpdate_FieldsOnlySkipsGet(t *testing.T) {
+	t.Parallel()
 	var raw map[string]any
 	getCalled, patchCalled := false, false
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -170,6 +174,7 @@ func TestApplyWorkSessionUpdate_FieldsOnlySkipsGet(t *testing.T) {
 }
 
 func TestApplyWorkSessionUpdate_SudoPlusFields(t *testing.T) {
+	t.Parallel()
 	var gotPATCH wsapi.WorkSessionUpdateRequest
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.Method {
@@ -196,6 +201,7 @@ func TestApplyWorkSessionUpdate_SudoPlusFields(t *testing.T) {
 }
 
 func TestParseRFC3339Flag(t *testing.T) {
+	t.Parallel()
 	v, err := parseRFC3339Flag("--starts-at", "  2027-01-15T10:00:00Z  ")
 	assert.NoError(t, err)
 	assert.Equal(t, "2027-01-15T10:00:00Z", v)

--- a/cmd/workspace/error_callbacks_test.go
+++ b/cmd/workspace/error_callbacks_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func TestErrorCallbacks_WiresEveryField(t *testing.T) {
+	t.Parallel()
 	ac := &client.AlpaconClient{}
 	retried := false
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -22,6 +22,7 @@ func setupTestConfig(t *testing.T) {
 }
 
 func TestIsMultiWorkspaceMode(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		config   Config
@@ -235,6 +236,7 @@ func TestActiveWorkSession_PerWorkspaceIsolation(t *testing.T) {
 }
 
 func TestIsServiceToken(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name  string
 		token string
@@ -254,6 +256,7 @@ func TestIsServiceToken(t *testing.T) {
 }
 
 func TestGetAuthMethod(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		cfg      Config

--- a/config/device_test.go
+++ b/config/device_test.go
@@ -53,6 +53,7 @@ func writeDeviceIDFile(t *testing.T, raw string) {
 }
 
 func TestIsValidDeviceID(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name string
 		id   string
@@ -76,6 +77,7 @@ func TestIsValidDeviceID(t *testing.T) {
 }
 
 func TestNewDeviceID_IsUniqueAndAcceptedByAuth0Pattern(t *testing.T) {
+	t.Parallel()
 	seen := make(map[string]bool)
 	for i := 0; i < 100; i++ {
 		id, err := newDeviceID()
@@ -273,6 +275,7 @@ func TestCreateDeviceIDFile_ReportsErrExistWhenPathIsTaken(t *testing.T) {
 // no-hard-link fallback on the contract createDeviceID branches on. It gives up
 // atomicity; it must not give up the exclusion.
 func TestCreateDeviceIDFileWithoutLink_ReportsErrExistWhenPathIsTaken(t *testing.T) {
+	t.Parallel()
 	path := filepath.Join(t.TempDir(), DeviceIDFileName)
 	const winner = "0f6f3f2e-2a9d-4a1e-8f2b-1c2d3e4f5a6b"
 	require.NoError(t, createDeviceIDFileWithoutLink(path, winner))
@@ -291,6 +294,7 @@ func TestCreateDeviceIDFileWithoutLink_ReportsErrExistWhenPathIsTaken(t *testing
 // probabilistic—the window is one write wide—but one-sided: a publication step
 // with no window cannot fail it, so a failure here is real.
 func TestCreateDeviceIDFile_NeverPublishesAnEmptyFile(t *testing.T) {
+	t.Parallel()
 	const rounds = 200
 	const deviceID = "0f6f3f2e-2a9d-4a1e-8f2b-1c2d3e4f5a6b"
 

--- a/pkg/tunnel/runtime/runtime_test.go
+++ b/pkg/tunnel/runtime/runtime_test.go
@@ -75,6 +75,7 @@ func (e *tempNetError) Timeout() bool   { return e.timeout }
 func (e *tempNetError) Temporary() bool { return e.temporary }
 
 func TestShutdownRunsOnce(t *testing.T) {
+	t.Parallel()
 	cause := errors.New("shutdown cause")
 	var listenerCloseCount int32
 	var sessionCloseCount int32
@@ -125,6 +126,7 @@ func TestShutdownRunsOnce(t *testing.T) {
 }
 
 func TestAcceptConnectionsRetriesOnTemporaryError(t *testing.T) {
+	t.Parallel()
 	var attempts int32
 	const retryCount = 3
 
@@ -160,6 +162,7 @@ func TestAcceptConnectionsRetriesOnTemporaryError(t *testing.T) {
 }
 
 func TestAcceptConnectionsTemporaryNonTimeoutErrorTriggersShutdown(t *testing.T) {
+	t.Parallel()
 	var listenerCloseCount int32
 	var sessionCloseCount int32
 
@@ -207,6 +210,7 @@ func TestAcceptConnectionsTemporaryNonTimeoutErrorTriggersShutdown(t *testing.T)
 }
 
 func TestAcceptConnectionsErrorTriggersShutdown(t *testing.T) {
+	t.Parallel()
 	acceptErr := errors.New("accept failure")
 	var listenerCloseCount int32
 	var sessionCloseCount int32
@@ -251,6 +255,7 @@ func TestAcceptConnectionsErrorTriggersShutdown(t *testing.T) {
 }
 
 func TestSessionCloseChanTriggersShutdown(t *testing.T) {
+	t.Parallel()
 	closeChan := make(chan struct{})
 	var listenerCloseCount int32
 	var sessionCloseCount int32
@@ -298,6 +303,7 @@ func TestSessionCloseChanTriggersShutdown(t *testing.T) {
 }
 
 func TestParsePort(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name      string
 		value     string
@@ -325,6 +331,7 @@ func TestParsePort(t *testing.T) {
 }
 
 func TestExtractTCPPort(t *testing.T) {
+	t.Parallel()
 	t.Run("tcp address", func(t *testing.T) {
 		port, err := extractTCPPort(&net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 5432})
 		if err != nil {
@@ -344,6 +351,7 @@ func TestExtractTCPPort(t *testing.T) {
 }
 
 func TestCheckReadyReturnsErrorWhenRuntimeAlreadyClosed(t *testing.T) {
+	t.Parallel()
 	r := &Runtime{
 		done: make(chan struct{}),
 	}
@@ -365,6 +373,7 @@ func TestCheckReadyReturnsErrorWhenRuntimeAlreadyClosed(t *testing.T) {
 }
 
 func TestCheckReadyReturnsOpenStreamError(t *testing.T) {
+	t.Parallel()
 	r := &Runtime{
 		done: make(chan struct{}),
 		session: &mockSession{
@@ -385,6 +394,7 @@ func TestCheckReadyReturnsOpenStreamError(t *testing.T) {
 }
 
 func TestBuildTunnelMetadata(t *testing.T) {
+	t.Parallel()
 	metadataBytes, err := buildTunnelMetadata("5432")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/utils/basedomain_test.go
+++ b/utils/basedomain_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 func TestExtractBaseDomain(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		input    string

--- a/utils/error_envelope_test.go
+++ b/utils/error_envelope_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 func TestBuildCliErrorEnvelope(t *testing.T) {
+	t.Parallel()
 	env := buildCliErrorEnvelope("extend", "work_session_not_usable", "Failed to extend work session: refused.")
 
 	assert.False(t, env.OK)
@@ -19,6 +20,7 @@ func TestBuildCliErrorEnvelope(t *testing.T) {
 }
 
 func TestBuildCliErrorEnvelope_NoCodeOmitsField(t *testing.T) {
+	t.Parallel()
 	env := buildCliErrorEnvelope("use", "", "boom")
 
 	rendered, err := FormatJSON(env)
@@ -28,6 +30,7 @@ func TestBuildCliErrorEnvelope_NoCodeOmitsField(t *testing.T) {
 }
 
 func TestBuildCliErrorEnvelopeFromErr_ExtractsServerCode(t *testing.T) {
+	t.Parallel()
 	// ParseErrorResponse falls back to parsing the legacy "msg; code: X; source: Y" string form.
 	err := errors.New("WorkSession is not usable; code: work_session_not_usable; source: work_session")
 	env := buildCliErrorEnvelopeFromErr("extend", err, "Failed to extend work session: refused.")
@@ -37,6 +40,7 @@ func TestBuildCliErrorEnvelopeFromErr_ExtractsServerCode(t *testing.T) {
 }
 
 func TestBuildCliErrorEnvelopeFromErr_NilErr(t *testing.T) {
+	t.Parallel()
 	env := buildCliErrorEnvelopeFromErr("recording", nil, "No recordings found for session ses-1.")
 
 	assert.Empty(t, env.ErrorCode)
@@ -44,16 +48,19 @@ func TestBuildCliErrorEnvelopeFromErr_NilErr(t *testing.T) {
 }
 
 func TestBuildCliErrorEnvelopeFromErr_PlainErr(t *testing.T) {
+	t.Parallel()
 	env := buildCliErrorEnvelopeFromErr("use", errors.New("config write failed"), "config write failed")
 
 	assert.Empty(t, env.ErrorCode)
 }
 
 func TestUsageErrorCodeConstant(t *testing.T) {
+	t.Parallel()
 	assert.Equal(t, "usage_error", UsageErrorCode)
 }
 
 func TestBuildCliUsageErrorEnvelope_CarriesUsageCodeAndExitTwo(t *testing.T) {
+	t.Parallel()
 	env := buildCliUsageErrorEnvelope("extend", "Either --expires-in or --expires-at is required.")
 
 	assert.False(t, env.OK)
@@ -64,6 +71,7 @@ func TestBuildCliUsageErrorEnvelope_CarriesUsageCodeAndExitTwo(t *testing.T) {
 }
 
 func TestBuildCliErrorEnvelope_DefaultsExitCodeToOne(t *testing.T) {
+	t.Parallel()
 	// Pins the default the new helper has to override; without the override the
 	// envelope would claim 1 while the process exits 6.
 	envelope := buildCliErrorEnvelope("work-session create", "", "work session was rejected")

--- a/utils/error_handler_test.go
+++ b/utils/error_handler_test.go
@@ -24,12 +24,14 @@ func withFastTimeout(t *testing.T) {
 }
 
 func TestHandleCommonErrors_UnknownError(t *testing.T) {
+	t.Parallel()
 	err := errors.New("connection refused")
 	result := HandleCommonErrors(err, "server1", ErrorHandlerCallbacks{})
 	assert.Equal(t, err, result)
 }
 
 func TestHandleCommonErrors_UsernameRequired(t *testing.T) {
+	t.Parallel()
 	t.Run("no callback returns original error", func(t *testing.T) {
 		err := errors.New(`{"code": "user_username_required", "source": ""}`)
 		result := HandleCommonErrors(err, "server1", ErrorHandlerCallbacks{})
@@ -56,6 +58,7 @@ func TestHandleCommonErrors_UsernameRequired(t *testing.T) {
 }
 
 func TestHandleCommonErrors_MFA_NoCallback(t *testing.T) {
+	t.Parallel()
 	err := errors.New(`{"code": "auth_mfa_required", "source": "command"}`)
 	result := HandleCommonErrors(err, "server1", ErrorHandlerCallbacks{})
 	assert.Equal(t, err, result)

--- a/utils/error_test.go
+++ b/utils/error_test.go
@@ -10,12 +10,14 @@ import (
 )
 
 func TestParseErrorResponse_NilError(t *testing.T) {
+	t.Parallel()
 	code, source := ParseErrorResponse(nil)
 	assert.Equal(t, "", code)
 	assert.Equal(t, "", source)
 }
 
 func TestParseErrorResponse_JSONFormat(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name           string
 		errMsg         string
@@ -58,6 +60,7 @@ func TestParseErrorResponse_JSONFormat(t *testing.T) {
 }
 
 func TestParseErrorResponse_TextFormat(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name           string
 		errMsg         string
@@ -94,12 +97,14 @@ func TestParseErrorResponse_TextFormat(t *testing.T) {
 }
 
 func TestParseErrorResponse_NoMatch(t *testing.T) {
+	t.Parallel()
 	code, source := ParseErrorResponse(errors.New("connection refused"))
 	assert.Equal(t, "", code)
 	assert.Equal(t, "", source)
 }
 
 func TestParseErrorResponse_WrappedJSONFormat(t *testing.T) {
+	t.Parallel()
 	inner := errors.New(`{"code": "work_session_required", "source": "command"}`)
 	wrapped := fmt.Errorf("failed to execute command on 'srv' server: %w", inner)
 	code, source := ParseErrorResponse(wrapped)
@@ -108,6 +113,7 @@ func TestParseErrorResponse_WrappedJSONFormat(t *testing.T) {
 }
 
 func TestParseErrorResponse_WrappedTextFormat(t *testing.T) {
+	t.Parallel()
 	inner := errors.New("code: work_session_expired; source: server")
 	wrapped := fmt.Errorf("request failed: %w", inner)
 	code, source := ParseErrorResponse(wrapped)
@@ -116,6 +122,7 @@ func TestParseErrorResponse_WrappedTextFormat(t *testing.T) {
 }
 
 func TestWorkSessionConstants(t *testing.T) {
+	t.Parallel()
 	assert.Equal(t, "work_session_required", WorkSessionRequired)
 	assert.Equal(t, "work_session_not_usable", WorkSessionNotUsable)
 	assert.Equal(t, "work_session_not_active", WorkSessionNotActive)
@@ -127,6 +134,7 @@ func TestWorkSessionConstants(t *testing.T) {
 }
 
 func TestClientErrorBand(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name           string
 		status         int
@@ -151,12 +159,14 @@ func TestClientErrorBand(t *testing.T) {
 }
 
 func TestServerBusyExitCode(t *testing.T) {
+	t.Parallel()
 	// Stable, script-facing contract—see README "Exit codes".
 	assert.Equal(t, "server_busy_with_user_work", ServerBusyWithUserWork)
 	assert.Equal(t, 5, ExitCodeServerBusy)
 }
 
 func TestExitCodeNotApproved_IsSixAndDistinct(t *testing.T) {
+	t.Parallel()
 	// 6 is a public contract documented in README; scripts and agents branch on it.
 	assert.Equal(t, 6, ExitCodeNotApproved)
 	assert.NotEqual(t, ExitCodeWorkSessionDenied, ExitCodeNotApproved)
@@ -165,6 +175,7 @@ func TestExitCodeNotApproved_IsSixAndDistinct(t *testing.T) {
 }
 
 func TestExitCodeUsageError_IsTwoAndDistinct(t *testing.T) {
+	t.Parallel()
 	// 2 is a public contract documented in README; scripts and agents branch on it.
 	assert.Equal(t, 2, ExitCodeUsageError)
 	assert.NotEqual(t, ExitCodeGeneralError, ExitCodeUsageError)

--- a/utils/jwt_test.go
+++ b/utils/jwt_test.go
@@ -20,6 +20,7 @@ func buildTestJWT(t *testing.T, claims map[string]any) string {
 }
 
 func TestDecodeJWTPayload(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name        string
 		token       string
@@ -95,6 +96,7 @@ func TestDecodeJWTPayload(t *testing.T) {
 }
 
 func TestDecodeJWTPayload_StandardPadding(t *testing.T) {
+	t.Parallel()
 	// Ensure payloads that need base64 padding (=, ==) still decode correctly
 	claims := map[string]any{"a": "b"}
 	token := buildTestJWT(t, claims)

--- a/utils/output_test.go
+++ b/utils/output_test.go
@@ -235,6 +235,7 @@ func TestPrintJson_TableOutput(t *testing.T) {
 }
 
 func TestFormatJSON_DisablesHTMLEscaping(t *testing.T) {
+	t.Parallel()
 	got, err := FormatJSON(map[string]string{"next": `alpacon work-session use <ID>`})
 	assert.NoError(t, err)
 	assert.Contains(t, got, "<ID>")
@@ -242,6 +243,7 @@ func TestFormatJSON_DisablesHTMLEscaping(t *testing.T) {
 }
 
 func TestPrintJSONError(t *testing.T) {
+	t.Parallel()
 	var buf bytes.Buffer
 	PrintJSONError(&buf, JSONErrorEnvelope[map[string]string]{
 		ExitCode:  3,
@@ -266,6 +268,7 @@ func TestPrintJSONError(t *testing.T) {
 // Callers write PlainText raw, outside the Cli* helpers, and interpolate
 // server-returned ids into Command (#364).
 func TestNextActionPlainTextSanitizesTerminalText(t *testing.T) {
+	t.Parallel()
 	const (
 		command     = "alpacon exec logs job-1\x1b[2K\u202e"
 		description = "after\x1b]0;pwn\x07 approval\u202e"

--- a/utils/pager_test.go
+++ b/utils/pager_test.go
@@ -29,6 +29,7 @@ func captureOutput(t *testing.T, fn func(stdout *os.File)) string {
 }
 
 func TestWriteToPager_NonTerminal(t *testing.T) {
+	t.Parallel()
 	want := "hello\nworld\n"
 
 	got := captureOutput(t, func(stdout *os.File) {
@@ -43,6 +44,7 @@ func TestWriteToPager_NonTerminal(t *testing.T) {
 }
 
 func TestWriteToPager_TerminalShortOutput(t *testing.T) {
+	t.Parallel()
 	want := "line1\nline2\nline3\n"
 
 	got := captureOutput(t, func(stdout *os.File) {

--- a/utils/poll_test.go
+++ b/utils/poll_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 func TestNextPollTick(t *testing.T) {
+	t.Parallel()
 	base := time.Second
 	tests := []struct {
 		name    string
@@ -30,6 +31,7 @@ func TestNextPollTick(t *testing.T) {
 }
 
 func TestNextPollBackoff(t *testing.T) {
+	t.Parallel()
 	base := time.Second
 	tests := []struct {
 		name       string

--- a/utils/purpose_demand_test.go
+++ b/utils/purpose_demand_test.go
@@ -199,6 +199,7 @@ func TestPrintPurposeAnswer_TableModeKeepsStdoutClean(t *testing.T) {
 }
 
 func TestPurposeDemandLead_SaysWhatSilenceCosts(t *testing.T) {
+	t.Parallel()
 	// Both surfaces read the expiry behaviour off this one string, so they
 	// cannot describe it differently. A caller who arrives through `exec logs`
 	// found the demand late by definition, and needs to know the command is not

--- a/utils/remote_path_test.go
+++ b/utils/remote_path_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 func TestRemoteFileName(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name       string
 		remotePath string

--- a/utils/ssh_parser_test.go
+++ b/utils/ssh_parser_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 func TestParseSSHTarget(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		input    string
@@ -122,6 +123,7 @@ func TestParseSSHTarget(t *testing.T) {
 }
 
 func TestIsRemoteTarget(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		input    string
@@ -188,6 +190,7 @@ func TestIsRemoteTarget(t *testing.T) {
 }
 
 func TestIsLocalTarget(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		input    string

--- a/utils/unzip_test.go
+++ b/utils/unzip_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 func TestUnzip_ValidFiles(t *testing.T) {
+	t.Parallel()
 	// Create a temporary zip file with valid content
 	tmpDir := t.TempDir()
 	zipPath := filepath.Join(tmpDir, "test.zip")
@@ -62,6 +63,7 @@ func TestUnzip_ValidFiles(t *testing.T) {
 }
 
 func TestUnzip_PathTraversalAttack(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		filename string
@@ -161,6 +163,7 @@ func TestUnzip_PathTraversalAttack(t *testing.T) {
 }
 
 func TestUnzip_DirectoryTraversal(t *testing.T) {
+	t.Parallel()
 	tmpDir := t.TempDir()
 	zipPath := filepath.Join(tmpDir, "test.zip")
 	extractDir := filepath.Join(tmpDir, "extract")
@@ -196,6 +199,7 @@ func TestUnzip_DirectoryTraversal(t *testing.T) {
 }
 
 func TestUnzip_NonExistentFile(t *testing.T) {
+	t.Parallel()
 	tmpDir := t.TempDir()
 	err := Unzip(filepath.Join(tmpDir, "nonexistent.zip"), tmpDir)
 	if err == nil {

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -19,6 +19,7 @@ import (
 )
 
 func TestBoolPointerToString(t *testing.T) {
+	t.Parallel()
 	trueVal := true
 	falseVal := false
 
@@ -28,6 +29,7 @@ func TestBoolPointerToString(t *testing.T) {
 }
 
 func TestTruncateString(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		str      string
@@ -48,6 +50,7 @@ func TestTruncateString(t *testing.T) {
 }
 
 func TestIsUUID(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		input    string
@@ -69,6 +72,7 @@ func TestIsUUID(t *testing.T) {
 }
 
 func TestBuildURL(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name         string
 		basePath     string
@@ -90,6 +94,7 @@ func TestBuildURL(t *testing.T) {
 }
 
 func TestTimeUtils(t *testing.T) {
+	t.Parallel()
 	now := time.Now()
 
 	tests := []struct {
@@ -122,6 +127,7 @@ func TestTimeUtils(t *testing.T) {
 }
 
 func TestExtractWorkspaceName(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		input    string
@@ -141,6 +147,7 @@ func TestExtractWorkspaceName(t *testing.T) {
 }
 
 func TestRemovePrefixBeforeAPI(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		input    string
@@ -160,6 +167,7 @@ func TestRemovePrefixBeforeAPI(t *testing.T) {
 }
 
 func TestSaveStream(t *testing.T) {
+	t.Parallel()
 	dest := filepath.Join(t.TempDir(), "nested", "file.txt")
 
 	written, err := saveStream(dest, strings.NewReader("hello world"))
@@ -183,6 +191,7 @@ func (r *failingReader) Read(p []byte) (int, error) {
 }
 
 func TestSaveStreamAtomic_RetainsExistingFileOnReadError(t *testing.T) {
+	t.Parallel()
 	dest := filepath.Join(t.TempDir(), "nested", "file.txt")
 	require.NoError(t, os.MkdirAll(filepath.Dir(dest), 0755))
 	require.NoError(t, os.WriteFile(dest, []byte("existing"), 0644))
@@ -208,6 +217,7 @@ func requireUnixModes(t *testing.T) {
 }
 
 func TestSaveStreamAtomic_PreservesExistingFileMode(t *testing.T) {
+	t.Parallel()
 	requireUnixModes(t)
 
 	dest := filepath.Join(t.TempDir(), "file.txt")
@@ -248,6 +258,7 @@ func TestSaveStreamAtomic_WarnsWhenKeptModeIsWiderThanANewFile(t *testing.T) {
 // through the filesystem makes them umask-dependent, and a umask that narrows
 // the setup mode retires the branch instead of testing it.
 func TestKeptModeIsWider(t *testing.T) {
+	t.Parallel()
 	requireUnixModes(t)
 
 	tests := []struct {
@@ -302,6 +313,7 @@ func (r *tempModeReader) Read(p []byte) (int, error) {
 }
 
 func TestSaveStreamAtomic_KeepsPartialReplacementUnreadable(t *testing.T) {
+	t.Parallel()
 	requireUnixModes(t)
 
 	dir := t.TempDir()
@@ -330,6 +342,7 @@ func TestSaveStreamAtomic_KeepsPartialReplacementUnreadable(t *testing.T) {
 }
 
 func TestSaveStreamAtomic_AppliesRequestedModeToNewFile(t *testing.T) {
+	t.Parallel()
 	requireUnixModes(t)
 
 	dest := filepath.Join(t.TempDir(), "file.txt")
@@ -350,6 +363,7 @@ func TestSaveStreamAtomic_AppliesRequestedModeToNewFile(t *testing.T) {
 }
 
 func TestSaveStreamAtomic_WritesThroughExistingSymlink(t *testing.T) {
+	t.Parallel()
 	if runtime.GOOS == "windows" {
 		t.Skip("symlink creation requires elevated privileges on some Windows environments")
 	}
@@ -378,6 +392,7 @@ func TestSaveStreamAtomic_WritesThroughExistingSymlink(t *testing.T) {
 }
 
 func TestSaveStreamAtomic_WritesThroughDanglingSymlink(t *testing.T) {
+	t.Parallel()
 	if runtime.GOOS == "windows" {
 		t.Skip("symlink creation requires elevated privileges on some Windows environments")
 	}
@@ -400,6 +415,7 @@ func TestSaveStreamAtomic_WritesThroughDanglingSymlink(t *testing.T) {
 }
 
 func TestSpoolToTempFile_ReopensForReadingAndReportsSize(t *testing.T) {
+	t.Parallel()
 	f, size, err := SpoolToTempFile("alpacon-spool-success-*.tmp", func(w io.Writer) error {
 		_, err := w.Write([]byte("spooled"))
 		return err
@@ -414,6 +430,7 @@ func TestSpoolToTempFile_ReopensForReadingAndReportsSize(t *testing.T) {
 }
 
 func TestSpoolToTempFile_CleansUpOnCallbackError(t *testing.T) {
+	t.Parallel()
 	pattern := "alpacon-spool-cleanup-" + strings.ReplaceAll(t.Name(), "/", "-") + "-*.tmp"
 	wantErr := errors.New("spool failed")
 
@@ -432,6 +449,7 @@ func TestSpoolToTempFile_CleansUpOnCallbackError(t *testing.T) {
 }
 
 func TestZipToWriter(t *testing.T) {
+	t.Parallel()
 	root := t.TempDir()
 	require.NoError(t, os.WriteFile(filepath.Join(root, "file.txt"), []byte("hello"), 0644))
 	require.NoError(t, os.Mkdir(filepath.Join(root, "nested"), 0755))
@@ -462,6 +480,7 @@ func TestZipToWriter(t *testing.T) {
 }
 
 func TestSplitAndTrim(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name  string
 		input string
@@ -483,6 +502,7 @@ func TestSplitAndTrim(t *testing.T) {
 }
 
 func TestSplitPath(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name       string
 		input      string
@@ -513,6 +533,7 @@ func TestSplitPath(t *testing.T) {
 }
 
 func TestStripANSIEscapes(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name  string
 		input string
@@ -532,6 +553,7 @@ func TestStripANSIEscapes(t *testing.T) {
 }
 
 func TestStripControlChars(t *testing.T) {
+	t.Parallel()
 	// C0, DEL, and C1 (rune 0x85 = NEL) are removed; printable Unicode (é = 0xE9) is kept.
 	assert.Equal(t, "abc", StripControlChars("a\x00b\x7fc"))
 	assert.Equal(t, "ab", StripControlChars("a\u0085b"))
@@ -539,6 +561,7 @@ func TestStripControlChars(t *testing.T) {
 }
 
 func TestStripFormatChars(t *testing.T) {
+	t.Parallel()
 	// Cf carries no control byte, so the control passes leave it behind.
 	assert.Equal(t, "denied approved", StripFormatChars("denied\u202e\u2066 approved"))
 	assert.Equal(t, "abé", StripFormatChars("a\u200dbé"))
@@ -558,6 +581,7 @@ func TestStripFormatChars(t *testing.T) {
 }
 
 func TestSanitizeTerminalText(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name  string
 		input string
@@ -575,6 +599,7 @@ func TestSanitizeTerminalText(t *testing.T) {
 }
 
 func TestRequirePositiveIntExitsWithUsageErrorCode(t *testing.T) {
+	t.Parallel()
 	helper := osexec.Command(os.Args[0], "-test.run=^TestRequirePositiveIntHelperProcess$")
 	helper.Env = append(os.Environ(), "GO_WANT_REQUIRE_POSITIVE_INT_HELPER=1")
 
@@ -586,6 +611,7 @@ func TestRequirePositiveIntExitsWithUsageErrorCode(t *testing.T) {
 }
 
 func TestRequirePositiveIntHelperProcess(t *testing.T) {
+	t.Parallel()
 	if os.Getenv("GO_WANT_REQUIRE_POSITIVE_INT_HELPER") != "1" {
 		return
 	}
@@ -593,6 +619,7 @@ func TestRequirePositiveIntHelperProcess(t *testing.T) {
 }
 
 func TestSanitizeTerminalLine(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name        string
 		input       string
@@ -645,6 +672,7 @@ func TestSanitizeTerminalLine(t *testing.T) {
 }
 
 func TestSanitizeTerminalBlock(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name        string
 		input       string

--- a/utils/worksession_error_test.go
+++ b/utils/worksession_error_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 func TestIsWorkSessionCode(t *testing.T) {
+	t.Parallel()
 	trueCodes := []string{
 		WorkSessionRequired,
 		WorkSessionNotUsable,
@@ -28,6 +29,7 @@ func TestIsWorkSessionCode(t *testing.T) {
 }
 
 func TestBuildWorkSessionDiagnostic(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		code          string
 		wantReason    string
@@ -68,12 +70,14 @@ func TestBuildWorkSessionDiagnostic(t *testing.T) {
 }
 
 func TestBuildWorkSessionDiagnostic_APIToken(t *testing.T) {
+	t.Parallel()
 	got := buildWorkSessionDiagnostic(WorkSessionRequired, "command", "srv-1", "API token", "")
 	assert.Contains(t, got, "API token")
 	assert.NotContains(t, got, "(interactive)")
 }
 
 func TestBuildWorkSessionErrorEnvelope(t *testing.T) {
+	t.Parallel()
 	tests := []string{
 		WorkSessionRequired,
 		WorkSessionNotActive,
@@ -102,6 +106,7 @@ func TestBuildWorkSessionErrorEnvelope(t *testing.T) {
 }
 
 func TestBuildWorkSessionErrorEnvelope_WithActiveWS(t *testing.T) {
+	t.Parallel()
 	envelope := buildWorkSessionErrorEnvelope(WorkSessionExpired, "webftp", "srv-2", "Browser login", "abc-123-uuid")
 
 	assert.NotNil(t, envelope.Context.CurrentWorksession)
@@ -122,6 +127,7 @@ func nextActionCommands(actions []NextAction) []string {
 }
 
 func TestBuildWorkSessionErrorEnvelope_ExpiredWithoutActiveWS(t *testing.T) {
+	t.Parallel()
 	// When activeWS is unknown, the placeholder must remain.
 	envelope := buildWorkSessionErrorEnvelope(WorkSessionExpired, "webftp", "srv-2", "Browser login", "")
 
@@ -129,6 +135,7 @@ func TestBuildWorkSessionErrorEnvelope_ExpiredWithoutActiveWS(t *testing.T) {
 }
 
 func TestBuildWorkSessionErrorEnvelope_RequiredKeepsPlaceholder(t *testing.T) {
+	t.Parallel()
 	// For work_session_required, activeWS is unrelated to the suggested `use <ID>`,
 	// so the placeholder must NOT be substituted even when activeWS is known.
 	envelope := buildWorkSessionErrorEnvelope(WorkSessionRequired, "command", "srv-1", "Browser login", "abc-123-uuid")
@@ -137,6 +144,7 @@ func TestBuildWorkSessionErrorEnvelope_RequiredKeepsPlaceholder(t *testing.T) {
 }
 
 func TestHandleWorkSessionError_NoOp(t *testing.T) {
+	t.Parallel()
 	// Non-WorkSession errors must not trigger any exit — just return.
 	// If HandleWorkSessionError calls os.Exit for this error, the test process dies.
 	err := errors.New("some unrelated error")
@@ -145,5 +153,6 @@ func TestHandleWorkSessionError_NoOp(t *testing.T) {
 }
 
 func TestHandleWorkSessionError_NilError(t *testing.T) {
+	t.Parallel()
 	HandleWorkSessionError(nil, "websh", "srv", "Browser login", "")
 }


### PR DESCRIPTION
## What

Adds `t.Parallel()` as the first statement of 695 of the 914 top-level tests, wraps the nine bare table loops in `cmd/approval/approval_list_test.go` and `cmd/worksession/worksession_timeline_test.go` in `t.Run`, and records the rule for new tests under "Test patterns" in `CLAUDE.md`.

## Why

Go runs test packages concurrently, but the tests inside one package run one after another unless each calls `t.Parallel()`. Nothing in this repository did, so the wall time of `go test -race ./...` was the sum of every sleep in `api/event`: the streaming fallback tests wait 12, 7, 7, 7 and 4 seconds back to back, and the whole suite took 74 seconds on a 10-core machine with the CPU mostly idle.

| Package | Before | After |
| --- | --- | --- |
| Whole suite (`go test -race -count=1 ./...`) | 73.8 s | 17.1 s |
| `api/event` | 73.0 s | 15.2 s |
| `cmd/exec` | 16.3 s | 6.3 s |
| `api/ftp` | 9.1 s | 4.7 s |

Local numbers, Apple Silicon, 10 cores. The suite is now bounded by its single longest test.

## Which tests stay serial

219 tests do not call `t.Parallel()`. Each falls into one of three groups, and each group either panics or races when made parallel:

- Process-wide state: `t.Setenv` (Go panics when a test calls both), `os.Stdout`/`os.Stderr` swaps including `testutil.CaptureOutput`, `utils.OutputFormat`, and every helper that does one of those for its caller (`withFormat`, `setupTestConfig`, `setupWorkSessionCommandConfig`, `captureStderr`).
- Package-level seams a test reassigns: `runPresenceStepUp`, `approvalWaitPollInterval`, `maxGapWidth`, `maxRetryDuration`, `maxDownloadRetryDelay`, `configReaders`, `tunnelFlags`, `consoleOnlySubcommands`.
- Package-level Cobra commands. Reading one looks harmless but is not: `Commands()` sorts the child list in place on first call and `Find()` builds the merged flag set lazily, so two parallel tests reading `CsrCmd` raced under `-race` on the first attempt.

Serial tests run to completion before any parallel test starts, so a serial test may still reassign a global as long as it restores it.

## Subtests

The nine table loops asserted inside a bare `for`, so a failure could only identify its row through the assertion message and `go test -run` could not select one. Each loop now wraps its body in `t.Run` named by the input. Mutating one expected value produces `--- FAIL: TestFormatSize/1023_bytes`, and `go test -run 'TestFormatSize/1023_bytes' ./cmd/worksession/` runs that row alone.

## Verification

- `go test -race -count=1 ./...` passed on four consecutive runs with no data race reported.
- `golangci-lint run ./...` reports 0 issues; `gofmt -l .` and `go vet ./...` are clean.
- Total statement coverage is unchanged at 61.9%.
