### PR TITLE
feat(websh): reconnect when the connection drops and advertise the capability

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,8 @@ $ alpacon websh --share <server>                 # share via temporary link
 $ alpacon websh join --url <SHARED_URL> --password <PASSWORD>
 ```
 
+If the connection drops for any reason other than the session ending—a restarted service, a network interruption—the terminal reconnects to the same session instead of closing, retrying up to five times with a growing delay; input typed while it is down is not delivered.
+
 ### Remote command execution
 ```bash
 $ alpacon exec <server> "<cmd>"

--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ $ alpacon websh --share <server>                 # share via temporary link
 $ alpacon websh join --url <SHARED_URL> --password <PASSWORD>
 ```
 
-If the connection drops for any reason other than the session ending—a restarted service, a network interruption—the terminal reconnects to the same session instead of closing, retrying up to five times with a growing delay; input typed while it is down is not delivered.
+For a terminal you opened yourself, if the connection drops for any reason other than the session ending—a restarted service, a network interruption—the terminal reconnects to the same session instead of closing, retrying up to five times with a growing delay; input typed while it is down is not delivered. A terminal joined through a shared link does not reconnect: rejoin with the link if it drops.
 
 ### Remote command execution
 ```bash

--- a/api/websh/types.go
+++ b/api/websh/types.go
@@ -1,6 +1,7 @@
 package websh
 
 import (
+	"io"
 	"net/http"
 	"sync"
 	"time"
@@ -10,11 +11,44 @@ import (
 )
 
 type WebsocketClient struct {
-	header     http.Header
-	conn       *websocket.Conn
+	header http.Header
+	// conn is the connection currently serving the session, replaced by each
+	// reconnect. Only the goroutine running the session touches it.
+	conn       *connection
 	done       chan struct{} // closed once the first outcome is recorded
 	err        error
 	finishOnce sync.Once
+	// reconnect carries a dropped session to a new connection. nil on a client
+	// that ends the session on the first drop, which is every non-interactive one.
+	reconnect *reconnector
+}
+
+// connection is one WebSocket connection of a session. A session outlives its
+// connections—a dropped link is re-dialed onto a new user channel—so each one
+// records its own ending and the session decides what that ending means.
+type connection struct {
+	ws      *websocket.Conn
+	ended   chan struct{} // closed once the first ending is recorded
+	err     error
+	endOnce sync.Once
+	pumps   sync.WaitGroup
+}
+
+// reconnector is what an interactive session needs to survive a dropped
+// connection: a new user channel to dial, and the terminal size to re-send on it.
+type reconnector struct {
+	// provision issues a new user channel on the same session and returns its
+	// WebSocket URL.
+	provision func() (string, error)
+	// resendSize re-sends the terminal size, which is what makes the remote shell
+	// redraw at the right width once the new connection is up.
+	resendSize func() error
+	// notice is where the reconnect line is printed, os.Stderr in production.
+	notice io.Writer
+	// baseDelay is the first backoff step, lowered by tests so a reconnect
+	// assertion does not have to sit through the production delay.
+	baseDelay   time.Duration
+	maxAttempts int
 }
 
 type SessionRequest struct {
@@ -24,6 +58,14 @@ type SessionRequest struct {
 	Username    string `json:"username"`
 	Groupname   string `json:"groupname"`
 	WorkSession string `json:"work_session,omitempty"`
+}
+
+// SessionSizeRequest updates a session's terminal size. The server resizes the
+// remote PTY on every update, so re-sending an unchanged size is what makes the
+// shell redraw after a reconnect.
+type SessionSizeRequest struct {
+	Rows int `json:"rows"`
+	Cols int `json:"cols"`
 }
 
 type SessionResponse struct {

--- a/api/websh/websh.go
+++ b/api/websh/websh.go
@@ -34,6 +34,33 @@ const (
 	// the same 4000 for the same meaning. A websh session never ends with 1000, so
 	// without this every normal end would be reported as a failure.
 	sessionEndCloseCode = 4000
+
+	// A close that does not mean the session ended is a dropped link—a restarted
+	// service, a network interruption—and the session it was carrying is still
+	// running on the server, so the client dials a new channel onto it instead of
+	// ending the shell. The budget bounds a server that keeps accepting a channel
+	// and dropping it: roughly 30s of waiting before the session is given up.
+	maxReconnectAttempts   = 5
+	reconnectBaseDelay     = 1 * time.Second
+	reconnectMaxDelay      = 15 * time.Second
+	reconnectBackoffFactor = 2
+)
+
+var (
+	// terminalSize reports the local terminal's size, in rows and columns. A var so
+	// a test can pin a size where there is no terminal to read one from.
+	terminalSize = func() (rows, cols int, err error) {
+		cols, rows, err = term.GetSize(int(os.Stdin.Fd()))
+		return rows, cols, err
+	}
+
+	// ErrReconnectFailed ends a session whose connection dropped and could not be
+	// re-established within the attempt budget.
+	ErrReconnectFailed = errors.New("could not reconnect to the session")
+
+	// ErrSessionGone ends a session the server refused a new channel on: it was
+	// closed while the connection was down, so retrying only asks again.
+	ErrSessionGone = errors.New("the session is no longer open")
 )
 
 // GetSessionList returns the newest tail connectable sessions. The endpoint sorts
@@ -94,12 +121,45 @@ func ForceCloseSession(ac *client.AlpaconClient, sessionID string) error {
 	return err
 }
 
+// ConnectToSession opens a read-only channel on someone else's session, which is
+// what watching one is.
 func ConnectToSession(ac *client.AlpaconClient, sessionID string) (SessionResponse, error) {
-	req := &ConnectRequest{
+	return createUserChannel(ac, &ConnectRequest{
 		Session:  sessionID,
 		IsMaster: false,
 		ReadOnly: true,
+	})
+}
+
+// ReconnectToSession opens a new interactive channel on a session the caller is
+// already running, so a client whose connection dropped can reattach. The
+// session's PTY channel is untouched by a user channel closing, so the shell and
+// everything running in it survive the gap.
+func ReconnectToSession(ac *client.AlpaconClient, sessionID string) (SessionResponse, error) {
+	return createUserChannel(ac, &ConnectRequest{
+		Session:  sessionID,
+		IsMaster: true,
+		ReadOnly: false,
+	})
+}
+
+// SendTerminalSize tells the server the terminal's current size. The server
+// resizes the remote PTY on every update, so this also redraws a shell that spent
+// a reconnect talking to nobody, even when the size itself has not changed.
+func SendTerminalSize(ac *client.AlpaconClient, sessionID string) error {
+	rows, cols, err := terminalSize()
+	if err != nil {
+		return err
 	}
+
+	_, err = ac.SendPatchRequest(
+		utils.BuildURL(sessionsBaseURL, sessionID, nil),
+		&SessionSizeRequest{Rows: rows, Cols: cols},
+	)
+	return err
+}
+
+func createUserChannel(ac *client.AlpaconClient, req *ConnectRequest) (SessionResponse, error) {
 	responseBody, err := ac.SendPostRequest(userChannelsBaseURL, req)
 	if err != nil {
 		return SessionResponse{}, err
@@ -168,12 +228,12 @@ func CreateWebshSession(ac *client.AlpaconClient, serverName, username, groupnam
 		return SessionResponse{}, err
 	}
 
-	width, height, err := term.GetSize(int(os.Stdin.Fd()))
+	rows, cols, err := terminalSize()
 	if err != nil {
 		return SessionResponse{}, err
 	}
 
-	sessionRequest := BuildSessionRequest(serverID, username, groupname, height, width, workSessionID)
+	sessionRequest := BuildSessionRequest(serverID, username, groupname, rows, cols, workSessionID)
 
 	responseBody, err := ac.SendPostRequest(sessionsBaseURL, sessionRequest)
 	if err != nil {
@@ -222,22 +282,94 @@ func (wsClient *WebsocketClient) dial(websocketURL string) error {
 		}
 		return fmt.Errorf("websocket connection failed: %w (status %s)", err, utils.SanitizeTerminalText(resp.Status))
 	}
-	wsClient.conn = conn
+	wsClient.conn = newConnection(conn)
 
 	return nil
+}
+
+func newConnection(ws *websocket.Conn) *connection {
+	return &connection{ws: ws, ended: make(chan struct{})}
+}
+
+// finish keeps the first ending. err is written before ended closes, so anyone
+// who saw ended can read it.
+func (c *connection) finish(err error) {
+	c.endOnce.Do(func() {
+		c.err = err
+		close(c.ended)
+	})
+}
+
+// close ends the connection and waits for its pumps, so a reconnect never starts
+// with a goroutine still reading or writing the socket it replaced.
+func (c *connection) close() {
+	_ = c.ws.Close()
+	c.pumps.Wait()
+}
+
+// startReader reads server output for as long as the connection lasts.
+func (c *connection) startReader() {
+	c.pumps.Add(1)
+	go func() {
+		defer c.pumps.Done()
+		c.readFromServer()
+	}()
+}
+
+// startWriter forwards user input for as long as the connection lasts. The input
+// channel outlives the connection: one stdin reader feeds every connection of the
+// session, since a goroutine parked in a terminal read cannot be released.
+func (c *connection) startWriter(inputChan <-chan string) {
+	c.pumps.Add(1)
+	go func() {
+		defer c.pumps.Done()
+		c.writeToServer(inputChan)
+	}()
+}
+
+// closeConn releases the current connection, if the session ever had one.
+func (wsClient *WebsocketClient) closeConn() {
+	if wsClient.conn != nil {
+		wsClient.conn.close()
+	}
 }
 
 // finish keeps the first outcome. err is written before done closes, so anyone who
 // saw done can read it. A deliberate close ends the session rather than failing it;
 // every other close code stays an error.
 func (wsClient *WebsocketClient) finish(err error) {
-	if websocket.IsCloseError(err, sessionEndCloseCode, websocket.CloseNormalClosure, websocket.CloseGoingAway) {
+	if endsSession(err) {
 		err = nil
 	}
 	wsClient.finishOnce.Do(func() {
 		wsClient.err = err
 		close(wsClient.done)
 	})
+}
+
+// endsSession reports whether a connection error means the session itself ended:
+// the proxy's session-end code, or one of the two normal WebSocket closes. Every
+// other ending—1012 on a restarted service, 1006 on a link that went away, a
+// transport error with no close frame at all—leaves the session running on the
+// server, so it is a connection to re-dial rather than a shell to close.
+func endsSession(err error) bool {
+	if err == nil {
+		return true
+	}
+	return websocket.IsCloseError(err, sessionEndCloseCode, websocket.CloseNormalClosure, websocket.CloseGoingAway)
+}
+
+// reconnectDelay returns the wait before the attempt after the given number of
+// failed ones: the base doubled once per failure, capped.
+func reconnectDelay(failures int, base time.Duration) time.Duration {
+	delay := min(base, reconnectMaxDelay)
+	for range failures {
+		delay *= reconnectBackoffFactor
+		if delay >= reconnectMaxDelay {
+			return reconnectMaxDelay
+		}
+	}
+	return delay
 }
 
 // OpenReadOnlyTerminal opens a read-only terminal view for watching another user's session.
@@ -248,7 +380,7 @@ func OpenReadOnlyTerminal(ac *client.AlpaconClient, sessionResponse SessionRespo
 	if err := wsClient.dial(sessionResponse.WebsocketURL); err != nil {
 		return err
 	}
-	defer func() { _ = wsClient.conn.Close() }()
+	defer wsClient.closeConn()
 
 	sigChan, stopSignals := notifySignals()
 	defer stopSignals()
@@ -259,11 +391,18 @@ func OpenReadOnlyTerminal(ac *client.AlpaconClient, sessionResponse SessionRespo
 	}
 	defer restore()
 
+	conn := wsClient.conn
 	go wsClient.watchInterrupt(sigChan)
 	go wsClient.readCtrlC()
-	go wsClient.readFromServer()
+	conn.startReader()
 
-	<-wsClient.done
+	// A watcher does not reconnect: it holds no session of its own, and the one
+	// it is watching may well have been what ended.
+	select {
+	case <-wsClient.done:
+	case <-conn.ended:
+		wsClient.finish(conn.err)
+	}
 	return wsClient.err
 }
 
@@ -297,17 +436,59 @@ func (wsClient *WebsocketClient) readCtrlC() {
 
 // OpenNewTerminal opens an interactive terminal on the session.
 // Input is forwarded to the server. Terminal echo is suppressed via raw mode.
-// Ends cleanly on the remote close, on Ctrl+D, or on a signal.
+// Ends cleanly on the remote close, on Ctrl+D, or on a signal. A connection that
+// drops for any other reason is re-dialed onto a new channel of the same session.
 func OpenNewTerminal(ac *client.AlpaconClient, sessionResponse SessionResponse) error {
-	wsClient := newWebsocketClient(ac.SetWebsocketHeader())
+	return openInteractiveTerminal(ac, sessionResponse, newReconnector(ac, sessionResponse.ID))
+}
+
+// OpenSharedTerminal opens the interactive terminal of a session joined through a
+// shared link. It does not reconnect: only the session's owner may open a new
+// channel on it, the invite channel is single-use, and the join response names no
+// session to ask about. A drop ends the terminal, and the link can be joined again.
+func OpenSharedTerminal(ac *client.AlpaconClient, sessionResponse SessionResponse) error {
+	return openInteractiveTerminal(ac, sessionResponse, nil)
+}
+
+func openInteractiveTerminal(ac *client.AlpaconClient, sessionResponse SessionResponse, reconnect *reconnector) error {
+	var header http.Header
+	if reconnect != nil {
+		header = ac.SetWebsocketHeaderWithCapabilities(client.CapabilityWebsocketReconnect)
+	} else {
+		header = ac.SetWebsocketHeader()
+	}
+
+	wsClient := newWebsocketClient(header)
+	wsClient.reconnect = reconnect
+
 	if err := wsClient.dial(sessionResponse.WebsocketURL); err != nil {
 		return err
 	}
-	defer func() { _ = wsClient.conn.Close() }()
+	defer wsClient.closeConn()
 
 	return wsClient.runWsClient()
 }
 
+func newReconnector(ac *client.AlpaconClient, sessionID string) *reconnector {
+	return &reconnector{
+		provision: func() (string, error) {
+			session, err := ReconnectToSession(ac, sessionID)
+			if err != nil {
+				return "", err
+			}
+			return session.WebsocketURL, nil
+		},
+		resendSize:  func() error { return SendTerminalSize(ac, sessionID) },
+		notice:      os.Stderr,
+		baseDelay:   reconnectBaseDelay,
+		maxAttempts: maxReconnectAttempts,
+	}
+}
+
+// runWsClient runs the session. Raw mode and the stdin reader are entered once and
+// span every connection the session goes through: leaving raw mode between
+// attempts would echo back whatever was typed into the gap, and re-entering it
+// would repaint over the shell the reconnect is trying to restore.
 func (wsClient *WebsocketClient) runWsClient() error {
 	sigChan, stopSignals := notifySignals()
 	defer stopSignals()
@@ -321,12 +502,100 @@ func (wsClient *WebsocketClient) runWsClient() error {
 	inputChan := make(chan string, 1)
 
 	go wsClient.watchInterrupt(sigChan)
-	go wsClient.readFromServer()
 	go wsClient.readUserInput(inputChan)
-	go wsClient.writeToServer(inputChan)
 
-	<-wsClient.done
+	wsClient.serveConnections(inputChan)
+
 	return wsClient.err
+}
+
+// serveConnections runs the current connection until it ends, then either records
+// the session's outcome or replaces the connection. It returns once the session
+// has an outcome, which is always recorded by the time it does.
+func (wsClient *WebsocketClient) serveConnections(inputChan <-chan string) {
+	for {
+		conn := wsClient.conn
+		conn.startReader()
+		conn.startWriter(inputChan)
+
+		select {
+		case <-wsClient.done:
+			return
+		case <-conn.ended:
+		}
+
+		// A connection ending and the session ending can land together—the remote
+		// closing while the user types Ctrl+D. The session's own outcome wins.
+		select {
+		case <-wsClient.done:
+			return
+		default:
+		}
+
+		conn.close()
+
+		if wsClient.reconnect == nil || endsSession(conn.err) {
+			wsClient.finish(conn.err)
+			return
+		}
+		if !wsClient.redial() {
+			return
+		}
+	}
+}
+
+// redial replaces a dropped connection with a new channel on the same session,
+// within a bounded number of attempts. It reports whether the session has a live
+// connection again; on false the session's outcome is already recorded.
+func (wsClient *WebsocketClient) redial() bool {
+	r := wsClient.reconnect
+	// The terminal is still in raw mode, where a bare newline leaves the cursor
+	// where it stood, so the notice carries its own carriage returns.
+	_, _ = fmt.Fprint(r.notice, "\r\nConnection lost, reconnecting...\r\n")
+
+	for failures := range r.maxAttempts {
+		if !wsClient.wait(reconnectDelay(failures, r.baseDelay)) {
+			return false // the session ended while waiting
+		}
+
+		websocketURL, err := r.provision()
+		if err != nil {
+			// A 4xx is the server refusing rather than failing: the session was
+			// closed while the link was down, and asking again only asks again.
+			if utils.IsFatalClientError(utils.HTTPStatusCode(err)) {
+				wsClient.finish(ErrSessionGone)
+				return false
+			}
+			continue
+		}
+		if err := wsClient.dial(websocketURL); err != nil {
+			continue
+		}
+		// Before the pumps, so the redraw the resize provokes lands on a socket
+		// that is already being read. A size the server would not take is not
+		// worth ending a working session over—the shell is usable, if possibly
+		// drawn at the width it had before.
+		if r.resendSize != nil {
+			_ = r.resendSize()
+		}
+		return true
+	}
+
+	wsClient.finish(ErrReconnectFailed)
+	return false
+}
+
+// wait blocks for delay, and reports whether the session outlasted it.
+func (wsClient *WebsocketClient) wait(delay time.Duration) bool {
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+
+	select {
+	case <-wsClient.done:
+		return false
+	case <-timer.C:
+		return true
+	}
 }
 
 // notifySignals returns the signal channel and the stop for the caller to defer.
@@ -353,11 +622,11 @@ func enterRawMode() (func(), error) {
 	return func() { _ = term.Restore(int(os.Stdin.Fd()), oldState) }, nil
 }
 
-func (wsClient *WebsocketClient) readFromServer() {
+func (c *connection) readFromServer() {
 	for {
-		_, message, err := wsClient.conn.ReadMessage()
+		_, message, err := c.ws.ReadMessage()
 		if err != nil {
-			wsClient.finish(err)
+			c.finish(err)
 			return
 		}
 		_, _ = os.Stdout.Write(message)
@@ -365,7 +634,13 @@ func (wsClient *WebsocketClient) readFromServer() {
 }
 
 // readUserInput cannot be released mid-read: a goroutine parked in ReadRune stays
-// there until the next keystroke, and only closing stdin would change that.
+// there until the next keystroke, and only closing stdin would change that. That
+// is why one reader serves the whole session rather than one per connection—a
+// reader left over from a dropped connection would race the next one for the
+// user's keystrokes.
+//
+// Between connections nothing is draining inputChan, so this parks on the send
+// until the session either reconnects or ends. Nothing is buffered on its behalf.
 func (wsClient *WebsocketClient) readUserInput(inputChan chan<- string) {
 	reader := bufio.NewReader(os.Stdin)
 	for {
@@ -386,7 +661,7 @@ func (wsClient *WebsocketClient) readUserInput(inputChan chan<- string) {
 	}
 }
 
-func (wsClient *WebsocketClient) writeToServer(inputChan <-chan string) {
+func (c *connection) writeToServer(inputChan <-chan string) {
 	// A ticker rather than time.After, which restarts on every arriving rune and
 	// so defers the flush for as long as input keeps coming.
 	ticker := time.NewTicker(writeFlushInterval)
@@ -395,15 +670,18 @@ func (wsClient *WebsocketClient) writeToServer(inputChan <-chan string) {
 	var inputBuffer []rune
 	for {
 		select {
-		case <-wsClient.done:
+		case <-c.ended:
+			// Whatever is still buffered goes with the connection: nothing here
+			// re-sends it, so input typed as the link dropped is lost. Replaying it
+			// would submit lines to a shell the user could no longer see.
 			return
 		case input := <-inputChan:
 			inputBuffer = append(inputBuffer, []rune(input)...)
 		case <-ticker.C:
 			if len(inputBuffer) > 0 {
-				err := wsClient.conn.WriteMessage(websocket.BinaryMessage, []byte(string(inputBuffer)))
+				err := c.ws.WriteMessage(websocket.BinaryMessage, []byte(string(inputBuffer)))
 				if err != nil {
-					wsClient.finish(err)
+					c.finish(err)
 					return
 				}
 				inputBuffer = []rune{}

--- a/api/websh/websh_test.go
+++ b/api/websh/websh_test.go
@@ -3,6 +3,7 @@ package websh
 import (
 	"encoding/json"
 	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -10,6 +11,7 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"syscall"
 	"testing"
 	"time"
@@ -375,11 +377,16 @@ func TestSessionGoroutines_ReturnAfterTheOutcomeIsTaken(t *testing.T) {
 			},
 		},
 		{
+			// The writer reports to its connection rather than to the session, since
+			// a connection ending is what a reconnect recovers from.
 			name: "writeToServer waiting to flush",
-			start: func(t *testing.T, wsClient *WebsocketClient) func() {
+			start: func(t *testing.T, _ *WebsocketClient) func() {
 				t.Helper()
-				// Empty, so only the done branch can end the loop: nothing is ever flushed.
-				return func() { wsClient.writeToServer(make(chan string)) }
+				conn := newConnection(nil)
+				conn.finish(errors.New("the connection dropped"))
+
+				// Empty, so only the ended branch can end the loop: nothing is ever flushed.
+				return func() { conn.writeToServer(make(chan string)) }
 			},
 		},
 		{
@@ -443,54 +450,49 @@ func TestReadCtrlC_EndsTheSessionOnCtrlC(t *testing.T) {
 
 func TestWriteToServer_ReportsWriteFailure(t *testing.T) {
 	t.Parallel()
-	conn, _ := dialTestServer(t)
-	require.NoError(t, conn.Close()) // every later WriteMessage fails
-
-	wsClient := newWebsocketClient(nil)
-	wsClient.conn = conn
+	ws, _ := dialTestServer(t)
+	require.NoError(t, ws.Close()) // every later WriteMessage fails
+	conn := newConnection(ws)
 
 	inputChan := make(chan string, 1)
 	inputChan <- "x" // buffered input forces the failing write
 
 	awaitReturn(t, "writeToServer parked on the failing write", func() {
-		wsClient.writeToServer(inputChan)
+		conn.writeToServer(inputChan)
 	})
 
-	assertReported(t, wsClient)
-	assert.Error(t, wsClient.err)
+	assertEnded(t, conn)
+	assert.Error(t, conn.err)
 }
 
 func TestReadFromServer_ReportsReadFailure(t *testing.T) {
 	t.Parallel()
-	conn, _ := dialTestServer(t)
-	require.NoError(t, conn.Close()) // every later ReadMessage fails
+	ws, _ := dialTestServer(t)
+	require.NoError(t, ws.Close()) // every later ReadMessage fails
 
-	wsClient := newWebsocketClient(nil)
-	wsClient.conn = conn
+	conn := newConnection(ws)
 
 	awaitReturn(t, "readFromServer parked on the failing read", func() {
-		wsClient.readFromServer()
+		conn.readFromServer()
 	})
 
-	assertReported(t, wsClient)
-	assert.Error(t, wsClient.err)
+	assertEnded(t, conn)
+	assert.Error(t, conn.err)
 }
 
 func TestReadFromServer_PrintsEveryMessage(t *testing.T) {
-	conn, _ := dialTestServer(t, "hi ", "there")
-
-	wsClient := newWebsocketClient(nil)
-	wsClient.conn = conn
+	ws, _ := dialTestServer(t, "hi ", "there")
+	conn := newConnection(ws)
 
 	stdout := testutil.CaptureStdout(t, func() {
 		awaitReturn(t, "readFromServer parked after the server went away", func() {
-			wsClient.readFromServer()
+			conn.readFromServer()
 		})
 	})
 
 	assert.Equal(t, "hi there", stdout) // the loop must survive a successful read
-	assertReported(t, wsClient)
-	assert.Error(t, wsClient.err)
+	assertEnded(t, conn)
+	assert.Error(t, conn.err)
 }
 
 func TestReadUserInput_ForwardsToTheWriter(t *testing.T) {
@@ -514,16 +516,14 @@ func TestReadUserInput_ForwardsToTheWriter(t *testing.T) {
 
 func TestWriteToServer_FlushesBufferedInput(t *testing.T) {
 	t.Parallel()
-	conn, received := dialTestServer(t)
-
-	wsClient := newWebsocketClient(nil)
-	wsClient.conn = conn
-	t.Cleanup(func() { wsClient.finish(nil) })
+	ws, received := dialTestServer(t)
+	conn := newConnection(ws)
+	t.Cleanup(func() { conn.finish(nil) })
 
 	inputChan := make(chan string, 2)
 	inputChan <- "l"
 	inputChan <- "s"
-	go wsClient.writeToServer(inputChan)
+	go conn.writeToServer(inputChan)
 
 	// The two runes may land in one flush or two, but every byte has to arrive.
 	var got string
@@ -743,6 +743,16 @@ func pipeStdin(t *testing.T) *os.File {
 	return pipeWrite
 }
 
+func assertEnded(t *testing.T, conn *connection) {
+	t.Helper()
+
+	select {
+	case <-conn.ended:
+	default:
+		require.Fail(t, "ended must be closed so the connection's other pump can leave")
+	}
+}
+
 func assertReported(t *testing.T, wsClient *WebsocketClient) {
 	t.Helper()
 
@@ -766,5 +776,385 @@ func awaitReturn(t *testing.T, msg string, fn func()) {
 	case <-returned:
 	case <-time.After(teardownWait):
 		require.Fail(t, msg)
+	}
+}
+
+func TestReconnectToSession_AsksForAnInteractiveChannel(t *testing.T) {
+	t.Parallel()
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+
+		var req ConnectRequest
+		if !assert.NoError(t, json.NewDecoder(r.Body).Decode(&req)) {
+			return
+		}
+		assert.Equal(t, "sess-xyz", req.Session)
+		// What separates reconnecting to your own session from watching someone
+		// else's: a read-only channel would come back to a shell that ignores
+		// every keystroke.
+		assert.True(t, req.IsMaster)
+		assert.False(t, req.ReadOnly)
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(SessionResponse{ID: "channel-2", WebsocketURL: "ws://localhost/ws"})
+	}))
+	defer ts.Close()
+
+	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
+	resp, err := ReconnectToSession(ac, "sess-xyz")
+	require.NoError(t, err)
+	assert.Equal(t, "ws://localhost/ws", resp.WebsocketURL)
+}
+
+// Which endings close the shell and which are a link to re-dial. Everything the
+// server does deliberately is in the first group; everything else leaves a session
+// still running on the far side.
+func TestEndsSession_SeparatesAnEndFromADrop(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			// What the proxy actually sends at the end of a session.
+			name: "session end",
+			err:  &websocket.CloseError{Code: sessionEndCloseCode},
+			want: true,
+		},
+		{
+			name: "normal closure",
+			err:  &websocket.CloseError{Code: websocket.CloseNormalClosure, Text: "session ended"},
+			want: true,
+		},
+		{
+			name: "going away",
+			err:  &websocket.CloseError{Code: websocket.CloseGoingAway},
+			want: true,
+		},
+		{
+			name: "no error at all",
+			want: true,
+		},
+		{
+			name: "service restart",
+			err:  &websocket.CloseError{Code: websocket.CloseServiceRestart},
+		},
+		{
+			name: "abnormal closure",
+			err:  &websocket.CloseError{Code: websocket.CloseAbnormalClosure},
+		},
+		{
+			name: "internal server error",
+			err:  &websocket.CloseError{Code: websocket.CloseInternalServerErr},
+		},
+		{
+			// A link that went away without a close frame of any kind.
+			name: "transport failure",
+			err:  errors.New("connection reset by peer"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, endsSession(tt.err))
+		})
+	}
+}
+
+func TestReconnectDelay_DoublesUpToTheCap(t *testing.T) {
+	t.Parallel()
+	// The whole production schedule, which is what bounds how long a dropped
+	// session waits before it is given up.
+	var schedule []time.Duration
+	for failures := range maxReconnectAttempts {
+		schedule = append(schedule, reconnectDelay(failures, reconnectBaseDelay))
+	}
+
+	assert.Equal(t, []time.Duration{
+		1 * time.Second,
+		2 * time.Second,
+		4 * time.Second,
+		8 * time.Second,
+		15 * time.Second, // 16s doubled past the cap
+	}, schedule)
+}
+
+func TestReconnectDelay_CapsABaseAlreadyOverTheLimit(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, reconnectMaxDelay, reconnectDelay(0, time.Minute))
+	assert.Equal(t, reconnectMaxDelay, reconnectDelay(3, time.Minute))
+}
+
+// The whole recovery, end to end: the server closes the first connection with a
+// service restart, the client provisions a new channel, dials it, and re-sends the
+// terminal size on it.
+func TestServeConnections_ReconnectsAfterAServiceRestart(t *testing.T) {
+	pinTerminalSize(t, 40, 120)
+
+	var upgrades atomic.Int32
+	dialHeaders := make(chan http.Header, receivedBufferSize)
+	channels := make(chan ConnectRequest, receivedBufferSize)
+	resizes := make(chan SessionSizeRequest, receivedBufferSize)
+
+	// SetWebsocketHeader sends an Origin, which the default CheckOrigin rejects
+	// as cross-origin against the httptest host.
+	upgrader := websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/ws/", func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case dialHeaders <- r.Header.Clone():
+		default:
+		}
+		ws, err := upgrader.Upgrade(w, r, nil)
+		if !assert.NoError(t, err) {
+			return
+		}
+		defer func() { _ = ws.Close() }()
+
+		if upgrades.Add(1) == 1 {
+			// A service going down for a restart is not the session ending.
+			_ = ws.WriteControl(
+				websocket.CloseMessage,
+				websocket.FormatCloseMessage(websocket.CloseServiceRestart, ""),
+				time.Now().Add(teardownWait),
+			)
+		}
+		// Held open until the client goes away: the first connection has a close
+		// frame to deliver, and the second is the one the reconnect landed on.
+		for {
+			if _, _, err := ws.ReadMessage(); err != nil {
+				return
+			}
+		}
+	})
+	mux.HandleFunc(userChannelsBaseURL, func(w http.ResponseWriter, r *http.Request) {
+		var req ConnectRequest
+		if assert.NoError(t, json.NewDecoder(r.Body).Decode(&req)) {
+			select {
+			case channels <- req:
+			default:
+			}
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(SessionResponse{
+			ID:           "channel-2",
+			WebsocketURL: "ws://" + r.Host + "/ws/",
+		})
+	})
+	mux.HandleFunc(sessionsBaseURL+"sess-1/", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPatch, r.Method)
+		var size SessionSizeRequest
+		if assert.NoError(t, json.NewDecoder(r.Body).Decode(&size)) {
+			select {
+			case resizes <- size:
+			default:
+			}
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{}`))
+	})
+
+	ts := httptest.NewServer(mux)
+	t.Cleanup(ts.Close)
+
+	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL, UserAgent: "alpacon-cli/test"}
+	wsClient := newWebsocketClient(ac.SetWebsocketHeaderWithCapabilities(client.CapabilityWebsocketReconnect))
+	wsClient.reconnect = newReconnector(ac, "sess-1")
+	wsClient.reconnect.baseDelay = time.Millisecond
+	wsClient.reconnect.notice = io.Discard
+
+	require.NoError(t, wsClient.dial("ws"+strings.TrimPrefix(ts.URL, "http")+"/ws/"))
+
+	served := make(chan struct{})
+	go func() {
+		defer close(served)
+		wsClient.serveConnections(make(chan string))
+	}()
+	t.Cleanup(func() {
+		wsClient.finish(nil)
+		<-served
+		wsClient.closeConn()
+	})
+
+	// The size lands only on a connection that is already up, so waiting for it
+	// waits for the whole recovery.
+	select {
+	case size := <-resizes:
+		assert.Equal(t, SessionSizeRequest{Rows: 40, Cols: 120}, size)
+	case <-time.After(teardownWait):
+		require.Fail(t, "the reconnected session never re-sent the terminal size",
+			"upgrades=%d", upgrades.Load())
+	}
+
+	select {
+	case req := <-channels:
+		assert.Equal(t, ConnectRequest{Session: "sess-1", IsMaster: true}, req)
+	default:
+		require.Fail(t, "the reconnect dialed without provisioning a new channel")
+	}
+
+	assert.Equal(t, int32(2), upgrades.Load(), "the client must dial again rather than reuse the closed connection")
+	for dial := 1; dial <= 2; dial++ {
+		select {
+		case header := <-dialHeaders:
+			assert.Equal(t, client.CapabilityWebsocketReconnect,
+				header.Get(client.ClientCapabilitiesHeader), "dial %d", dial)
+			assert.Equal(t, "alpacon-cli/test", header.Get("User-Agent"), "dial %d", dial)
+		default:
+			require.Fail(t, "the server saw fewer dials than the client made", "dial %d", dial)
+		}
+	}
+
+	select {
+	case <-wsClient.done:
+		require.Fail(t, "a service restart must not end the session", "err=%v", wsClient.err)
+	default:
+	}
+}
+
+func TestRedial_StopsWhenTheServerRefusesANewChannel(t *testing.T) {
+	t.Parallel()
+	var attempts atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"detail": "session is closed"}`))
+	}))
+	t.Cleanup(ts.Close)
+
+	wsClient := newTestReconnectClient(ts.URL)
+
+	assert.False(t, wsClient.redial())
+	assertReported(t, wsClient)
+	require.ErrorIs(t, wsClient.err, ErrSessionGone)
+	// The session was closed while the link was down; asking again only asks again.
+	assert.Equal(t, int32(1), attempts.Load())
+}
+
+func TestRedial_SpendsTheBudgetOnAServerThatKeepsFailing(t *testing.T) {
+	t.Parallel()
+	var attempts atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"detail": "service unavailable"}`))
+	}))
+	t.Cleanup(ts.Close)
+
+	wsClient := newTestReconnectClient(ts.URL)
+
+	assert.False(t, wsClient.redial())
+	assertReported(t, wsClient)
+	require.ErrorIs(t, wsClient.err, ErrReconnectFailed)
+	assert.Equal(t, int32(maxReconnectAttempts), attempts.Load(), "a 5xx is worth the whole budget")
+}
+
+func TestRedial_StopsWhenTheSessionEndsMidWait(t *testing.T) {
+	t.Parallel()
+	var attempts atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"detail": "service unavailable"}`))
+	}))
+	t.Cleanup(ts.Close)
+
+	wsClient := newTestReconnectClient(ts.URL)
+	// Ctrl+C during the backoff: the wait has to end with the session, not carry
+	// on dialing for a shell nobody is watching.
+	wsClient.reconnect.baseDelay = teardownWait
+	wsClient.finish(nil)
+
+	awaitReturn(t, "redial parked on the backoff after the session ended", func() {
+		assert.False(t, wsClient.redial())
+	})
+	assert.Zero(t, attempts.Load())
+}
+
+// newTestReconnectClient is a client whose reconnect talks to ts and waits in
+// milliseconds rather than seconds.
+func newTestReconnectClient(baseURL string) *WebsocketClient {
+	ac := &client.AlpaconClient{HTTPClient: &http.Client{}, BaseURL: baseURL}
+
+	wsClient := newWebsocketClient(nil)
+	wsClient.reconnect = newReconnector(ac, "sess-1")
+	wsClient.reconnect.baseDelay = time.Millisecond
+	wsClient.reconnect.notice = io.Discard
+
+	return wsClient
+}
+
+// pinTerminalSize replaces the terminal size lookup, which a test process has no
+// terminal to answer.
+func pinTerminalSize(t *testing.T, rows, cols int) {
+	t.Helper()
+
+	original := terminalSize
+	terminalSize = func() (int, int, error) { return rows, cols, nil }
+	t.Cleanup(func() { terminalSize = original })
+}
+
+// What reaches the server on the real entry points' first dial. Raw mode fails on
+// a pipe, so each call returns right after the handshake the assertions read.
+func TestOpenTerminal_AdvertisesTheCapabilityOnlyWhereItReconnects(t *testing.T) {
+	tests := []struct {
+		name string
+		open func(*client.AlpaconClient, SessionResponse) error
+		want string
+	}{
+		{
+			name: "an interactive session reconnects",
+			open: OpenNewTerminal,
+			want: client.CapabilityWebsocketReconnect,
+		},
+		{
+			// The joiner may not open a channel on someone else's session, so
+			// claiming the capability would promise a recovery it cannot make.
+			name: "a joined session does not",
+			open: OpenSharedTerminal,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dialHeaders := make(chan http.Header, receivedBufferSize)
+			upgrader := websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				select {
+				case dialHeaders <- r.Header.Clone():
+				default:
+				}
+				ws, err := upgrader.Upgrade(w, r, nil)
+				if !assert.NoError(t, err) {
+					return
+				}
+				_ = ws.Close() // the handler must not outlive the assertions below
+			}))
+			t.Cleanup(ts.Close)
+
+			pipeStdin(t) // a pipe is not a tty, so raw mode fails after the dial succeeds
+
+			ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL, UserAgent: "alpacon-cli/test"}
+			err := tt.open(ac, SessionResponse{
+				ID:           "sess-1",
+				WebsocketURL: "ws" + strings.TrimPrefix(ts.URL, "http"),
+			})
+
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "stdin is not a terminal")
+
+			select {
+			case header := <-dialHeaders:
+				assert.Equal(t, tt.want, header.Get(client.ClientCapabilitiesHeader))
+				assert.Equal(t, "alpacon-cli/test", header.Get("User-Agent"))
+			default:
+				require.Fail(t, "the server saw no dial")
+			}
+		})
 	}
 }

