### PR TITLE
fix(utils): rewrite the zip slip guard as a prefix check

### DIFF
--- a/utils/unzip_test.go
+++ b/utils/unzip_test.go
@@ -207,3 +207,49 @@ func TestUnzip_NonExistentFile(t *testing.T) {
 		t.Error("Expected error for non-existent zip file, but got none")
 	}
 }
+
+func TestUnzip_RelativeDestination(t *testing.T) {
+	tests := []struct {
+		name string
+		dest string
+	}{
+		{name: "current directory", dest: "."},
+		{name: "relative subdirectory", dest: "out"},
+		{name: "relative subdirectory with trailing separator", dest: "out/"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			zipPath := filepath.Join(tmpDir, "test.zip")
+
+			zf, err := os.Create(zipPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			zw := zip.NewWriter(zf)
+			fw, err := zw.Create("file.txt")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err := fw.Write([]byte("content")); err != nil {
+				t.Fatal(err)
+			}
+			_ = zw.Close()
+			_ = zf.Close()
+
+			workDir := filepath.Join(tmpDir, "work")
+			if err := os.MkdirAll(workDir, 0o755); err != nil {
+				t.Fatal(err)
+			}
+			t.Chdir(workDir)
+
+			if err := Unzip(zipPath, tt.dest); err != nil {
+				t.Fatalf("Unzip into %q failed: %v", tt.dest, err)
+			}
+			if _, err := os.Stat(filepath.Join(workDir, tt.dest, "file.txt")); err != nil {
+				t.Errorf("file.txt was not extracted into %q: %v", tt.dest, err)
+			}
+		})
+	}
+}

--- a/utils/unzip_test.go
+++ b/utils/unzip_test.go
@@ -93,6 +93,11 @@ func TestUnzip_PathTraversalAttack(t *testing.T) {
 			wantErr:  true,
 		},
 		{
+			name:     "sibling directory sharing the destination prefix",
+			filename: "../extract-evil/file.txt",
+			wantErr:  true,
+		},
+		{
 			name:     "valid file with dots in name",
 			filename: "file..txt",
 			wantErr:  false,

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -390,8 +390,13 @@ func Unzip(src string, dest string) error {
 	}
 	defer func() { _ = r.Close() }()
 
+	// Absolute so a relative dest such as "." keeps the prefix filepath.Join cleans away.
 	// CodeQL's go/zipslip accepts only this prefix form; TrimSuffix keeps a root dest off "//".
-	destPrefix := strings.TrimSuffix(filepath.Clean(dest), string(os.PathSeparator)) + string(os.PathSeparator)
+	destDir, err := filepath.Abs(dest)
+	if err != nil {
+		return err
+	}
+	destPrefix := strings.TrimSuffix(destDir, string(os.PathSeparator)) + string(os.PathSeparator)
 
 	for _, f := range r.File {
 		// Prevent zip slip vulnerability by validating file path
@@ -400,7 +405,7 @@ func Unzip(src string, dest string) error {
 			return fmt.Errorf("invalid file path (absolute path): %s", f.Name)
 		}
 
-		fpath := filepath.Join(dest, f.Name)
+		fpath := filepath.Join(destDir, f.Name)
 
 		if !strings.HasPrefix(fpath, destPrefix) {
 			return fmt.Errorf("invalid file path: %s", f.Name)

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -390,6 +390,9 @@ func Unzip(src string, dest string) error {
 	}
 	defer func() { _ = r.Close() }()
 
+	// CodeQL's go/zipslip accepts only this prefix form; TrimSuffix keeps a root dest off "//".
+	destPrefix := strings.TrimSuffix(filepath.Clean(dest), string(os.PathSeparator)) + string(os.PathSeparator)
+
 	for _, f := range r.File {
 		// Prevent zip slip vulnerability by validating file path
 		// Reject absolute paths
@@ -399,9 +402,7 @@ func Unzip(src string, dest string) error {
 
 		fpath := filepath.Join(dest, f.Name)
 
-		// Use filepath.Rel to safely validate the path is within destination
-		rel, err := filepath.Rel(dest, fpath)
-		if err != nil || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) || rel == ".." {
+		if !strings.HasPrefix(fpath, destPrefix) {
 			return fmt.Errorf("invalid file path: %s", f.Name)
 		}
 


### PR DESCRIPTION
## What

`utils.Unzip` validated each archive entry with `filepath.Rel` against the destination. It now resolves the destination once with `filepath.Abs`, joins every entry onto that, and checks containment with `strings.HasPrefix` against the destination plus a trailing separator.

Containment behavior is unchanged. Absolute entry names are still rejected up front, and `utils/unzip_test.go` keeps every traversal case it had. Two groups of cases were added: a sibling directory sharing the destination's name (`../extract-evil/file.txt`), and three relative destinations (`.`, `out`, `out/`).

## Why

CodeQL's `go/zipslip` is the whole reason. The `filepath.Rel` form is a correct check but not one the query reads as a sanitizer, so [alert 13](https://github.com/alpacax/alpacon-cli/security/code-scanning/13) stayed open on code that was never vulnerable. `strings.HasPrefix` against the destination is the form the query does read.

Three details in that expression:

- The prefix ends in a separator. Without it, `extract-evil` next to `extract` clears the check and writes outside the destination. The sibling test case fails in exactly that way.
- The destination is resolved with `filepath.Abs`. `filepath.Join` cleans `"./file.txt"` down to `"file.txt"`, so a literal `"./"` prefix matches nothing and `alpacon cp -r server:/dir .` would have been rejected entry by entry. Copilot caught this on the first round; it is fixed in 5092c16 and pinned by the `.` case.
- `strings.TrimSuffix` covers the only destination whose resolved form already ends in a separator, the filesystem root. `"/" + "/"` is `"//"`, which no path matches.

`pkg/selfupdate/archive.go` reads archives too and needs no such guard: its `destPath` comes from `destDir` and the expected binary name, and an entry name only ever reaches `filepath.Base` for comparison.

## Verification

CodeQL run locally with codeql 2.26.4 and codeql/go-queries 1.6.9, the versions behind the alert.

| Tree | `Security/CWE-022/ZipSlip.ql` |
| --- | --- |
| Before | 1 alert at `utils/utils.go:393-423`, the location GitHub reports |
| After | none |

The whole `Security/CWE-022/` directory—ZipSlip, TaintedPath, UnsafeUnzipSymlink—is clean on the pushed tree.

`go test -race ./...` passes, `go vet ./...` is silent, and `golangci-lint run ./utils/...` reports 0 issues.

Both added test groups were seen red first:

- Drop the trailing separator from the prefix, and the sibling case reports `File created outside extract directory: extract-evil`.
- Swap `filepath.Abs` back to `filepath.Clean`, and the `.` case reports `Unzip into "." failed: invalid file path: file.txt`.
