### PR TITLE
fix: fail instead of reporting success when a command's output cannot be read

### DIFF
--- a/api/event/chunks.go
+++ b/api/event/chunks.go
@@ -1,6 +1,7 @@
 package event
 
 import (
+	"net/http"
 	"net/url"
 	"sort"
 	"strconv"
@@ -8,6 +9,7 @@ import (
 
 	"github.com/alpacax/alpacon-cli/api"
 	"github.com/alpacax/alpacon-cli/client"
+	"github.com/alpacax/alpacon-cli/utils"
 )
 
 // noSeqBound is the toSeq sentinel that leaves getCommandChunks unbounded (seq
@@ -68,10 +70,12 @@ func ResolveCommandOutput(ac *client.AlpaconClient, cmdID, result string) (strin
 // pickCommandOutput decides between the two. A chunk fetch failure is fatal only
 // when result carries nothing: a server predating the chunk endpoint answers the
 // legacy field alone, while an empty result leaves nothing to print, and
-// reporting success there describes a command that produced no output.
+// reporting success there describes a command that produced no output. A 404 is
+// that older server saying it has no chunk store at all, so its empty result is
+// the whole output rather than a result nobody could read.
 func pickCommandOutput(result, chunked string, chunkErr error) (string, error) {
 	if chunkErr != nil {
-		if result != "" {
+		if result != "" || utils.HTTPStatusCode(chunkErr) == http.StatusNotFound {
 			return result, nil
 		}
 		return "", chunkErr

--- a/api/event/chunks.go
+++ b/api/event/chunks.go
@@ -57,3 +57,27 @@ func GetCommandOutput(ac *client.AlpaconClient, cmdID string) (string, error) {
 	}
 	return b.String(), nil
 }
+
+// ResolveCommandOutput reconstructs a finished command's output from its chunks,
+// falling back to the result field the command detail carries.
+func ResolveCommandOutput(ac *client.AlpaconClient, cmdID, result string) (string, error) {
+	chunked, err := GetCommandOutput(ac, cmdID)
+	return pickCommandOutput(result, chunked, err)
+}
+
+// pickCommandOutput decides between the two. A chunk fetch failure is fatal only
+// when result carries nothing: a server predating the chunk endpoint answers the
+// legacy field alone, while an empty result leaves nothing to print, and
+// reporting success there describes a command that produced no output.
+func pickCommandOutput(result, chunked string, chunkErr error) (string, error) {
+	if chunkErr != nil {
+		if result != "" {
+			return result, nil
+		}
+		return "", chunkErr
+	}
+	if chunked != "" {
+		return chunked, nil
+	}
+	return result, nil
+}

--- a/api/event/chunks_test.go
+++ b/api/event/chunks_test.go
@@ -15,6 +15,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// statusErr carries an HTTP status the way the API client's own errors do,
+// which is what utils.HTTPStatusCode reads out of the chain.
+type statusErr struct{ code int }
+
+func (e *statusErr) Error() string       { return fmt.Sprintf("HTTP %d", e.code) }
+func (e *statusErr) HTTPStatusCode() int { return e.code }
+
 func TestGetCommandChunks_PassesSeqGteAndReturnsResults(t *testing.T) {
 	t.Parallel()
 	cmdID := "a1b2c3d4-1234-5678-abcd-000000000000"
@@ -161,6 +168,9 @@ func TestPickCommandOutput(t *testing.T) {
 		{name: "a command that printed nothing stays empty", want: ""},
 		{name: "fetch failure falls back to a legacy result", result: "legacy", err: fetchErr, want: "legacy"},
 		{name: "fetch failure with nothing to fall back on", err: fetchErr, wantErr: fetchErr},
+		// A server without the endpoint carries the whole output in result, so an
+		// empty one there is a command that printed nothing, not an unread result.
+		{name: "a 404 leaves an empty legacy result standing", err: &statusErr{code: http.StatusNotFound}, want: ""},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -185,18 +195,22 @@ func TestResolveCommandOutputSurfacesFetchFailure(t *testing.T) {
 	const cmdID = "a1b2c3d4-1234-5678-abcd-000000000000"
 	tests := []struct {
 		name    string
+		status  int
 		result  string
 		want    string
 		wantErr bool
 	}{
-		{name: "nothing to fall back on is an error", wantErr: true},
-		{name: "a legacy result stands in for the chunks", result: "legacy", want: "legacy"},
+		{name: "nothing to fall back on is an error", status: http.StatusInternalServerError, wantErr: true},
+		{name: "a legacy result stands in for the chunks", status: http.StatusInternalServerError, result: "legacy", want: "legacy"},
+		// The 404 tag has to survive the wrapping FetchAllPages puts around it,
+		// which is the half a pure table cannot see.
+		{name: "a server without the chunk endpoint is not a failure", status: http.StatusNotFound},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-				w.WriteHeader(http.StatusInternalServerError)
+				w.WriteHeader(tt.status)
 			}))
 			defer ts.Close()
 

--- a/api/event/chunks_test.go
+++ b/api/event/chunks_test.go
@@ -2,6 +2,7 @@ package event
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -140,6 +141,75 @@ func TestGetCommandChunks_SendsSeqLteWhenBounded(t *testing.T) {
 			for _, want := range tt.wantQ {
 				assert.Contains(t, capturedQuery, want)
 			}
+		})
+	}
+}
+
+func TestPickCommandOutput(t *testing.T) {
+	t.Parallel()
+	fetchErr := errors.New("unexpected response from server (HTTP 500)")
+	tests := []struct {
+		name    string
+		result  string
+		chunked string
+		err     error
+		want    string
+		wantErr error
+	}{
+		{name: "chunks win over the legacy field", result: "legacy", chunked: "chunked", want: "chunked"},
+		{name: "no chunks falls back to the legacy field", result: "legacy", want: "legacy"},
+		{name: "a command that printed nothing stays empty", want: ""},
+		{name: "fetch failure falls back to a legacy result", result: "legacy", err: fetchErr, want: "legacy"},
+		{name: "fetch failure with nothing to fall back on", err: fetchErr, wantErr: fetchErr},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := pickCommandOutput(tt.result, tt.chunked, tt.err)
+			if tt.wantErr != nil {
+				require.ErrorIs(t, err, tt.wantErr)
+				assert.Empty(t, got)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// TestResolveCommandOutputSurfacesFetchFailure pins the wiring pickCommandOutput
+// cannot: that the fetch error reaches the decision, and that result and the
+// chunks are not passed the wrong way round.
+func TestResolveCommandOutputSurfacesFetchFailure(t *testing.T) {
+	t.Parallel()
+	const cmdID = "a1b2c3d4-1234-5678-abcd-000000000000"
+	tests := []struct {
+		name    string
+		result  string
+		want    string
+		wantErr bool
+	}{
+		{name: "nothing to fall back on is an error", wantErr: true},
+		{name: "a legacy result stands in for the chunks", result: "legacy", want: "legacy"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusInternalServerError)
+			}))
+			defer ts.Close()
+
+			ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
+
+			got, err := ResolveCommandOutput(ac, cmdID, tt.result)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Empty(t, got)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }

--- a/api/event/event.go
+++ b/api/event/event.go
@@ -621,9 +621,9 @@ func drainRemainingChunks(ac *client.AlpaconClient, cmdID string, lastSeq int, o
 // errorFromDetails maps a terminal command status to an error so unrecognized
 // statuses are not masked as success.
 func errorFromDetails(d EventDetails) error {
-	// A switch case cannot call a predicate, so every status matched by one is
-	// handled ahead of the switch—a server-side rename then lands in types.go
-	// alone.
+	// A switch case cannot call a predicate, so every status this function answers
+	// specially is handled ahead of the switch—a server-side rename then lands in
+	// types.go alone.
 	if IsAwaitingPurposeStatus(d.Status) {
 		return &AwaitingPurposeError{CommandID: d.ID, ExpiresAt: d.PurposeExpiresAt}
 	}

--- a/api/event/event.go
+++ b/api/event/event.go
@@ -621,8 +621,9 @@ func drainRemainingChunks(ac *client.AlpaconClient, cmdID string, lastSeq int, o
 // errorFromDetails maps a terminal command status to an error so unrecognized
 // statuses are not masked as success.
 func errorFromDetails(d EventDetails) error {
-	// A switch case cannot call a predicate, so the two approval statuses are
-	// matched ahead of it—a server-side rename then lands in types.go alone.
+	// A switch case cannot call a predicate, so every status matched by one is
+	// handled ahead of the switch—a server-side rename then lands in types.go
+	// alone.
 	if IsAwaitingPurposeStatus(d.Status) {
 		return &AwaitingPurposeError{CommandID: d.ID, ExpiresAt: d.PurposeExpiresAt}
 	}
@@ -631,6 +632,16 @@ func errorFromDetails(d EventDetails) error {
 	}
 	if IsRejectedStatus(d.Status) {
 		return &CommandRejectedError{CommandID: d.ID}
+	}
+	if IsStatusOnlyFailure(d.Status) {
+		phase := ""
+		if d.ErrorPhase != nil {
+			phase = *d.ErrorPhase
+		}
+		if phase == "" {
+			return fmt.Errorf("command failed with status: %s", d.Status)
+		}
+		return fmt.Errorf("command failed: [%s] %s (status=%s)", phase, DescribePhase(phase), d.Status)
 	}
 	switch d.Status {
 	case "completed", "success", "failed":
@@ -646,15 +657,6 @@ func errorFromDetails(d EventDetails) error {
 			return &RemoteCommandError{Output: d.Result, ExitCode: exitCode, ErrorPhase: phase, CommandID: d.ID}
 		}
 		return nil
-	case "stuck", "error", "cancelled":
-		phase := ""
-		if d.ErrorPhase != nil {
-			phase = *d.ErrorPhase
-		}
-		if phase == "" {
-			return fmt.Errorf("command failed with status: %s", d.Status)
-		}
-		return fmt.Errorf("command failed: [%s] %s (status=%s)", phase, DescribePhase(phase), d.Status)
 	default:
 		return fmt.Errorf("unexpected command status: %s (command may still be running)", d.Status)
 	}

--- a/api/event/event.go
+++ b/api/event/event.go
@@ -680,15 +680,18 @@ func runCommandFallbackFromID(ac *client.AlpaconClient, cmdID string, out io.Wri
 	if err != nil {
 		return err
 	}
-	// Command has finished: reconstruct output from chunks best-effort, falling
-	// back to Result when chunks are empty or unavailable. No warning on failure—
-	// the polling-fallback warning above already covers it.
-	output := details.Result
-	if reconstructed, oerr := GetCommandOutput(ac, cmdID); oerr == nil && reconstructed != "" {
-		output = reconstructed
-	}
+	output, oerr := ResolveCommandOutput(ac, cmdID, details.Result)
 	if output != "" {
 		_, _ = fmt.Fprint(out, output)
 	}
-	return errorFromDetails(details)
+	// The command's own failure carries the remote exit code the caller
+	// propagates, so it outranks an unreadable output. The warning above names a
+	// lost stream, not a lost output, so it cannot stand in for this error.
+	if err := errorFromDetails(details); err != nil {
+		return err
+	}
+	if oerr != nil {
+		return fmt.Errorf("failed to read command output: %w", oerr)
+	}
+	return nil
 }

--- a/api/event/event_test.go
+++ b/api/event/event_test.go
@@ -2272,3 +2272,73 @@ func TestGetCommandByID_MissingSudoFieldsStayNil(t *testing.T) {
 	assert.Nil(t, details.SudoGrantStatus)
 	assert.Nil(t, details.SudoApprovalRequestID)
 }
+
+// TestRunCommandFallbackFromID_ChunkFetchFailure pins what the polling fallback
+// owes the caller when the chunk store is the thing that failed. The warning
+// this path prints first says the stream was lost; a successful command that
+// then prints nothing and returns nil says the command produced no output.
+func TestRunCommandFallbackFromID_ChunkFetchFailure(t *testing.T) {
+	t.Parallel()
+	const cmdID = "a1b2c3d4-1234-5678-abcd-000000000000"
+	tests := []struct {
+		name       string
+		result     string
+		success    bool
+		wantOut    string
+		wantErrMsg string
+		wantRemote bool
+	}{
+		{
+			name:       "a successful command with nothing to print",
+			success:    true,
+			wantErrMsg: "failed to read command output",
+		},
+		{
+			name:    "a legacy result stands in for the chunks",
+			result:  "legacy output\n",
+			success: true,
+			wantOut: "legacy output\n",
+		},
+		{
+			name:       "the command's own failure outranks the read failure",
+			wantRemote: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch {
+				case strings.Contains(r.URL.Path, "/chunks/"):
+					w.WriteHeader(http.StatusInternalServerError)
+				case r.URL.Path == "/api/events/commands/"+cmdID+"/":
+					w.Header().Set("Content-Type", "application/json")
+					_ = json.NewEncoder(w).Encode(map[string]any{
+						"id": cmdID, "status": "completed", "success": tt.success,
+						"exit_code": 0, "result": tt.result,
+					})
+				default:
+					http.NotFound(w, r)
+				}
+			}))
+			defer ts.Close()
+
+			ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
+
+			var out bytes.Buffer
+			err := runCommandFallbackFromID(ac, cmdID, &out, false, fmt.Errorf("websocket dial failed"))
+
+			assert.Equal(t, tt.wantOut, out.String())
+			switch {
+			case tt.wantRemote:
+				var remoteErr *RemoteCommandError
+				require.ErrorAs(t, err, &remoteErr)
+			case tt.wantErrMsg != "":
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErrMsg)
+			default:
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/api/event/types.go
+++ b/api/event/types.go
@@ -227,3 +227,12 @@ func IsAwaitingPurposeStatus(status string) bool {
 func IsRejectedStatus(status string) bool {
 	return status == "rejected"
 }
+
+// IsStatusOnlyFailure reports the terminal failures whose whole outcome is a
+// line about the status: the command never reached a result worth printing. It
+// lives here so the polling path and the detach path read the triple from one
+// place—both decide alike on an unreadable output, and a fourth terminal status
+// must not reach one of them and miss the other.
+func IsStatusOnlyFailure(status string) bool {
+	return status == "stuck" || status == "error" || status == "cancelled"
+}

--- a/cmd/exec/logs.go
+++ b/cmd/exec/logs.go
@@ -74,9 +74,9 @@ Run the command again later to check for completion.`,
 			return
 		}
 
-		// Only the statuses whose outcome prints the output are worth a fetch. A
-		// running command and a status-only failure both answer with a line of
-		// their own, which an unreachable chunk store would only bury.
+		// Only the statuses whose outcome prints the output are worth a fetch: the
+		// rest answer with a line of their own and an empty stdoutLine, so the
+		// round trip buys nothing and a chunk store that hangs costs the wait.
 		var readErr error
 		if !event.IsRunningStatus(details.Status) && !isStatusOnlyFailure(details.Status) {
 			output, oerr := event.ResolveCommandOutput(alpaconClient, jobID, details.Result)

--- a/cmd/exec/logs.go
+++ b/cmd/exec/logs.go
@@ -78,7 +78,7 @@ Run the command again later to check for completion.`,
 		// rest answer with a line of their own and an empty stdoutLine, so the
 		// round trip buys nothing and a chunk store that hangs costs the wait.
 		var readErr error
-		if !event.IsRunningStatus(details.Status) && !isStatusOnlyFailure(details.Status) {
+		if !event.IsRunningStatus(details.Status) && !event.IsStatusOnlyFailure(details.Status) {
 			output, oerr := event.ResolveCommandOutput(alpaconClient, jobID, details.Result)
 			if oerr != nil {
 				readErr = oerr
@@ -120,12 +120,6 @@ func init() {
 	ExecCmd.AddCommand(logsCmd)
 }
 
-// isStatusOnlyFailure reports the statuses whose outcome is a line about the
-// status alone: the command never reached a result worth printing.
-func isStatusOnlyFailure(status string) bool {
-	return status == "stuck" || status == "error" || status == "cancelled"
-}
-
 // logsCommandOutcome guarantees a non-empty stderrLine ends with \n. Neither the
 // awaiting_purpose demand, the awaiting_approval hold, nor a rejection reaches
 // here: the caller answers all three on their own contracts first.
@@ -142,7 +136,7 @@ func logsCommandOutcome(details event.EventDetails) (stdoutLine, stderrLine stri
 		return "", stderrLine, 0
 	}
 
-	if isStatusOnlyFailure(details.Status) {
+	if event.IsStatusOnlyFailure(details.Status) {
 		if details.ErrorPhase != nil && *details.ErrorPhase != "" {
 			phase, desc := sanitizedPhaseParts(*details.ErrorPhase)
 			stderrLine = fmt.Sprintf("%s: [%s] %s (status=%s)\n",

--- a/cmd/exec/logs.go
+++ b/cmd/exec/logs.go
@@ -74,9 +74,12 @@ Run the command again later to check for completion.`,
 			return
 		}
 
-		// Only the statuses whose outcome prints the output are worth a fetch: the
-		// rest answer with a line of their own and an empty stdoutLine, so the
-		// round trip buys nothing and a chunk store that hangs costs the wait.
+		// Only the statuses whose outcome prints the output are worth a fetch, for
+		// two different reasons. A status-only failure answers with a line of its
+		// own and an empty stdoutLine, so the round trip buys nothing and a chunk
+		// store that hangs costs the wait. A running status needs the skip to stay
+		// correct: its outcome exits 0, so a read error would take the
+		// exitCode == 0 gate below and bury the "still running" line.
 		var readErr error
 		if !event.IsRunningStatus(details.Status) && !event.IsStatusOnlyFailure(details.Status) {
 			output, oerr := event.ResolveCommandOutput(alpaconClient, jobID, details.Result)

--- a/cmd/exec/logs.go
+++ b/cmd/exec/logs.go
@@ -74,18 +74,15 @@ Run the command again later to check for completion.`,
 			return
 		}
 
-		// Output is stored as chunks (Result is empty under the streaming
-		// contract); reconstruct it, falling back to Result for legacy commands.
 		// A running command's output is not printed here, so skip the fetch and
 		// keep an unreachable chunk store from burying the "still running" line.
 		if !event.IsRunningStatus(details.Status) {
-			output, oerr := event.GetCommandOutput(alpaconClient, jobID)
-			result, rerr := resolveCommandOutput(details.Result, output, oerr)
-			if rerr != nil {
-				utils.CliErrorWithExit("failed to fetch command output: %s", rerr)
+			output, oerr := event.ResolveCommandOutput(alpaconClient, jobID, details.Result)
+			if oerr != nil {
+				utils.CliErrorWithExit("failed to read command output: %s", oerr)
 				return
 			}
-			details.Result = result
+			details.Result = output
 		}
 
 		// What the requester said the command was for, ahead of the outcome and
@@ -112,24 +109,6 @@ Run the command again later to check for completion.`,
 
 func init() {
 	ExecCmd.AddCommand(logsCmd)
-}
-
-// resolveCommandOutput picks what `exec logs` prints as the command's output.
-// A chunk fetch failure is fatal only when Result carries nothing: a server
-// predating the chunk endpoint still answers the legacy field, while an empty
-// Result leaves nothing to print, and exiting 0 there would report a command
-// that finished having produced no output.
-func resolveCommandOutput(result, chunked string, chunkErr error) (string, error) {
-	if chunkErr != nil {
-		if result != "" {
-			return result, nil
-		}
-		return "", chunkErr
-	}
-	if chunked != "" {
-		return chunked, nil
-	}
-	return result, nil
 }
 
 // logsCommandOutcome guarantees a non-empty stderrLine ends with \n. Neither the

--- a/cmd/exec/logs.go
+++ b/cmd/exec/logs.go
@@ -74,15 +74,17 @@ Run the command again later to check for completion.`,
 			return
 		}
 
-		// A running command's output is not printed here, so skip the fetch and
-		// keep an unreachable chunk store from burying the "still running" line.
-		if !event.IsRunningStatus(details.Status) {
+		// Only the statuses whose outcome prints the output are worth a fetch. A
+		// running command and a status-only failure both answer with a line of
+		// their own, which an unreachable chunk store would only bury.
+		var readErr error
+		if !event.IsRunningStatus(details.Status) && !isStatusOnlyFailure(details.Status) {
 			output, oerr := event.ResolveCommandOutput(alpaconClient, jobID, details.Result)
 			if oerr != nil {
-				utils.CliErrorWithExit("failed to read command output: %s", oerr)
-				return
+				readErr = oerr
+			} else {
+				details.Result = output
 			}
-			details.Result = output
 		}
 
 		// What the requester said the command was for, ahead of the outcome and
@@ -95,6 +97,13 @@ Run the command again later to check for completion.`,
 		}
 
 		stdoutLine, stderrLine, exitCode := logsCommandOutcome(details)
+		// The command's own failure carries the remote exit code this command
+		// propagates, so it outranks an unreadable output—the order
+		// runCommandFallbackFromID keeps on the polling path.
+		if exitCode == 0 && readErr != nil {
+			utils.CliErrorWithExit("failed to read command output: %s", readErr)
+			return
+		}
 		if stdoutLine != "" {
 			fmt.Println(stdoutLine)
 		}
@@ -109,6 +118,12 @@ Run the command again later to check for completion.`,
 
 func init() {
 	ExecCmd.AddCommand(logsCmd)
+}
+
+// isStatusOnlyFailure reports the statuses whose outcome is a line about the
+// status alone: the command never reached a result worth printing.
+func isStatusOnlyFailure(status string) bool {
+	return status == "stuck" || status == "error" || status == "cancelled"
 }
 
 // logsCommandOutcome guarantees a non-empty stderrLine ends with \n. Neither the
@@ -127,7 +142,7 @@ func logsCommandOutcome(details event.EventDetails) (stdoutLine, stderrLine stri
 		return "", stderrLine, 0
 	}
 
-	if details.Status == "stuck" || details.Status == "error" || details.Status == "cancelled" {
+	if isStatusOnlyFailure(details.Status) {
 		if details.ErrorPhase != nil && *details.ErrorPhase != "" {
 			phase, desc := sanitizedPhaseParts(*details.ErrorPhase)
 			stderrLine = fmt.Sprintf("%s: [%s] %s (status=%s)\n",

--- a/cmd/exec/logs.go
+++ b/cmd/exec/logs.go
@@ -76,8 +76,16 @@ Run the command again later to check for completion.`,
 
 		// Output is stored as chunks (Result is empty under the streaming
 		// contract); reconstruct it, falling back to Result for legacy commands.
-		if output, oerr := event.GetCommandOutput(alpaconClient, jobID); oerr == nil && output != "" {
-			details.Result = output
+		// A running command's output is not printed here, so skip the fetch and
+		// keep an unreachable chunk store from burying the "still running" line.
+		if !event.IsRunningStatus(details.Status) {
+			output, oerr := event.GetCommandOutput(alpaconClient, jobID)
+			result, rerr := resolveCommandOutput(details.Result, output, oerr)
+			if rerr != nil {
+				utils.CliErrorWithExit("failed to fetch command output: %s", rerr)
+				return
+			}
+			details.Result = result
 		}
 
 		// What the requester said the command was for, ahead of the outcome and
@@ -104,6 +112,24 @@ Run the command again later to check for completion.`,
 
 func init() {
 	ExecCmd.AddCommand(logsCmd)
+}
+
+// resolveCommandOutput picks what `exec logs` prints as the command's output.
+// A chunk fetch failure is fatal only when Result carries nothing: a server
+// predating the chunk endpoint still answers the legacy field, while an empty
+// Result leaves nothing to print, and exiting 0 there would report a command
+// that finished having produced no output.
+func resolveCommandOutput(result, chunked string, chunkErr error) (string, error) {
+	if chunkErr != nil {
+		if result != "" {
+			return result, nil
+		}
+		return "", chunkErr
+	}
+	if chunked != "" {
+		return chunked, nil
+	}
+	return result, nil
 }
 
 // logsCommandOutcome guarantees a non-empty stderrLine ends with \n. Neither the

--- a/cmd/exec/logs_test.go
+++ b/cmd/exec/logs_test.go
@@ -2,7 +2,6 @@ package exec
 
 import (
 	"encoding/json"
-	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -11,7 +10,6 @@ import (
 	"github.com/alpacax/alpacon-cli/api/event"
 	"github.com/alpacax/alpacon-cli/utils"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func boolPtr(b bool) *bool    { return &b }
@@ -254,38 +252,6 @@ func TestExecLogsChunkFetchFailureExitsNonZero(t *testing.T) {
 
 	stdout, stderr, exitCode := runExecLogsHelper(t, ts.URL, utils.OutputFormatTable, jobID)
 	assert.Equal(t, 1, exitCode, "unreadable output is a failure, not a command that printed nothing")
-	assert.Contains(t, stderr, "failed to fetch command output")
+	assert.Contains(t, stderr, "failed to read command output")
 	assert.Empty(t, stdout)
-}
-
-func TestResolveCommandOutput(t *testing.T) {
-	t.Parallel()
-	fetchErr := errors.New("unexpected response from server (HTTP 500)")
-	tests := []struct {
-		name    string
-		result  string
-		chunked string
-		err     error
-		want    string
-		wantErr error
-	}{
-		{name: "chunks win over the legacy field", result: "legacy", chunked: "chunked", want: "chunked"},
-		{name: "no chunks falls back to the legacy field", result: "legacy", want: "legacy"},
-		{name: "a command that printed nothing stays empty", want: ""},
-		{name: "fetch failure falls back to a legacy result", result: "legacy", err: fetchErr, want: "legacy"},
-		{name: "fetch failure with nothing to fall back on", err: fetchErr, wantErr: fetchErr},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-			got, err := resolveCommandOutput(tt.result, tt.chunked, tt.err)
-			if tt.wantErr != nil {
-				require.ErrorIs(t, err, tt.wantErr)
-				assert.Empty(t, got)
-				return
-			}
-			require.NoError(t, err)
-			assert.Equal(t, tt.want, got)
-		})
-	}
 }

--- a/cmd/exec/logs_test.go
+++ b/cmd/exec/logs_test.go
@@ -253,5 +253,7 @@ func TestExecLogsChunkFetchFailureExitsNonZero(t *testing.T) {
 	stdout, stderr, exitCode := runExecLogsHelper(t, ts.URL, utils.OutputFormatTable, jobID)
 	assert.Equal(t, 1, exitCode, "unreadable output is a failure, not a command that printed nothing")
 	assert.Contains(t, stderr, "failed to read command output")
+	// A bad verb would leave the marker in place of the reason the read failed.
+	assert.NotContains(t, stderr, "%!", "the fetch error must render, not print a bad-verb marker")
 	assert.Empty(t, stdout)
 }

--- a/cmd/exec/logs_test.go
+++ b/cmd/exec/logs_test.go
@@ -30,6 +30,20 @@ func TestIsRunningStatus(t *testing.T) {
 	}
 }
 
+func TestIsStatusOnlyFailure(t *testing.T) {
+	t.Parallel()
+	statusOnly := []string{"stuck", "error", "cancelled"}
+	for _, s := range statusOnly {
+		assert.True(t, event.IsStatusOnlyFailure(s), "expected %q to carry no printable result", s)
+	}
+	// "failed" belongs to the other group: it carries the remote exit code and a
+	// result, so its output is fetched and printed.
+	withResult := []string{"completed", "success", "failed", "running", "queued", "awaiting_approval", "rejected"}
+	for _, s := range withResult {
+		assert.False(t, event.IsStatusOnlyFailure(s), "expected %q to not be a status-only failure", s)
+	}
+}
+
 func TestLogsCommandOutcome(t *testing.T) {
 	t.Parallel()
 	tests := []struct {

--- a/cmd/exec/logs_test.go
+++ b/cmd/exec/logs_test.go
@@ -2,9 +2,11 @@ package exec
 
 import (
 	"encoding/json"
+	"maps"
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/alpacax/alpacon-cli/api/event"
@@ -256,4 +258,69 @@ func TestExecLogsChunkFetchFailureExitsNonZero(t *testing.T) {
 	// A bad verb would leave the marker in place of the reason the read failed.
 	assert.NotContains(t, stderr, "%!", "the fetch error must render, not print a bad-verb marker")
 	assert.Empty(t, stdout)
+}
+
+// TestExecLogsChunkFetchFailureYieldsToTheCommandsOwnFailure pins the order
+// runCommandFallbackFromID keeps on the polling path: the command's own failure
+// carries the exit code a script branches on, so an unreadable output must not
+// take its place. A status-only failure prints no output at all, so it is never
+// fetched for.
+func TestExecLogsChunkFetchFailureYieldsToTheCommandsOwnFailure(t *testing.T) {
+	t.Parallel()
+	const jobID = "a1b2c3d4-5678-abcd-ef01-234567890abc"
+	tests := []struct {
+		name          string
+		detail        map[string]any
+		wantExitCode  int
+		wantStderr    string
+		wantChunkRead bool
+	}{
+		{
+			name:          "a remote failure keeps its own exit code",
+			detail:        map[string]any{"status": "completed", "success": false, "exit_code": 2, "result": ""},
+			wantExitCode:  2,
+			wantChunkRead: true,
+		},
+		{
+			name:         "a stuck command keeps its status line",
+			detail:       map[string]any{"status": "stuck", "result": ""},
+			wantExitCode: 1,
+			wantStderr:   "command failed with status: stuck",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			var chunkReads atomic.Int32
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch r.URL.Path {
+				case "/api/events/commands/" + jobID + "/chunks/":
+					chunkReads.Add(1)
+					w.WriteHeader(http.StatusInternalServerError)
+				case "/api/events/commands/" + jobID + "/":
+					w.Header().Set("Content-Type", "application/json")
+					detail := map[string]any{"id": jobID}
+					maps.Copy(detail, tt.detail)
+					_ = json.NewEncoder(w).Encode(detail)
+				default:
+					http.NotFound(w, r)
+				}
+			}))
+			defer ts.Close()
+
+			stdout, stderr, exitCode := runExecLogsHelper(t, ts.URL, utils.OutputFormatTable, jobID)
+			assert.Equal(t, tt.wantExitCode, exitCode)
+			assert.NotContains(t, stderr, "failed to read command output")
+			if tt.wantStderr != "" {
+				assert.Contains(t, stderr, tt.wantStderr)
+			}
+			if tt.wantChunkRead {
+				assert.Positive(t, chunkReads.Load(), "the outcome prints the output, so it is read")
+			} else {
+				assert.Zero(t, chunkReads.Load(), "the outcome prints no output, so nothing is fetched")
+			}
+			assert.Empty(t, stdout)
+		})
+	}
 }

--- a/cmd/exec/logs_test.go
+++ b/cmd/exec/logs_test.go
@@ -1,12 +1,17 @@
 package exec
 
 import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 
 	"github.com/alpacax/alpacon-cli/api/event"
 	"github.com/alpacax/alpacon-cli/utils"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func boolPtr(b bool) *bool    { return &b }
@@ -221,6 +226,66 @@ func TestLogsCommandOutcomeSanitizesServerText(t *testing.T) {
 			_, stderrLine, _ := logsCommandOutcome(tt.details)
 
 			assert.Equal(t, tt.wantStderr, stderrLine)
+		})
+	}
+}
+
+// TestExecLogsChunkFetchFailureExitsNonZero pins the failure a discarded chunk
+// error hides. Output lives in chunks under the streaming contract, so a 500
+// there leaves Result empty and nothing to print, and exit 0 tells the caller
+// the command finished having produced no output.
+func TestExecLogsChunkFetchFailureExitsNonZero(t *testing.T) {
+	t.Parallel()
+	const jobID = "a1b2c3d4-5678-abcd-ef01-234567890abc"
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/events/commands/" + jobID + "/chunks/":
+			w.WriteHeader(http.StatusInternalServerError)
+		case "/api/events/commands/" + jobID + "/":
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"id": jobID, "status": "completed", "success": true, "exit_code": 0, "result": "",
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer ts.Close()
+
+	stdout, stderr, exitCode := runExecLogsHelper(t, ts.URL, utils.OutputFormatTable, jobID)
+	assert.Equal(t, 1, exitCode, "unreadable output is a failure, not a command that printed nothing")
+	assert.Contains(t, stderr, "failed to fetch command output")
+	assert.Empty(t, stdout)
+}
+
+func TestResolveCommandOutput(t *testing.T) {
+	t.Parallel()
+	fetchErr := errors.New("unexpected response from server (HTTP 500)")
+	tests := []struct {
+		name    string
+		result  string
+		chunked string
+		err     error
+		want    string
+		wantErr error
+	}{
+		{name: "chunks win over the legacy field", result: "legacy", chunked: "chunked", want: "chunked"},
+		{name: "no chunks falls back to the legacy field", result: "legacy", want: "legacy"},
+		{name: "a command that printed nothing stays empty", want: ""},
+		{name: "fetch failure falls back to a legacy result", result: "legacy", err: fetchErr, want: "legacy"},
+		{name: "fetch failure with nothing to fall back on", err: fetchErr, wantErr: fetchErr},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := resolveCommandOutput(tt.result, tt.chunked, tt.err)
+			if tt.wantErr != nil {
+				require.ErrorIs(t, err, tt.wantErr)
+				assert.Empty(t, got)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }


### PR DESCRIPTION
## Background

Under the streaming contract a command's output is stored as chunks and the `result` field on the command detail stays empty, so every non-streaming path rebuilds the output through `api/event`'s `GetCommandOutput` and keeps `result` only as the fallback for a command that predates the chunk endpoint.

Two paths did that, and both discarded the fetch error.

`cmd/exec/logs.go`, behind `alpacon exec logs JOB_ID`:

```go
if output, oerr := event.GetCommandOutput(alpaconClient, jobID); oerr == nil && output != "" {
	details.Result = output
}
```

`api/event/event.go`'s `runCommandFallbackFromID`, the path `exec` and `websh` take when the output stream cannot be set up and the CLI falls back to polling:

```go
output := details.Result
if reconstructed, oerr := GetCommandOutput(ac, cmdID); oerr == nil && reconstructed != "" {
	output = reconstructed
}
```

On either path a 500 or a network failure on `/api/events/commands/<id>/chunks/` took the `oerr == nil` guard out and left the output at the empty string it already held. The command then printed nothing and reported success—exit `0` from `exec logs`, a nil error from the fallback. Under the streaming contract that is indistinguishable from a command that ran fine and produced no output, so a script or an AI agent branching on the exit code read an unreadable result as a clean one, which is the case the exit codes exist to keep apart.

The fallback path was the more misleading of the two, because it looks covered. It warns first, and its comment said the warning was enough:

```
real-time output unavailable (%v); falling back to polling
```

That names a lost stream. It says nothing about a lost output, and it is printed before the fetch that failed.

## Changes

### One copy of the decision, in `api/event`

`api/event/chunks.go` gains the two functions that replace both copies:

- `ResolveCommandOutput(ac, cmdID, result)` pairs the fetch with the fallback. Both call sites now call this and nothing else.
- `pickCommandOutput(result, chunked, chunkErr)` is the fallback with the fetch lifted out, so a case table can read it without a server.

`cmd/exec` already imports `api/event`, so this is the only direction the shared version could go.

A chunk fetch failure is reported exactly when `result` carries nothing to fall back on:

| chunk fetch | `result` | printed as the output | what the caller ends on |
|---|---|---|---|
| ok, non-empty | anything | the chunks | the command's own outcome |
| ok, empty | non-empty | `result`, the legacy field | the command's own outcome |
| ok, empty | empty | nothing | the command's own outcome |
| failed with 404 | anything | `result`, the legacy field | the command's own outcome |
| failed otherwise | non-empty | `result`, the legacy field | the command's own outcome |
| failed otherwise | empty | nothing | the read failure, unless the command failed on its own |

A server predating the chunk endpoint answers only the legacy field, which is why a failed fetch with a non-empty `result` still prints and still ends on the command's own outcome. There is nothing a caller could do with an error about a store that server does not have.

The 404 row is that same server saying it has no chunk store at all, and there an empty `result` is the whole output rather than an output nobody could read—a command that printed nothing must not become `failed to read command output` on those deployments. `utils.HTTPStatusCode` reads the status the client tags onto the error, and `api.FetchAllPages` wraps with `%w`, so the tag reaches the decision.

The last row is the only one where the read failure has anything to say, and even there it yields to a command that failed on its own—that failure carries the remote exit code, and both paths keep it. Both sections below spell that out.

### `alpacon exec logs`

A command that otherwise succeeded now reports `failed to read command output: ...` and exits `1`. The message names the fetch and not the command, because the command itself may well have succeeded and it is the CLI that could not read what it wrote. It goes through `utils.CliErrorWithExit`, which sanitizes the server's text (#364). Exit `1` needs no new README row: the table there already covers a server error under the general failure code.

The read failure is held until the outcome is known and surfaces only where the outcome would otherwise be exit `0`, so a command that failed on its own keeps the exit code it carries—the same order the polling fallback keeps, below. Without that, an unreachable chunk store turned a command that exited `7` into a generic CLI failure, which is the exit code a script branches on.

The fetch itself is skipped on the statuses whose outcome prints no output, and the two halves of that condition are skipped for different reasons.

`stuck`/`error`/`cancelled` are answered with a status line and exit `1`, and `logsCommandOutcome` returns an empty `stdoutLine` there, so the round trip buys nothing and a chunk store that hangs rather than errors costs the wait. An earlier revision of this description credited that half with keeping an unreachable chunk store from burying the status line. It does not, and neither does the comment that used to say so in `logs.go` (`0e2c8d2`). The ordering above does it alone: dropping `!event.IsStatusOnlyFailure` leaves both the status line and the exit code standing, and only the request counter in `TestExecLogsChunkFetchFailureYieldsToTheCommandsOwnFailure` goes red. What that half saves is the round trip.

A running command is the other half, and there the skip is what produces the answer rather than what saves a request. `logsCommandOutcome` returns exit `0` for a running status, so a read error takes the `exitCode == 0` gate instead of yielding to the outcome. Dropping `!event.IsRunningStatus` alone, against the same chunk store answering 500, replaces the "still running" line with a read failure:

```
exit=1 chunkReads=1 stdout=""
stderr="Error: failed to read command output: fetching page 1 from
/api/events/commands/a1b2c3d4-5678-abcd-ef01-234567890abc/chunks/:
server returned an empty error response"
```

`go test ./cmd/exec/` stays green with that half dropped, for the reason the last section of this description gives, so the comment above the guard is what carries it (`3e2466f`).

### The polling fallback

`runCommandFallbackFromID` returns `failed to read command output: %w` wrapping the fetch error, which reaches the caller as the command's failure.

The command's own failure keeps precedence over an unreadable output, because it is what carries the remote exit code `exec` propagates as its own; replacing it with a generic read error would change the exit code scripts branch on. Only a command that otherwise reported success now ends on the read failure. `exec logs` applies the same rule, so this is one decision written once and honored on both paths.

### One spelling of the status-only failures

`"stuck"`, `"error"` and `"cancelled"` were matched in two places: `errorFromDetails` carried them as a switch case on the polling path, and `cmd/exec` had a private `isStatusOnlyFailure` for the detach path. Since the point of the change above is that the two paths decide alike on an unreadable output, a fourth terminal status reaching one spelling and missing the other would split them again. `event.IsStatusOnlyFailure` in `api/event/types.go` now holds the triple, beside `IsRunningStatus` and `IsRejectedStatus`, and both callers read it (`e4dde03`).

A switch case cannot call a predicate, so `errorFromDetails` matches the three in an `if` ahead of its switch—the shape the awaiting and rejected statuses already had there. The messages it builds are unchanged.

`api/ftp/ftp.go:696` and `:751` are deliberately left alone. They test `"stuck" || "error"` without `"cancelled"`, so they are a different judgment, and folding them in would change what `alpacon cp` reports.

## Testing

The full suite, as CI runs it, plus the linters, re-run on the pushed head:

```
$ gofmt -l .
(no output)
$ go vet ./...
(no output)
$ golangci-lint run ./...
0 issues.
$ go test -race -shuffle=on ./...
exit=0    ok packages: 42    FAIL lines: 0
```

Every new test was seen RED. Mutating the shared decision back into swallowing the error (`if chunkErr != nil { return result, nil }`) reddens both packages at once, which is the check that the duplication is actually gone:

```
--- FAIL: TestPickCommandOutput/fetch_failure_with_nothing_to_fall_back_on
--- FAIL: TestResolveCommandOutputSurfacesFetchFailure/nothing_to_fall_back_on_is_an_error
--- FAIL: TestRunCommandFallbackFromID_ChunkFetchFailure/a_successful_command_with_nothing_to_print
--- FAIL: TestExecLogsChunkFetchFailureExitsNonZero
    Messages: helper exited 0; stderr:
```

Restoring `runCommandFallbackFromID`'s old body alone, with the shared decision left correct, reddens the fallback test with the lie itself:

```
--- FAIL: TestRunCommandFallbackFromID_ChunkFetchFailure/a_successful_command_with_nothing_to_print
    Error: An error is expected but got nil.
```

New coverage:

- `TestPickCommandOutput` (`api/event/chunks_test.go`), a case table over the `(fetch, result)` combinations in the table above, the 404 included.
- `TestResolveCommandOutputSurfacesFetchFailure` (`api/event/chunks_test.go`), three cases through an `httptest` server answering the chunks endpoint with a 500 or a 404. It pins the wiring the pure table cannot: that the fetch error reaches the decision, that `result` and the chunks are not passed the wrong way round, and that the 404 tag survives the wrapping `FetchAllPages` puts around it. Mutating the constant to `http.StatusGone` reddens the 404 case in both tests.
- `TestRunCommandFallbackFromID_ChunkFetchFailure` (`api/event/event_test.go`), three cases driving the real fallback against a server whose command detail is terminal and whose chunks endpoint is a 500: a successful command with nothing to print returns the read error, a legacy `result` stands in for the chunks, and a failed command still returns its own `RemoteCommandError`.
- `TestExecLogsChunkFetchFailureExitsNonZero` (`cmd/exec/logs_test.go`), which drives the real `exec logs` through the package's helper process against the same shape of server. It asserts exit `1`, the message on stderr, an empty stdout, and that the message carries no bad-verb marker—the reason the read failed is the only thing the caller has to go on, and a mis-rendered verb would replace it with `%!d(...)` while the prefix assertion stayed green.
- `TestExecLogsChunkFetchFailureYieldsToTheCommandsOwnFailure` (`cmd/exec/logs_test.go`), two cases against the same shape of server: a remote failure carrying `exit_code: 2` still exits `2` and prints no read error, and a `stuck` command still prints `command failed with status: stuck` while a counter in the handler pins that the chunks endpoint was never called. Reverting the ordering reddens both, the second on all three counts:

```
--- FAIL: .../a_remote_failure_keeps_its_own_exit_code
    Error: Not equal: expected: 2, actual: 1
--- FAIL: .../a_stuck_command_keeps_its_status_line
    Error: "...failed to read command output..." does not contain "command failed with status: stuck"
    Error: Should be zero, but was 1
    Messages: the outcome prints no output, so nothing is fetched
```

- `TestIsStatusOnlyFailure` (`cmd/exec/logs_test.go`), beside the existing `TestIsRunningStatus`, over the extracted predicate: the three statuses it holds, and the ones that must stay out of it—`"failed"` above all, since that one carries the remote exit code and a result, so its output is fetched and printed. Mutating the predicate to `return false` reddens both packages, which is what says the extraction preserved behavior:

```
--- FAIL: TestRunCommandStreaming_TerminalStatusErrors
--- FAIL: TestIsStatusOnlyFailure
--- FAIL: TestLogsCommandOutcome
--- FAIL: TestLogsCommandOutcomeSanitizesServerText
--- FAIL: TestExecLogsChunkFetchFailureYieldsToTheCommandsOwnFailure
```

Dropping only `"cancelled"` from the triple reddens the new test alone.

One thing is deliberately not covered: that a running command reaches its own "still running" line and exit `0` without touching the chunks endpoint. The package's helper-process harness (`runHelperProcess`, `cmd/exec/pending_approval_test.go:107`) requires a non-zero exit and a running command exits `0`, so an exit-`0` path cannot ride it, and widening that contract would touch every helper-process test in the package. `TestIsRunningStatus` and `TestLogsCommandOutcome` cover the predicate and the outcome on both sides, but neither reaches the guard that calls it, which is why dropping the running half leaves the package green and why the comment above the guard states what that half holds.