--- a/client/client.go
+++ b/client/client.go
@@ -28,6 +28,15 @@ const (
 	// stale-token retry reads it back off the request to learn which token the
 	// server rejected.
 	bearerPrefix = "Bearer "
+
+	// ClientCapabilitiesHeader carries the optional behaviors a WebSocket
+	// connection supports, as a comma-separated list.
+	ClientCapabilitiesHeader = "X-Alpacon-Client-Capabilities"
+
+	// CapabilityWebsocketReconnect says the client re-dials a new channel and
+	// resumes the session when the connection drops, so closing the connection
+	// for a transient reason does not take the session with it.
+	CapabilityWebsocketReconnect = "websocket-reconnect"
 )
 
 // refreshAccessToken is a test seam so a unit test can drive the stale-token
@@ -221,10 +230,33 @@ func parseAuthStatusErrorPayload(body []byte) (message string, code string, sour
 	return message, code, source, true
 }
 
+// SetWebsocketHeader builds the header for a WebSocket dial. gorilla sends no
+// User-Agent of its own, so a client assembled without one—every client outside
+// NewAlpaconAPIClient—would dial anonymously; fall back to the same string the
+// HTTP requests carry.
 func (ac *AlpaconClient) SetWebsocketHeader() http.Header {
+	userAgent := ac.UserAgent
+	if userAgent == "" {
+		userAgent = utils.GetUserAgent()
+	}
+
 	headers := http.Header{}
 	headers.Set("Origin", ac.BaseURL)
-	headers.Set("User-Agent", ac.UserAgent)
+	headers.Set("User-Agent", userAgent)
+
+	return headers
+}
+
+// SetWebsocketHeaderWithCapabilities is SetWebsocketHeader plus the capabilities
+// this connection supports, so the server can tell a client that re-dials a
+// dropped connection from one that ends the session on it. Only a caller that
+// actually implements a capability may advertise it; a server that does not read
+// the header is unaffected either way.
+func (ac *AlpaconClient) SetWebsocketHeaderWithCapabilities(capabilities ...string) http.Header {
+	headers := ac.SetWebsocketHeader()
+	if len(capabilities) > 0 {
+		headers.Set(ClientCapabilitiesHeader, strings.Join(capabilities, ", "))
+	}
 
 	return headers
 }

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -1099,3 +1099,78 @@ func TestNewAlpaconAPIClient_PinsWorkspaceIdentityFromConfig(t *testing.T) {
 	assert.Equal(t, "https://my-workspace.alpacon.io", ac.BaseURL)
 	assert.Equal(t, "my-workspace", ac.WorkspaceName)
 }
+
+// gorilla sends no User-Agent of its own and copies the header it is handed
+// verbatim, so whatever these two build is exactly what reaches the server.
+func TestSetWebsocketHeader_CarriesTheUserAgent(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name      string
+		userAgent string
+		want      string
+	}{
+		{
+			name:      "the client's own",
+			userAgent: "alpacon-cli/9.9.9",
+			want:      "alpacon-cli/9.9.9",
+		},
+		{
+			// Every client assembled outside NewAlpaconAPIClient, which is the only
+			// place that fills the field in.
+			name: "the default when the client carries none",
+			want: utils.GetUserAgent(),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ac := &AlpaconClient{BaseURL: "https://my-workspace.alpacon.io", UserAgent: tt.userAgent}
+
+			header := ac.SetWebsocketHeader()
+
+			assert.Equal(t, tt.want, header.Get("User-Agent"))
+			assert.Equal(t, "https://my-workspace.alpacon.io", header.Get("Origin"))
+			assert.Empty(t, header.Get(ClientCapabilitiesHeader), "a plain dial claims no capability")
+		})
+	}
+}
+
+func TestSetWebsocketHeaderWithCapabilities(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name         string
+		capabilities []string
+		want         string
+	}{
+		{
+			name:         "one capability",
+			capabilities: []string{CapabilityWebsocketReconnect},
+			want:         CapabilityWebsocketReconnect,
+		},
+		{
+			name:         "several are comma-separated",
+			capabilities: []string{CapabilityWebsocketReconnect, "some-later-capability"},
+			want:         CapabilityWebsocketReconnect + ", some-later-capability",
+		},
+		{
+			// A caller with nothing to advertise must not send an empty header,
+			// which a server could read as a claim of no capabilities at all.
+			name: "none sends no header",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ac := &AlpaconClient{BaseURL: "https://my-workspace.alpacon.io", UserAgent: "alpacon-cli/9.9.9"}
+
+			header := ac.SetWebsocketHeaderWithCapabilities(tt.capabilities...)
+
+			assert.Equal(t, tt.want, header.Get(ClientCapabilitiesHeader))
+			// The capabilities ride alongside what a plain dial already sends.
+			assert.Equal(t, "alpacon-cli/9.9.9", header.Get("User-Agent"))
+			assert.Equal(t, "https://my-workspace.alpacon.io", header.Get("Origin"))
+		})
+	}
+}

--- a/cmd/websh/websh.go
+++ b/cmd/websh/websh.go
@@ -312,7 +312,17 @@ Note: All flags must be placed before the server name.
 		}()
 
 		if err = websh.OpenNewTerminal(alpaconClient, session); err != nil {
-			utils.CliErrorWithExitCode(utils.ExitCodeGeneralError, "Websh session ended with error: %s.", err)
+			// A session the client could not get back to says so on its own terms:
+			// wrapping it in "ended with error" would read as the shell having
+			// failed, when what failed is the connection to it.
+			switch {
+			case errors.Is(err, websh.ErrReconnectFailed):
+				utils.CliErrorWithExitCode(utils.ExitCodeGeneralError, "Could not reconnect to the session.")
+			case errors.Is(err, websh.ErrSessionGone):
+				utils.CliErrorWithExitCode(utils.ExitCodeGeneralError, "The session is no longer open.")
+			default:
+				utils.CliErrorWithExitCode(utils.ExitCodeGeneralError, "Websh session ended with error: %s.", err)
+			}
 		}
 	},
 }

--- a/cmd/websh/websh_join.go
+++ b/cmd/websh/websh_join.go
@@ -28,7 +28,7 @@ var webshJoinCmd = &cobra.Command{
 			utils.CliErrorWithExit("Failed to join the session: %s.", err)
 		}
 
-		if err = websh.OpenNewTerminal(alpaconClient, session); err != nil {
+		if err = websh.OpenSharedTerminal(alpaconClient, session); err != nil {
 			utils.CliErrorWithExitCode(utils.ExitCodeGeneralError, "Websh session ended with error: %s.", err)
 		}
 	},


### PR DESCRIPTION
## Summary

A restarted service or a network interruption closed the `websh` WebSocket and the terminal exited with an error, while the session, the shell and everything running in it were still there on the server. `alpacon websh` now re-dials a new channel on the same session instead, and tells the server on the upgrade request that it does.

## Behavior

**Before.** Any close other than 4000 (the proxy's session end), 1000 or 1001 ended the terminal with `Websh session ended with error: ...` and exit code 1.

**After.** Those three codes still end the session cleanly. Every other ending—1012 from a service going down for a restart, 1006 from a link that went away, a transport error carrying no close frame at all—prints `Connection lost, reconnecting...` on stderr and recovers:

1. open a new user channel on the same session (`POST /api/websh/user-channels/`, `is_master: true`, `read_only: false`),
2. dial the WebSocket URL it returns,
3. re-send the terminal size, which is what makes the remote shell redraw,
4. resume the output and input pumps.

The terminal stays in raw mode throughout—it is entered once for the whole session, not per connection—and no banner is reprinted.

**Budget.** Five attempts, the wait doubling from 1s to a 15s cap (1, 2, 4, 8, 15), so roughly 30 seconds before the session is given up with `Could not reconnect to the session` and exit code 1, the same code as before. A 4xx on the channel request is the server refusing rather than failing—the session was closed while the link was down—so it stops immediately with `The session is no longer open.` and does not spend the budget asking again. Only 5xx and network errors count against it.

**Input.** Nothing is buffered on the user's behalf: input typed while the link is down is not delivered, and the runes the writer still held when the connection dropped go with it. Replaying them would submit lines to a shell nobody could see.

**Not included.** `alpacon websh join` keeps the old behavior: a joined session's invite channel is single-use, the joiner may not open a channel on someone else's session, and the join response names no session to ask about. `alpacon websh watch` is read-only and unchanged.

## Header

Every dial that can reconnect now sends, alongside the `Origin` and `User-Agent` a dial already carried:

```
X-Alpacon-Client-Capabilities: websocket-reconnect
```

`client.SetWebsocketHeaderWithCapabilities(...)` builds it, so any other dial can advertise the same way; a caller with nothing to advertise sends no header at all rather than an empty one. `SetWebsocketHeader` also falls back to `utils.GetUserAgent()` when the client carries none—gorilla sends no user agent of its own, so such a dial was anonymous.

## Testing

`gofmt -l .` clean, `go vet ./...` clean, `golangci-lint run ./...` (v2.9.0, both `GOOS=linux` and `GOOS=windows`) reports `0 issues`.

```
$ go test -race -shuffle=on ./...
ok  	github.com/alpacax/alpacon-cli/api/websh	1.150s
ok  	github.com/alpacax/alpacon-cli/client	1.123s
ok  	github.com/alpacax/alpacon-cli/cmd/websh	1.080s
...
ok  	github.com/alpacax/alpacon-cli/utils	1.625s
```

New coverage:

- `TestEndsSession_SeparatesAnEndFromADrop` — which close codes end the shell and which are a link to re-dial (4000/1000/1001/nil end; 1012, 1006, 1011 and a bare transport error reconnect).
- `TestReconnectDelay_DoublesUpToTheCap` / `..._CapsABaseAlreadyOverTheLimit` — the whole production schedule, 1s → 15s.
- `TestServeConnections_ReconnectsAfterAServiceRestart` — an in-process `httptest` WebSocket server closes the first connection with 1012 and accepts the second; asserts the client provisions exactly one new master channel, dials again, re-sends the pinned size as a `PATCH`, sends the capability header on **both** dials, and does not end the session.
- `TestOpenTerminal_AdvertisesTheCapabilityOnlyWhereItReconnects` — the header on the real entry points' first dial: present for `OpenNewTerminal`, absent for a joined session.
- `TestRedial_StopsWhenTheServerRefusesANewChannel` (4xx, one attempt), `..._SpendsTheBudgetOnAServerThatKeepsFailing` (5xx, five attempts), `..._StopsWhenTheSessionEndsMidWait` (Ctrl+C during the backoff).
- `TestReconnectToSession_AsksForAnInteractiveChannel`, and `TestSetWebsocketHeader*` in `client`.

Both halves of the integration test were proved by reverting the behavior: with every close treated as a session end it fails with `upgrades=1`, and with the size re-send removed it fails with `upgrades=2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0132tX6w2ET78zpfYowjWkKk
