### PR TITLE
fix(utils): confine zip extraction to its destination

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -22,8 +22,9 @@ jobs:
 
     # Windows is not a portability formality: the files that replace a running
     # executable are compiled out everywhere else and would ship untested without
-    # this runner. It runs only the packages that carry them—the rest of the
-    # suite asserts Unix file modes in tests that predate this job.
+    # this runner, and unzip_path.go's volume-name and case-insensitive branches
+    # are unreachable on Unix. It runs only the packages that carry them—the rest
+    # of the suite asserts Unix file modes in tests that predate this job.
     strategy:
       fail-fast: false
       matrix:
@@ -31,7 +32,7 @@ jobs:
           - os: ubuntu-latest
             packages: ./...
           - os: windows-latest
-            packages: ./pkg/selfupdate/... ./cmd
+            packages: ./pkg/selfupdate/... ./cmd ./utils
 
     defaults:
       run:

--- a/utils/unzip_path.go
+++ b/utils/unzip_path.go
@@ -14,6 +14,7 @@ const maxZipSymlinkHops = 255
 func resolveZipPath(root *os.Root, rootNames []string, name string) (string, error) {
 	pending := strings.Split(name, string(os.PathSeparator))
 	var resolved []string
+	missing := false
 	links := 0
 	for len(pending) > 0 {
 		part := pending[0]
@@ -25,12 +26,18 @@ func resolveZipPath(root *os.Root, rootNames []string, name string) (string, err
 			if len(resolved) == 0 {
 				return "", fmt.Errorf("zip path escapes destination: %s", name)
 			}
+			// Everything after the first absent component is absent too, so the
+			// kernel would stop here rather than let '..' select a sibling.
+			if missing {
+				return "", fmt.Errorf("zip path traverses a missing directory: %s", name)
+			}
 			resolved = resolved[:len(resolved)-1]
 			continue
 		}
 		candidate := filepath.Join(filepath.Join(resolved...), part)
 		info, err := root.Lstat(candidate)
 		if os.IsNotExist(err) {
+			missing = true
 			resolved = append(resolved, part)
 			continue
 		}
@@ -59,6 +66,7 @@ func resolveZipPath(root *os.Root, rootNames []string, name string) (string, err
 				return "", err
 			}
 			resolved = nil
+			missing = false
 		} else if filepath.VolumeName(target) != "" || strings.HasPrefix(target, string(os.PathSeparator)) {
 			return "", fmt.Errorf("zip symlink escapes destination: %s", candidate)
 		}

--- a/utils/unzip_path.go
+++ b/utils/unzip_path.go
@@ -1,0 +1,89 @@
+package utils
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+func resolveZipPath(root *os.Root, rootNames []string, name string) (string, error) {
+	pending := strings.Split(name, string(os.PathSeparator))
+	var resolved []string
+	links := 0
+	for len(pending) > 0 {
+		part := pending[0]
+		pending = pending[1:]
+		switch part {
+		case "", ".":
+			continue
+		case "..":
+			if len(resolved) == 0 {
+				return "", fmt.Errorf("zip path escapes destination: %s", name)
+			}
+			resolved = resolved[:len(resolved)-1]
+			continue
+		}
+		candidate := filepath.Join(filepath.Join(resolved...), part)
+		info, err := root.Lstat(candidate)
+		if os.IsNotExist(err) {
+			resolved = append(resolved, part)
+			continue
+		}
+		if err != nil {
+			return "", err
+		}
+		if info.Mode()&os.ModeSymlink == 0 {
+			if len(pending) > 0 && !info.IsDir() {
+				return "", fmt.Errorf("zip path component is not a directory: %s", candidate)
+			}
+			resolved = append(resolved, part)
+			continue
+		}
+		links++
+		if links > 255 {
+			return "", fmt.Errorf("too many symlinks in zip path: %s", name)
+		}
+		target, err := root.Readlink(candidate)
+		if err != nil {
+			return "", err
+		}
+		target = filepath.FromSlash(target)
+		if filepath.IsAbs(target) {
+			target, err = zipRelativeTarget(rootNames, target)
+			if err != nil {
+				return "", err
+			}
+			resolved = nil
+		} else if filepath.VolumeName(target) != "" || strings.HasPrefix(target, string(os.PathSeparator)) {
+			return "", fmt.Errorf("zip symlink escapes destination: %s", candidate)
+		}
+		// Expand links before consuming '..'; cleaning first can select a different file.
+		pending = append(strings.Split(target, string(os.PathSeparator)), pending...)
+	}
+	if len(resolved) == 0 {
+		return ".", nil
+	}
+	return filepath.Join(resolved...), nil
+}
+
+func zipRelativeTarget(rootNames []string, target string) (string, error) {
+	for _, name := range rootNames {
+		prefix := strings.TrimRight(name, string(os.PathSeparator)) + string(os.PathSeparator)
+		if zipPathEqual(target, name) {
+			return ".", nil
+		}
+		if len(target) >= len(prefix) && zipPathEqual(target[:len(prefix)], prefix) {
+			return target[len(prefix):], nil
+		}
+	}
+	return "", fmt.Errorf("zip symlink escapes destination: %s", target)
+}
+
+func zipPathEqual(a, b string) bool {
+	if runtime.GOOS == "windows" {
+		return strings.EqualFold(a, b)
+	}
+	return a == b
+}

--- a/utils/unzip_path.go
+++ b/utils/unzip_path.go
@@ -34,7 +34,9 @@ func resolveZipPath(root *os.Root, rootNames []string, name string) (string, err
 			resolved = resolved[:len(resolved)-1]
 			continue
 		}
-		candidate := filepath.Join(filepath.Join(resolved...), part)
+		// resolved holds clean single components and part carries no separator,
+		// so joining the strings is what filepath.Join would return anyway.
+		candidate := strings.Join(append(resolved, part), string(os.PathSeparator))
 		info, err := root.Lstat(candidate)
 		if os.IsNotExist(err) {
 			missing = true

--- a/utils/unzip_path.go
+++ b/utils/unzip_path.go
@@ -8,6 +8,9 @@ import (
 	"strings"
 )
 
+// Same cap filepath.walkSymlinks applies, so a zip path gives up where a plain one does.
+const maxZipSymlinkHops = 255
+
 func resolveZipPath(root *os.Root, rootNames []string, name string) (string, error) {
 	pending := strings.Split(name, string(os.PathSeparator))
 	var resolved []string
@@ -42,7 +45,7 @@ func resolveZipPath(root *os.Root, rootNames []string, name string) (string, err
 			continue
 		}
 		links++
-		if links > 255 {
+		if links > maxZipSymlinkHops {
 			return "", fmt.Errorf("too many symlinks in zip path: %s", name)
 		}
 		target, err := root.Readlink(candidate)

--- a/utils/unzip_path.go
+++ b/utils/unzip_path.go
@@ -11,7 +11,25 @@ import (
 // Same cap filepath.walkSymlinks applies, so a zip path gives up where a plain one does.
 const maxZipSymlinkHops = 255
 
-func resolveZipPath(root *os.Root, rootNames []string, name string) (string, error) {
+// zipRoot is one spelling of the destination, paired with the prefix an absolute
+// symlink target must carry to be inside it. Both are fixed for a whole Unzip call.
+type zipRoot struct {
+	name   string
+	prefix string
+}
+
+func newZipRoots(names ...string) []zipRoot {
+	roots := make([]zipRoot, 0, len(names))
+	for _, name := range names {
+		roots = append(roots, zipRoot{
+			name:   name,
+			prefix: strings.TrimRight(name, string(os.PathSeparator)) + string(os.PathSeparator),
+		})
+	}
+	return roots
+}
+
+func resolveZipPath(root *os.Root, roots []zipRoot, name string) (string, error) {
 	pending := strings.Split(name, string(os.PathSeparator))
 	var resolved []string
 	missing := false
@@ -63,7 +81,7 @@ func resolveZipPath(root *os.Root, rootNames []string, name string) (string, err
 		}
 		target = filepath.FromSlash(target)
 		if filepath.IsAbs(target) {
-			target, err = zipRelativeTarget(rootNames, target)
+			target, err = zipRelativeTarget(roots, target)
 			if err != nil {
 				return "", err
 			}
@@ -81,14 +99,13 @@ func resolveZipPath(root *os.Root, rootNames []string, name string) (string, err
 	return filepath.Join(resolved...), nil
 }
 
-func zipRelativeTarget(rootNames []string, target string) (string, error) {
-	for _, name := range rootNames {
-		prefix := strings.TrimRight(name, string(os.PathSeparator)) + string(os.PathSeparator)
-		if zipPathEqual(target, name) {
+func zipRelativeTarget(roots []zipRoot, target string) (string, error) {
+	for _, r := range roots {
+		if zipPathEqual(target, r.name) {
 			return ".", nil
 		}
-		if len(target) >= len(prefix) && zipPathEqual(target[:len(prefix)], prefix) {
-			return target[len(prefix):], nil
+		if len(target) >= len(r.prefix) && zipPathEqual(target[:len(r.prefix)], r.prefix) {
+			return target[len(r.prefix):], nil
 		}
 	}
 	return "", fmt.Errorf("zip symlink escapes destination: %s", target)

--- a/utils/unzip_path.go
+++ b/utils/unzip_path.go
@@ -29,6 +29,16 @@ func newZipRoots(names ...string) []zipRoot {
 	return roots
 }
 
+// resolveZipPath maps an archive entry name to a path relative to root, with every
+// symlink expanded, and rejects anything that leaves the destination. Confinement
+// does not rest on it: os.Root is the boundary, so a bug here can misplace a file
+// inside the destination but never outside it.
+//
+// os.Root refuses an absolute symlink even when its target is inside the root, so
+// permitting one is what these hops cost; failing closed instead would be about
+// five lines. We resolve and follow the link because the destination is a folder
+// the user chose and may already have populated, and because an archive naming
+// "link" asks for what "link" points at.
 func resolveZipPath(root *os.Root, roots []zipRoot, name string) (string, error) {
 	pending := strings.Split(name, string(os.PathSeparator))
 	var resolved []string

--- a/utils/unzip_perm_unix_test.go
+++ b/utils/unzip_perm_unix_test.go
@@ -1,0 +1,47 @@
+//go:build unix
+
+package utils
+
+import (
+	"archive/zip"
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Serial: syscall.Umask is process-wide, and 0755 is indistinguishable from
+// 0777 under the usual 022 umask.
+func TestUnzip_DirectoriesUseFixedPerm(t *testing.T) {
+	old := syscall.Umask(0)
+	t.Cleanup(func() { syscall.Umask(old) })
+
+	tmpDir := t.TempDir()
+	extractDir := filepath.Join(tmpDir, "extract")
+	zipPath := writeUnzipArchive(t, tmpDir, func(zw *zip.Writer) {
+		header := &zip.FileHeader{Name: "dir/", Method: zip.Deflate}
+		header.SetMode(os.ModeDir | 0o777)
+		_, err := zw.CreateHeader(header)
+		require.NoError(t, err)
+
+		fw, err := zw.Create("nested/file.txt")
+		require.NoError(t, err)
+		_, err = fw.Write([]byte("content"))
+		require.NoError(t, err)
+	})
+
+	require.NoError(t, Unzip(zipPath, extractDir))
+
+	for _, dir := range []string{
+		extractDir,
+		filepath.Join(extractDir, "dir"),
+		filepath.Join(extractDir, "nested"),
+	} {
+		info, err := os.Stat(dir)
+		require.NoError(t, err)
+		assert.Equal(t, os.FileMode(0o755), info.Mode().Perm(), dir)
+	}
+}

--- a/utils/unzip_symlink_test.go
+++ b/utils/unzip_symlink_test.go
@@ -1,0 +1,110 @@
+package utils
+
+import (
+	"archive/zip"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUnzip_ConfinesSymlinks(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		target string
+		entry  string
+	}{
+		{"file", "../outside/file", "link"},
+		{"directory", "../outside", "link/file"},
+		{"new directory", "../outside", "link/new/"},
+		{"new file", "../outside", "link/new/file"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			dir := t.TempDir()
+			dest := filepath.Join(dir, "dest")
+			outside := filepath.Join(dir, "outside")
+			require.NoError(t, os.Mkdir(dest, 0755))
+			require.NoError(t, os.Mkdir(outside, 0755))
+			require.NoError(t, os.WriteFile(filepath.Join(outside, "file"), []byte("original"), 0600))
+			makeUnzipSymlink(t, filepath.FromSlash(tt.target), filepath.Join(dest, "link"))
+			archive := writeUnzipTestArchive(t, dir, tt.entry)
+
+			require.Error(t, Unzip(archive, dest))
+			content, err := os.ReadFile(filepath.Join(outside, "file"))
+			require.NoError(t, err)
+			assert.Equal(t, "original", string(content))
+			entries, err := os.ReadDir(outside)
+			require.NoError(t, err)
+			assert.Len(t, entries, 1)
+		})
+	}
+}
+
+func TestUnzip_AllowsInternalSymlink(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	dest := filepath.Join(dir, "dest")
+	require.NoError(t, os.MkdirAll(filepath.Join(dest, "real"), 0755))
+	makeUnzipSymlink(t, "real", filepath.Join(dest, "link"))
+	require.NoError(t, Unzip(writeUnzipTestArchive(t, dir, "link/file"), dest))
+	content, err := os.ReadFile(filepath.Join(dest, "real", "file"))
+	require.NoError(t, err)
+	assert.Equal(t, "replacement", string(content))
+}
+
+func TestUnzip_MaterializesArchiveSymlinkAsFile(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	archive := filepath.Join(dir, "test.zip")
+	f, err := os.Create(archive)
+	require.NoError(t, err)
+	zw := zip.NewWriter(f)
+	header := &zip.FileHeader{Name: "link"}
+	header.SetMode(os.ModeSymlink | 0777)
+	w, err := zw.CreateHeader(header)
+	require.NoError(t, err)
+	_, err = w.Write([]byte("../outside"))
+	require.NoError(t, err)
+	require.NoError(t, zw.Close())
+	require.NoError(t, f.Close())
+	dest := filepath.Join(dir, "dest")
+	require.NoError(t, Unzip(archive, dest))
+	info, err := os.Lstat(filepath.Join(dest, "link"))
+	require.NoError(t, err)
+	assert.True(t, info.Mode().IsRegular(), "extracted mode: %v", info.Mode())
+	content, err := os.ReadFile(filepath.Join(dest, "link"))
+	require.NoError(t, err)
+	assert.Equal(t, "../outside", string(content))
+}
+
+func makeUnzipSymlink(t *testing.T, target, link string) {
+	t.Helper()
+	err := os.Symlink(target, link)
+	if err != nil && runtime.GOOS == "windows" {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+	require.NoError(t, err)
+}
+
+func writeUnzipTestArchive(t *testing.T, dir, entry string) string {
+	t.Helper()
+	archive := filepath.Join(dir, "test.zip")
+	f, err := os.Create(archive)
+	require.NoError(t, err)
+	zw := zip.NewWriter(f)
+	w, err := zw.Create(entry)
+	require.NoError(t, err)
+	if entry[len(entry)-1] != '/' {
+		_, err = w.Write([]byte("replacement"))
+		require.NoError(t, err)
+	}
+	require.NoError(t, zw.Close())
+	require.NoError(t, f.Close())
+	return archive
+}

--- a/utils/unzip_symlink_test.go
+++ b/utils/unzip_symlink_test.go
@@ -84,7 +84,7 @@ func TestUnzip_ResolvesLinkBeforeParentComponent(t *testing.T) {
 	makeUnzipSymlink(t, filepath.Join("real", "subdir"), filepath.Join(dest, "alias"))
 	target := dest + string(os.PathSeparator) + "alias" + string(os.PathSeparator) + ".." + string(os.PathSeparator) + "file"
 	makeUnzipSymlink(t, target, filepath.Join(dest, "link"))
-	requireParentInLink(t, filepath.Join(dest, "link"))
+	skipUnlessParentInLink(t, filepath.Join(dest, "link"))
 	require.NoError(t, Unzip(writeUnzipTestArchive(t, dir, "link"), dest))
 	data, err := os.ReadFile(filepath.Join(dest, "real", "file"))
 	require.NoError(t, err)
@@ -196,7 +196,7 @@ func TestUnzip_RejectsParentAfterNonDirectory(t *testing.T) {
 			}
 			sep := string(os.PathSeparator)
 			makeUnzipSymlink(t, dest+sep+tc.middle+sep+".."+sep+"victim", filepath.Join(dest, "link"))
-			requireParentInLink(t, filepath.Join(dest, "link"))
+			skipUnlessParentInLink(t, filepath.Join(dest, "link"))
 			require.Error(t, Unzip(writeUnzipTestArchive(t, dir, "link"), dest))
 			data, err := os.ReadFile(filepath.Join(dest, "victim"))
 			require.NoError(t, err)
@@ -214,10 +214,10 @@ func makeUnzipSymlink(t *testing.T, target, link string) {
 	require.NoError(t, err)
 }
 
-// requireParentInLink skips a case whose subject is a ".." left for resolveZipPath
+// skipUnlessParentInLink skips a case whose subject is a ".." left for resolveZipPath
 // to consume. Windows normalizes an absolute target when the link is created, so
 // the ".." is already gone by the time Readlink sees it and the case cannot be built.
-func requireParentInLink(t *testing.T, link string) {
+func skipUnlessParentInLink(t *testing.T, link string) {
 	t.Helper()
 	target, err := os.Readlink(link)
 	require.NoError(t, err)

--- a/utils/unzip_symlink_test.go
+++ b/utils/unzip_symlink_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -239,7 +240,7 @@ func writeUnzipTestArchive(t *testing.T, dir, entry string) string {
 	return writeUnzipArchive(t, dir, func(zw *zip.Writer) {
 		w, err := zw.Create(entry)
 		require.NoError(t, err)
-		if entry[len(entry)-1] != '/' {
+		if !strings.HasSuffix(entry, "/") {
 			_, err = w.Write([]byte("replacement"))
 			require.NoError(t, err)
 		}

--- a/utils/unzip_symlink_test.go
+++ b/utils/unzip_symlink_test.go
@@ -108,3 +108,142 @@ func writeUnzipTestArchive(t *testing.T, dir, entry string) string {
 	require.NoError(t, f.Close())
 	return archive
 }
+
+func TestUnzip_AllowsAbsoluteInternalSymlinks(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name, target, entry, want string
+		directory                 bool
+	}{
+		{"directory", "real", "link/new/file", "real/new/file", false},
+		{"directory entry", "real", "link/new/", "real/new", true},
+		{"existing file", "real/file", "link", "real/file", false},
+		{"dangling file", "real/missing", "link", "real/missing", false},
+		{"dangling directory", "missing", "link/new/file", "missing/new/file", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			dir := t.TempDir()
+			dest := filepath.Join(dir, "dest")
+			require.NoError(t, os.MkdirAll(filepath.Join(dest, "real"), 0755))
+			require.NoError(t, os.WriteFile(filepath.Join(dest, "real", "file"), []byte("original"), 0600))
+			target := filepath.Join(dest, filepath.FromSlash(tc.target))
+			makeUnzipSymlink(t, target, filepath.Join(dest, "link"))
+			require.NoError(t, Unzip(writeUnzipTestArchive(t, dir, tc.entry), dest))
+			path := filepath.Join(dest, filepath.FromSlash(tc.want))
+			if tc.directory {
+				info, err := os.Stat(path)
+				require.NoError(t, err)
+				assert.True(t, info.IsDir(), "mode: %v", info.Mode())
+			} else {
+				data, err := os.ReadFile(path)
+				require.NoError(t, err)
+				assert.Equal(t, "replacement", string(data))
+			}
+			got, err := os.Readlink(filepath.Join(dest, "link"))
+			require.NoError(t, err)
+			assert.Equal(t, target, got)
+		})
+	}
+}
+
+func TestUnzip_ResolvesLinkBeforeParentComponent(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	dest := filepath.Join(dir, "dest")
+	require.NoError(t, os.MkdirAll(filepath.Join(dest, "real", "subdir"), 0755))
+	makeUnzipSymlink(t, filepath.Join("real", "subdir"), filepath.Join(dest, "alias"))
+	target := dest + string(os.PathSeparator) + "alias" + string(os.PathSeparator) + ".." + string(os.PathSeparator) + "file"
+	makeUnzipSymlink(t, target, filepath.Join(dest, "link"))
+	require.NoError(t, Unzip(writeUnzipTestArchive(t, dir, "link"), dest))
+	data, err := os.ReadFile(filepath.Join(dest, "real", "file"))
+	require.NoError(t, err)
+	assert.Equal(t, "replacement", string(data))
+	_, err = os.Stat(filepath.Join(dest, "file"))
+	assert.ErrorIs(t, err, os.ErrNotExist)
+}
+
+func TestUnzip_AbsoluteLinksWithDestinationAlias(t *testing.T) {
+	t.Parallel()
+	for _, canonical := range []bool{false, true} {
+		name := "original spelling"
+		if canonical {
+			name = "canonical spelling"
+		}
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			dir := t.TempDir()
+			real := filepath.Join(dir, "real")
+			dest := filepath.Join(dir, "dest")
+			require.NoError(t, os.MkdirAll(filepath.Join(real, "files"), 0755))
+			makeUnzipSymlink(t, real, dest)
+			target := filepath.Join(dest, "files")
+			if canonical {
+				var err error
+				target, err = filepath.EvalSymlinks(target)
+				require.NoError(t, err)
+			}
+			makeUnzipSymlink(t, target, filepath.Join(real, "link"))
+			require.NoError(t, Unzip(writeUnzipTestArchive(t, dir, "link/file"), dest))
+			data, err := os.ReadFile(filepath.Join(real, "files", "file"))
+			require.NoError(t, err)
+			assert.Equal(t, "replacement", string(data))
+		})
+	}
+}
+
+func TestUnzip_RejectsAbsoluteEscapesAndCycles(t *testing.T) {
+	t.Parallel()
+	for _, name := range []string{"external file", "external directory", "sibling prefix", "nested escape", "cycle", "parent escape"} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			dir := t.TempDir()
+			dest := filepath.Join(dir, "dest")
+			outside := filepath.Join(dir, "dest-other")
+			require.NoError(t, os.Mkdir(dest, 0755))
+			require.NoError(t, os.Mkdir(outside, 0755))
+			require.NoError(t, os.WriteFile(filepath.Join(outside, "file"), []byte("original"), 0600))
+			entry := "link/file"
+			target := outside
+			switch name {
+			case "external file":
+				target = filepath.Join(outside, "file")
+				entry = "link"
+			case "external directory":
+				target = dir
+				entry = "link/dest-other/file"
+			case "nested escape":
+				makeUnzipSymlink(t, outside, filepath.Join(dest, "second"))
+				target = filepath.Join(dest, "second")
+			case "cycle":
+				target = filepath.Join(dest, "link")
+			case "parent escape":
+				target = dest + string(os.PathSeparator) + ".." + string(os.PathSeparator) + "dest-other"
+			}
+			makeUnzipSymlink(t, target, filepath.Join(dest, "link"))
+			require.Error(t, Unzip(writeUnzipTestArchive(t, dir, entry), dest))
+			data, err := os.ReadFile(filepath.Join(outside, "file"))
+			require.NoError(t, err)
+			assert.Equal(t, "original", string(data))
+			entries, err := os.ReadDir(outside)
+			require.NoError(t, err)
+			assert.Len(t, entries, 1)
+		})
+	}
+}
+
+func TestUnzip_RejectsParentAfterRegularFile(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	dest := filepath.Join(dir, "dest")
+	require.NoError(t, os.Mkdir(dest, 0755))
+	for _, name := range []string{"plain", "victim"} {
+		require.NoError(t, os.WriteFile(filepath.Join(dest, name), []byte("original"), 0600))
+	}
+	target := dest + string(os.PathSeparator) + "plain" + string(os.PathSeparator) + ".." + string(os.PathSeparator) + "victim"
+	makeUnzipSymlink(t, target, filepath.Join(dest, "link"))
+	require.Error(t, Unzip(writeUnzipTestArchive(t, dir, "link"), dest))
+	data, err := os.ReadFile(filepath.Join(dest, "victim"))
+	require.NoError(t, err)
+	assert.Equal(t, "original", string(data))
+}

--- a/utils/unzip_symlink_test.go
+++ b/utils/unzip_symlink_test.go
@@ -12,41 +12,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestUnzip_ConfinesSymlinks(t *testing.T) {
-	t.Parallel()
-	tests := []struct {
-		name   string
-		target string
-		entry  string
-	}{
-		{"file", "../outside/file", "link"},
-		{"directory", "../outside", "link/file"},
-		{"new directory", "../outside", "link/new/"},
-		{"new file", "../outside", "link/new/file"},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-			dir := t.TempDir()
-			dest := filepath.Join(dir, "dest")
-			outside := filepath.Join(dir, "outside")
-			require.NoError(t, os.Mkdir(dest, 0755))
-			require.NoError(t, os.Mkdir(outside, 0755))
-			require.NoError(t, os.WriteFile(filepath.Join(outside, "file"), []byte("original"), 0600))
-			makeUnzipSymlink(t, filepath.FromSlash(tt.target), filepath.Join(dest, "link"))
-			archive := writeUnzipTestArchive(t, dir, tt.entry)
-
-			require.Error(t, Unzip(archive, dest))
-			content, err := os.ReadFile(filepath.Join(outside, "file"))
-			require.NoError(t, err)
-			assert.Equal(t, "original", string(content))
-			entries, err := os.ReadDir(outside)
-			require.NoError(t, err)
-			assert.Len(t, entries, 1)
-		})
-	}
-}
-
 func TestUnzip_AllowsInternalSymlink(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
@@ -158,7 +123,7 @@ func TestUnzip_AbsoluteLinksWithDestinationAlias(t *testing.T) {
 	}
 }
 
-func TestUnzip_RejectsAbsoluteEscapesAndCycles(t *testing.T) {
+func TestUnzip_ConfinesSymlinks(t *testing.T) {
 	t.Parallel()
 	for _, tc := range []struct {
 		name   string
@@ -167,6 +132,18 @@ func TestUnzip_RejectsAbsoluteEscapesAndCycles(t *testing.T) {
 		// A second symlink inside dest that the case's own target points at.
 		hop bool
 	}{
+		{"relative file", "link", func(dir, dest, outside string) string {
+			return filepath.Join("..", "dest-other", "file")
+		}, false},
+		{"relative directory", "link/file", func(dir, dest, outside string) string {
+			return filepath.Join("..", "dest-other")
+		}, false},
+		{"relative new directory", "link/new/", func(dir, dest, outside string) string {
+			return filepath.Join("..", "dest-other")
+		}, false},
+		{"relative new file", "link/new/file", func(dir, dest, outside string) string {
+			return filepath.Join("..", "dest-other")
+		}, false},
 		{"external file", "link", func(dir, dest, outside string) string { return filepath.Join(outside, "file") }, false},
 		{"external directory", "link/dest-other/file", func(dir, dest, outside string) string { return dir }, false},
 		{"sibling prefix", "link/file", func(dir, dest, outside string) string { return outside }, false},

--- a/utils/unzip_symlink_test.go
+++ b/utils/unzip_symlink_test.go
@@ -61,18 +61,7 @@ func TestUnzip_AllowsInternalSymlink(t *testing.T) {
 func TestUnzip_MaterializesArchiveSymlinkAsFile(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
-	archive := filepath.Join(dir, "test.zip")
-	f, err := os.Create(archive)
-	require.NoError(t, err)
-	zw := zip.NewWriter(f)
-	header := &zip.FileHeader{Name: "link"}
-	header.SetMode(os.ModeSymlink | 0777)
-	w, err := zw.CreateHeader(header)
-	require.NoError(t, err)
-	_, err = w.Write([]byte("../outside"))
-	require.NoError(t, err)
-	require.NoError(t, zw.Close())
-	require.NoError(t, f.Close())
+	archive := writeUnzipSymlinkArchive(t, dir, "link", "../outside")
 	dest := filepath.Join(dir, "dest")
 	require.NoError(t, Unzip(archive, dest))
 	info, err := os.Lstat(filepath.Join(dest, "link"))
@@ -81,32 +70,6 @@ func TestUnzip_MaterializesArchiveSymlinkAsFile(t *testing.T) {
 	content, err := os.ReadFile(filepath.Join(dest, "link"))
 	require.NoError(t, err)
 	assert.Equal(t, "../outside", string(content))
-}
-
-func makeUnzipSymlink(t *testing.T, target, link string) {
-	t.Helper()
-	err := os.Symlink(target, link)
-	if err != nil && runtime.GOOS == "windows" {
-		t.Skipf("symlinks unavailable: %v", err)
-	}
-	require.NoError(t, err)
-}
-
-func writeUnzipTestArchive(t *testing.T, dir, entry string) string {
-	t.Helper()
-	archive := filepath.Join(dir, "test.zip")
-	f, err := os.Create(archive)
-	require.NoError(t, err)
-	zw := zip.NewWriter(f)
-	w, err := zw.Create(entry)
-	require.NoError(t, err)
-	if entry[len(entry)-1] != '/' {
-		_, err = w.Write([]byte("replacement"))
-		require.NoError(t, err)
-	}
-	require.NoError(t, zw.Close())
-	require.NoError(t, f.Close())
-	return archive
 }
 
 func TestUnzip_AllowsAbsoluteInternalSymlinks(t *testing.T) {
@@ -165,12 +128,14 @@ func TestUnzip_ResolvesLinkBeforeParentComponent(t *testing.T) {
 
 func TestUnzip_AbsoluteLinksWithDestinationAlias(t *testing.T) {
 	t.Parallel()
-	for _, canonical := range []bool{false, true} {
-		name := "original spelling"
-		if canonical {
-			name = "canonical spelling"
-		}
-		t.Run(name, func(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		canonical bool
+	}{
+		{"original spelling", false},
+		{"canonical spelling", true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			dir := t.TempDir()
 			real := filepath.Join(dir, "real")
@@ -178,7 +143,7 @@ func TestUnzip_AbsoluteLinksWithDestinationAlias(t *testing.T) {
 			require.NoError(t, os.MkdirAll(filepath.Join(real, "files"), 0755))
 			makeUnzipSymlink(t, real, dest)
 			target := filepath.Join(dest, "files")
-			if canonical {
+			if tc.canonical {
 				var err error
 				target, err = filepath.EvalSymlinks(target)
 				require.NoError(t, err)
@@ -194,8 +159,23 @@ func TestUnzip_AbsoluteLinksWithDestinationAlias(t *testing.T) {
 
 func TestUnzip_RejectsAbsoluteEscapesAndCycles(t *testing.T) {
 	t.Parallel()
-	for _, name := range []string{"external file", "external directory", "sibling prefix", "nested escape", "cycle", "parent escape"} {
-		t.Run(name, func(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		entry  string
+		target func(dir, dest, outside string) string
+		// A second symlink inside dest that the case's own target points at.
+		hop bool
+	}{
+		{"external file", "link", func(dir, dest, outside string) string { return filepath.Join(outside, "file") }, false},
+		{"external directory", "link/dest-other/file", func(dir, dest, outside string) string { return dir }, false},
+		{"sibling prefix", "link/file", func(dir, dest, outside string) string { return outside }, false},
+		{"nested escape", "link/file", func(dir, dest, outside string) string { return filepath.Join(dest, "second") }, true},
+		{"cycle", "link/file", func(dir, dest, outside string) string { return filepath.Join(dest, "link") }, false},
+		{"parent escape", "link/file", func(dir, dest, outside string) string {
+			return dest + string(os.PathSeparator) + ".." + string(os.PathSeparator) + "dest-other"
+		}, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			dir := t.TempDir()
 			dest := filepath.Join(dir, "dest")
@@ -203,25 +183,11 @@ func TestUnzip_RejectsAbsoluteEscapesAndCycles(t *testing.T) {
 			require.NoError(t, os.Mkdir(dest, 0755))
 			require.NoError(t, os.Mkdir(outside, 0755))
 			require.NoError(t, os.WriteFile(filepath.Join(outside, "file"), []byte("original"), 0600))
-			entry := "link/file"
-			target := outside
-			switch name {
-			case "external file":
-				target = filepath.Join(outside, "file")
-				entry = "link"
-			case "external directory":
-				target = dir
-				entry = "link/dest-other/file"
-			case "nested escape":
+			if tc.hop {
 				makeUnzipSymlink(t, outside, filepath.Join(dest, "second"))
-				target = filepath.Join(dest, "second")
-			case "cycle":
-				target = filepath.Join(dest, "link")
-			case "parent escape":
-				target = dest + string(os.PathSeparator) + ".." + string(os.PathSeparator) + "dest-other"
 			}
-			makeUnzipSymlink(t, target, filepath.Join(dest, "link"))
-			require.Error(t, Unzip(writeUnzipTestArchive(t, dir, entry), dest))
+			makeUnzipSymlink(t, tc.target(dir, dest, outside), filepath.Join(dest, "link"))
+			require.Error(t, Unzip(writeUnzipTestArchive(t, dir, tc.entry), dest))
 			data, err := os.ReadFile(filepath.Join(outside, "file"))
 			require.NoError(t, err)
 			assert.Equal(t, "original", string(data))
@@ -246,4 +212,49 @@ func TestUnzip_RejectsParentAfterRegularFile(t *testing.T) {
 	data, err := os.ReadFile(filepath.Join(dest, "victim"))
 	require.NoError(t, err)
 	assert.Equal(t, "original", string(data))
+}
+
+func makeUnzipSymlink(t *testing.T, target, link string) {
+	t.Helper()
+	err := os.Symlink(target, link)
+	if err != nil && runtime.GOOS == "windows" {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+	require.NoError(t, err)
+}
+
+func writeUnzipTestArchive(t *testing.T, dir, entry string) string {
+	t.Helper()
+	return writeUnzipArchive(t, dir, func(zw *zip.Writer) {
+		w, err := zw.Create(entry)
+		require.NoError(t, err)
+		if entry[len(entry)-1] != '/' {
+			_, err = w.Write([]byte("replacement"))
+			require.NoError(t, err)
+		}
+	})
+}
+
+func writeUnzipSymlinkArchive(t *testing.T, dir, entry, target string) string {
+	t.Helper()
+	return writeUnzipArchive(t, dir, func(zw *zip.Writer) {
+		header := &zip.FileHeader{Name: entry}
+		header.SetMode(os.ModeSymlink | 0777)
+		w, err := zw.CreateHeader(header)
+		require.NoError(t, err)
+		_, err = w.Write([]byte(target))
+		require.NoError(t, err)
+	})
+}
+
+func writeUnzipArchive(t *testing.T, dir string, addEntry func(*zip.Writer)) string {
+	t.Helper()
+	archive := filepath.Join(dir, "test.zip")
+	f, err := os.Create(archive)
+	require.NoError(t, err)
+	zw := zip.NewWriter(f)
+	addEntry(zw)
+	require.NoError(t, zw.Close())
+	require.NoError(t, f.Close())
+	return archive
 }

--- a/utils/unzip_symlink_test.go
+++ b/utils/unzip_symlink_test.go
@@ -84,6 +84,7 @@ func TestUnzip_ResolvesLinkBeforeParentComponent(t *testing.T) {
 	makeUnzipSymlink(t, filepath.Join("real", "subdir"), filepath.Join(dest, "alias"))
 	target := dest + string(os.PathSeparator) + "alias" + string(os.PathSeparator) + ".." + string(os.PathSeparator) + "file"
 	makeUnzipSymlink(t, target, filepath.Join(dest, "link"))
+	requireParentInLink(t, filepath.Join(dest, "link"))
 	require.NoError(t, Unzip(writeUnzipTestArchive(t, dir, "link"), dest))
 	data, err := os.ReadFile(filepath.Join(dest, "real", "file"))
 	require.NoError(t, err)
@@ -195,6 +196,7 @@ func TestUnzip_RejectsParentAfterNonDirectory(t *testing.T) {
 			}
 			sep := string(os.PathSeparator)
 			makeUnzipSymlink(t, dest+sep+tc.middle+sep+".."+sep+"victim", filepath.Join(dest, "link"))
+			requireParentInLink(t, filepath.Join(dest, "link"))
 			require.Error(t, Unzip(writeUnzipTestArchive(t, dir, "link"), dest))
 			data, err := os.ReadFile(filepath.Join(dest, "victim"))
 			require.NoError(t, err)
@@ -210,6 +212,19 @@ func makeUnzipSymlink(t *testing.T, target, link string) {
 		t.Skipf("symlinks unavailable: %v", err)
 	}
 	require.NoError(t, err)
+}
+
+// requireParentInLink skips a case whose subject is a ".." left for resolveZipPath
+// to consume. Windows normalizes an absolute target when the link is created, so
+// the ".." is already gone by the time Readlink sees it and the case cannot be built.
+func requireParentInLink(t *testing.T, link string) {
+	t.Helper()
+	target, err := os.Readlink(link)
+	require.NoError(t, err)
+	sep := string(os.PathSeparator)
+	if !strings.Contains(target, sep+".."+sep) {
+		t.Skipf("platform resolved %q out of the link target: %q", "..", target)
+	}
 }
 
 func writeUnzipTestArchive(t *testing.T, dir, entry string) string {

--- a/utils/unzip_symlink_test.go
+++ b/utils/unzip_symlink_test.go
@@ -198,20 +198,31 @@ func TestUnzip_RejectsAbsoluteEscapesAndCycles(t *testing.T) {
 	}
 }
 
-func TestUnzip_RejectsParentAfterRegularFile(t *testing.T) {
+func TestUnzip_RejectsParentAfterNonDirectory(t *testing.T) {
 	t.Parallel()
-	dir := t.TempDir()
-	dest := filepath.Join(dir, "dest")
-	require.NoError(t, os.Mkdir(dest, 0755))
-	for _, name := range []string{"plain", "victim"} {
-		require.NoError(t, os.WriteFile(filepath.Join(dest, name), []byte("original"), 0600))
+	for _, tc := range []struct {
+		name   string
+		middle string
+	}{
+		{"regular file", "plain"},
+		{"missing component", "missing"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			dir := t.TempDir()
+			dest := filepath.Join(dir, "dest")
+			require.NoError(t, os.Mkdir(dest, 0755))
+			for _, name := range []string{"plain", "victim"} {
+				require.NoError(t, os.WriteFile(filepath.Join(dest, name), []byte("original"), 0600))
+			}
+			sep := string(os.PathSeparator)
+			makeUnzipSymlink(t, dest+sep+tc.middle+sep+".."+sep+"victim", filepath.Join(dest, "link"))
+			require.Error(t, Unzip(writeUnzipTestArchive(t, dir, "link"), dest))
+			data, err := os.ReadFile(filepath.Join(dest, "victim"))
+			require.NoError(t, err)
+			assert.Equal(t, "original", string(data))
+		})
 	}
-	target := dest + string(os.PathSeparator) + "plain" + string(os.PathSeparator) + ".." + string(os.PathSeparator) + "victim"
-	makeUnzipSymlink(t, target, filepath.Join(dest, "link"))
-	require.Error(t, Unzip(writeUnzipTestArchive(t, dir, "link"), dest))
-	data, err := os.ReadFile(filepath.Join(dest, "victim"))
-	require.NoError(t, err)
-	assert.Equal(t, "original", string(data))
 }
 
 func makeUnzipSymlink(t *testing.T, target, link string) {

--- a/utils/unzip_test.go
+++ b/utils/unzip_test.go
@@ -114,15 +114,13 @@ func TestUnzip_PathTraversalAttack(t *testing.T) {
 				t.Errorf("Unexpected error for valid path %q: %v", tt.filename, err)
 			}
 
-			// Verify malicious file was not created outside extract directory
-			if tt.wantErr {
-				// Check that no files were created outside extractDir
-				parentDir := filepath.Dir(extractDir)
-				entries, _ := os.ReadDir(parentDir)
-				for _, entry := range entries {
-					if entry.Name() != "extract" && entry.Name() != "test.zip" {
-						t.Errorf("File created outside extract directory: %s", entry.Name())
-					}
+			// A rejected entry and an accepted one both stay inside extractDir, so
+			// this holds for every case—including the one Windows relocates.
+			parentDir := filepath.Dir(extractDir)
+			entries, _ := os.ReadDir(parentDir)
+			for _, entry := range entries {
+				if entry.Name() != "extract" && entry.Name() != "test.zip" {
+					t.Errorf("File created outside extract directory: %s", entry.Name())
 				}
 			}
 		})

--- a/utils/unzip_test.go
+++ b/utils/unzip_test.go
@@ -4,6 +4,7 @@ import (
 	"archive/zip"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -65,7 +66,9 @@ func TestUnzip_PathTraversalAttack(t *testing.T) {
 		{
 			name:     "absolute path unix",
 			filename: "/etc/passwd",
-			wantErr:  true,
+			// Windows reads a leading slash as rooted but not absolute, so the entry
+			// is joined onto the destination rather than rejected. It stays confined.
+			wantErr: runtime.GOOS != "windows",
 		},
 		{
 			name:     "parent directory only",

--- a/utils/unzip_test.go
+++ b/utils/unzip_test.go
@@ -5,50 +5,28 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestUnzip_ValidFiles(t *testing.T) {
 	t.Parallel()
-	// Create a temporary zip file with valid content
 	tmpDir := t.TempDir()
-	zipPath := filepath.Join(tmpDir, "test.zip")
 	extractDir := filepath.Join(tmpDir, "extract")
-
-	// Create test zip file
-	zf, err := os.Create(zipPath)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer func() { _ = zf.Close() }()
-
-	zw := zip.NewWriter(zf)
-	defer func() { _ = zw.Close() }()
-
-	// Add a valid file
-	fw, err := zw.Create("test.txt")
-	if err != nil {
-		t.Fatal(err)
-	}
-	_, err = fw.Write([]byte("test content"))
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// Add a file in subdirectory
-	fw, err = zw.Create("subdir/nested.txt")
-	if err != nil {
-		t.Fatal(err)
-	}
-	_, err = fw.Write([]byte("nested content"))
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	_ = zw.Close()
-	_ = zf.Close()
+	zipPath := writeUnzipArchive(t, tmpDir, func(zw *zip.Writer) {
+		for _, entry := range []struct{ name, content string }{
+			{"test.txt", "test content"},
+			{"subdir/nested.txt", "nested content"},
+		} {
+			fw, err := zw.Create(entry.name)
+			require.NoError(t, err)
+			_, err = fw.Write([]byte(entry.content))
+			require.NoError(t, err)
+		}
+	})
 
 	// Test extraction
-	err = Unzip(zipPath, extractDir)
+	err := Unzip(zipPath, extractDir)
 	if err != nil {
 		t.Errorf("Unzip failed for valid archive: %v", err)
 	}
@@ -114,37 +92,18 @@ func TestUnzip_PathTraversalAttack(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			tmpDir := t.TempDir()
-			zipPath := filepath.Join(tmpDir, "test.zip")
 			extractDir := filepath.Join(tmpDir, "extract")
 
-			// Create malicious zip file
-			zf, err := os.Create(zipPath)
-			if err != nil {
-				t.Fatal(err)
-			}
-			defer func() { _ = zf.Close() }()
-
-			zw := zip.NewWriter(zf)
-
-			// Create file header manually to bypass path validation
-			header := &zip.FileHeader{
-				Name:   tt.filename,
-				Method: zip.Deflate,
-			}
-			fw, err := zw.CreateHeader(header)
-			if err != nil {
-				t.Fatal(err)
-			}
-			_, err = fw.Write([]byte("malicious content"))
-			if err != nil {
-				t.Fatal(err)
-			}
-
-			_ = zw.Close()
-			_ = zf.Close()
+			zipPath := writeUnzipArchive(t, tmpDir, func(zw *zip.Writer) {
+				// A hand-built header carries the path zw.Create would validate away.
+				fw, err := zw.CreateHeader(&zip.FileHeader{Name: tt.filename, Method: zip.Deflate})
+				require.NoError(t, err)
+				_, err = fw.Write([]byte("malicious content"))
+				require.NoError(t, err)
+			})
 
 			// Test extraction
-			err = Unzip(zipPath, extractDir)
+			err := Unzip(zipPath, extractDir)
 			if tt.wantErr && err == nil {
 				t.Errorf("Expected error for malicious path %q, but got none", tt.filename)
 			}
@@ -170,35 +129,18 @@ func TestUnzip_PathTraversalAttack(t *testing.T) {
 func TestUnzip_DirectoryTraversal(t *testing.T) {
 	t.Parallel()
 	tmpDir := t.TempDir()
-	zipPath := filepath.Join(tmpDir, "test.zip")
 	extractDir := filepath.Join(tmpDir, "extract")
 
-	// Create zip with directory traversal
-	zf, err := os.Create(zipPath)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer func() { _ = zf.Close() }()
-
-	zw := zip.NewWriter(zf)
-
-	// Add a directory with parent path
-	header := &zip.FileHeader{
-		Name:   "../evil-dir/",
-		Method: zip.Deflate,
-	}
-	header.SetMode(os.ModeDir | 0755)
-	_, err = zw.CreateHeader(header)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	_ = zw.Close()
-	_ = zf.Close()
+	zipPath := writeUnzipArchive(t, tmpDir, func(zw *zip.Writer) {
+		// Add a directory with parent path
+		header := &zip.FileHeader{Name: "../evil-dir/", Method: zip.Deflate}
+		header.SetMode(os.ModeDir | 0755)
+		_, err := zw.CreateHeader(header)
+		require.NoError(t, err)
+	})
 
 	// Test extraction should fail
-	err = Unzip(zipPath, extractDir)
-	if err == nil {
+	if err := Unzip(zipPath, extractDir); err == nil {
 		t.Error("Expected error for directory with path traversal, but got none")
 	}
 }
@@ -225,22 +167,12 @@ func TestUnzip_RelativeDestination(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			tmpDir := t.TempDir()
-			zipPath := filepath.Join(tmpDir, "test.zip")
-
-			zf, err := os.Create(zipPath)
-			if err != nil {
-				t.Fatal(err)
-			}
-			zw := zip.NewWriter(zf)
-			fw, err := zw.Create("file.txt")
-			if err != nil {
-				t.Fatal(err)
-			}
-			if _, err := fw.Write([]byte("content")); err != nil {
-				t.Fatal(err)
-			}
-			_ = zw.Close()
-			_ = zf.Close()
+			zipPath := writeUnzipArchive(t, tmpDir, func(zw *zip.Writer) {
+				fw, err := zw.Create("file.txt")
+				require.NoError(t, err)
+				_, err = fw.Write([]byte("content"))
+				require.NoError(t, err)
+			})
 
 			workDir := filepath.Join(tmpDir, "work")
 			if err := os.MkdirAll(workDir, 0o755); err != nil {

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -397,6 +397,17 @@ func Unzip(src string, dest string) error {
 		return err
 	}
 	destPrefix := strings.TrimSuffix(destDir, string(os.PathSeparator)) + string(os.PathSeparator)
+	if len(r.File) == 0 {
+		return nil
+	}
+	if err := os.MkdirAll(destDir, os.ModePerm); err != nil {
+		return err
+	}
+	root, err := os.OpenRoot(destDir)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = root.Close() }()
 
 	for _, f := range r.File {
 		// Prevent zip slip vulnerability by validating file path
@@ -410,28 +421,32 @@ func Unzip(src string, dest string) error {
 		if !strings.HasPrefix(fpath, destPrefix) {
 			return fmt.Errorf("invalid file path: %s", f.Name)
 		}
+		relativePath, err := filepath.Rel(destDir, fpath)
+		if err != nil {
+			return err
+		}
 
 		if f.FileInfo().IsDir() {
-			err := os.MkdirAll(fpath, os.ModePerm)
+			err := root.MkdirAll(relativePath, os.ModePerm)
 			if err != nil {
 				return err
 			}
 			continue
 		}
 
-		if err := os.MkdirAll(filepath.Dir(fpath), os.ModePerm); err != nil {
+		if err := root.MkdirAll(filepath.Dir(relativePath), os.ModePerm); err != nil {
 			return err
 		}
 
-		if err := extractFile(fpath, f); err != nil {
+		if err := extractFile(root, relativePath, f); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func extractFile(fpath string, f *zip.File) (err error) {
-	outFile, err := os.OpenFile(fpath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, f.Mode())
+func extractFile(root *os.Root, fpath string, f *zip.File) (err error) {
+	outFile, err := root.OpenFile(fpath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, f.Mode().Perm())
 	if err != nil {
 		return err
 	}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -408,6 +408,10 @@ func Unzip(src string, dest string) error {
 		return err
 	}
 	defer func() { _ = root.Close() }()
+	canonicalDest, err := filepath.EvalSymlinks(destDir)
+	if err != nil {
+		return err
+	}
 
 	for _, f := range r.File {
 		// Prevent zip slip vulnerability by validating file path
@@ -422,6 +426,10 @@ func Unzip(src string, dest string) error {
 			return fmt.Errorf("invalid file path: %s", f.Name)
 		}
 		relativePath, err := filepath.Rel(destDir, fpath)
+		if err != nil {
+			return err
+		}
+		relativePath, err = resolveZipPath(root, []string{destDir, canonicalDest}, relativePath)
 		if err != nil {
 			return err
 		}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -412,6 +412,10 @@ func Unzip(src string, dest string) error {
 	if err != nil {
 		return err
 	}
+	rootNames := []string{destDir}
+	if canonicalDest != destDir {
+		rootNames = append(rootNames, canonicalDest)
+	}
 
 	for _, f := range r.File {
 		// Prevent zip slip vulnerability by validating file path
@@ -425,11 +429,7 @@ func Unzip(src string, dest string) error {
 		if !strings.HasPrefix(fpath, destPrefix) {
 			return fmt.Errorf("invalid file path: %s", f.Name)
 		}
-		relativePath, err := filepath.Rel(destDir, fpath)
-		if err != nil {
-			return err
-		}
-		relativePath, err = resolveZipPath(root, []string{destDir, canonicalDest}, relativePath)
+		relativePath, err := resolveZipPath(root, rootNames, strings.TrimPrefix(fpath, destPrefix))
 		if err != nil {
 			return err
 		}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -390,6 +390,12 @@ func Unzip(src string, dest string) error {
 	}
 	defer func() { _ = r.Close() }()
 
+	if len(r.File) == 0 {
+		// An empty archive creates nothing, as it did before the destination was
+		// pinned: the MkdirAll below would otherwise leave a directory behind.
+		return nil
+	}
+
 	// Absolute so a relative dest such as "." keeps the prefix filepath.Join cleans away.
 	// CodeQL's go/zipslip accepts only this prefix form; TrimSuffix keeps a root dest off "//".
 	destDir, err := filepath.Abs(dest)
@@ -397,9 +403,6 @@ func Unzip(src string, dest string) error {
 		return err
 	}
 	destPrefix := strings.TrimSuffix(destDir, string(os.PathSeparator)) + string(os.PathSeparator)
-	if len(r.File) == 0 {
-		return nil
-	}
 	if err := os.MkdirAll(destDir, os.ModePerm); err != nil {
 		return err
 	}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -453,8 +453,8 @@ func Unzip(src string, dest string) error {
 	return nil
 }
 
-func extractFile(root *os.Root, fpath string, f *zip.File) (err error) {
-	outFile, err := root.OpenFile(fpath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, f.Mode().Perm())
+func extractFile(root *os.Root, name string, f *zip.File) (err error) {
+	outFile, err := root.OpenFile(name, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, f.Mode().Perm())
 	if err != nil {
 		return err
 	}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -25,6 +25,10 @@ import (
 const (
 	// DefaultApprovalWaitTimeout is the shared --wait default so exec, work-session create, and event wait match; not a ceiling (--wait-approval exceeds it), preserving the old 30 × 10s window.
 	DefaultApprovalWaitTimeout = 5 * time.Minute
+
+	// zipDirPerm is what a directory an archive asks for is created as. An archive
+	// dictates no permission bits here, the same reason extractFile takes only Perm().
+	zipDirPerm = 0o755
 )
 
 var (
@@ -403,7 +407,7 @@ func Unzip(src string, dest string) error {
 		return err
 	}
 	destPrefix := strings.TrimSuffix(destDir, string(os.PathSeparator)) + string(os.PathSeparator)
-	if err := os.MkdirAll(destDir, os.ModePerm); err != nil {
+	if err := os.MkdirAll(destDir, zipDirPerm); err != nil {
 		return err
 	}
 	root, err := os.OpenRoot(destDir)
@@ -438,14 +442,14 @@ func Unzip(src string, dest string) error {
 		}
 
 		if f.FileInfo().IsDir() {
-			err := root.MkdirAll(relativePath, os.ModePerm)
+			err := root.MkdirAll(relativePath, zipDirPerm)
 			if err != nil {
 				return err
 			}
 			continue
 		}
 
-		if err := root.MkdirAll(filepath.Dir(relativePath), os.ModePerm); err != nil {
+		if err := root.MkdirAll(filepath.Dir(relativePath), zipDirPerm); err != nil {
 			return err
 		}
 

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -423,6 +423,7 @@ func Unzip(src string, dest string) error {
 	if canonicalDest != destDir {
 		rootNames = append(rootNames, canonicalDest)
 	}
+	roots := newZipRoots(rootNames...)
 
 	for _, f := range r.File {
 		// Prevent zip slip vulnerability by validating file path
@@ -436,7 +437,7 @@ func Unzip(src string, dest string) error {
 		if !strings.HasPrefix(fpath, destPrefix) {
 			return fmt.Errorf("invalid file path: %s", f.Name)
 		}
-		relativePath, err := resolveZipPath(root, rootNames, strings.TrimPrefix(fpath, destPrefix))
+		relativePath, err := resolveZipPath(root, roots, strings.TrimPrefix(fpath, destPrefix))
 		if err != nil {
 			return err
 		}

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -209,7 +209,7 @@ func TestSaveStreamAtomic_RetainsExistingFileOnReadError(t *testing.T) {
 	assert.Empty(t, matches)
 }
 
-func requireUnixModes(t *testing.T) {
+func skipUnlessUnixModes(t *testing.T) {
 	t.Helper()
 	if runtime.GOOS == "windows" {
 		t.Skip("Unix file modes are not enforced on Windows")
@@ -218,7 +218,7 @@ func requireUnixModes(t *testing.T) {
 
 func TestSaveStreamAtomic_PreservesExistingFileMode(t *testing.T) {
 	t.Parallel()
-	requireUnixModes(t)
+	skipUnlessUnixModes(t)
 
 	dest := filepath.Join(t.TempDir(), "file.txt")
 	require.NoError(t, os.WriteFile(dest, []byte("existing"), 0600))
@@ -237,7 +237,7 @@ func TestSaveStreamAtomic_PreservesExistingFileMode(t *testing.T) {
 }
 
 func TestSaveStreamAtomic_WarnsWhenKeptModeIsWiderThanANewFile(t *testing.T) {
-	requireUnixModes(t)
+	skipUnlessUnixModes(t)
 
 	dest := filepath.Join(t.TempDir(), "id_rsa")
 	require.NoError(t, os.WriteFile(dest, []byte("existing"), 0644))
@@ -259,7 +259,7 @@ func TestSaveStreamAtomic_WarnsWhenKeptModeIsWiderThanANewFile(t *testing.T) {
 // the setup mode retires the branch instead of testing it.
 func TestKeptModeIsWider(t *testing.T) {
 	t.Parallel()
-	requireUnixModes(t)
+	skipUnlessUnixModes(t)
 
 	tests := []struct {
 		name        string
@@ -279,7 +279,7 @@ func TestKeptModeIsWider(t *testing.T) {
 }
 
 func TestSaveStreamAtomic_NoWarningForANewFile(t *testing.T) {
-	requireUnixModes(t)
+	skipUnlessUnixModes(t)
 
 	stderr := captureStderr(t, func() {
 		_, err := SaveStreamAtomic(filepath.Join(t.TempDir(), "fresh"), strings.NewReader("x"), 0600)
@@ -314,7 +314,7 @@ func (r *tempModeReader) Read(p []byte) (int, error) {
 
 func TestSaveStreamAtomic_KeepsPartialReplacementUnreadable(t *testing.T) {
 	t.Parallel()
-	requireUnixModes(t)
+	skipUnlessUnixModes(t)
 
 	dir := t.TempDir()
 	dest := filepath.Join(dir, "file.txt")
@@ -343,7 +343,7 @@ func TestSaveStreamAtomic_KeepsPartialReplacementUnreadable(t *testing.T) {
 
 func TestSaveStreamAtomic_AppliesRequestedModeToNewFile(t *testing.T) {
 	t.Parallel()
-	requireUnixModes(t)
+	skipUnlessUnixModes(t)
 
 	dest := filepath.Join(t.TempDir(), "file.txt")
 


### PR DESCRIPTION
## Background

Unzip validated the joined path with a string-prefix check and then opened it with plain `os.OpenFile`. A symlink already present under the destination redirected the write outside it, and the prefix check could not see that because it only looks at the name.

## Changes

`Unzip` pins the destination with `os.OpenRoot` and does every mkdir and file write through that root, so the final open is confined whatever the name says.

The new `utils/unzip_path.go` resolves each path component before the write. `resolveZipPath` walks the components with `Lstat` and `Readlink`, follows relative links inside the root, and rejects cycles and escapes. It exists because `os.Root` refuses every absolute symlink outright, including one that points back inside the destination; `zipRelativeTarget` rewrites such a target relative to the root, matching against `destDir` and its `filepath.EvalSymlinks` form so a destination reached through a symlink still resolves. A target that does not match either form is rejected. Link expansion happens before `..` is consumed, because cleaning first can select a different file. The function carries a doc comment stating that contract and recording why it permits an absolute internal symlink at all, since failing closed instead would be about five lines and the choice is otherwise invisible.

A component that does not exist is recorded as such, and a following `..` is refused rather than popped. Without that, a target of `<dest>/missing/../victim` resolved to `<dest>/victim` and the entry overwrote it, where the kernel answers ENOENT. Nothing escaped the destination in that case, but the entry landed on a file the archive never named.

`extractFile` passes `f.Mode().Perm()` rather than `f.Mode()`. `os.Root.OpenFile` rejects a mode carrying non-permission bits outright — `openat raw: unsupported file mode` — so the change is forced by the move to `os.Root`, and it also stops an archive from setting setuid, setgid or sticky on an extracted file, which the old `os.OpenFile` call passed straight through to `open(2)`.

Directories an archive asks for are created 0755 through the new `zipDirPerm` constant, not `os.ModePerm`. 0777 predates this branch, but the branch hands it to `root.MkdirAll` on both extraction paths as well, and a umask is the only thing that was narrowing it. `TestUnzip_DirectoriesUseFixedPerm` pins that: it lowers the umask to 0, so the requested bits survive to disk, and checks the destination, a directory entry the archive asks for at 0777, and the parent of a nested file. `syscall.Umask` is process-wide, so the test is serial and restores what it found, and the file carries a `unix` build tag because Windows has no umask and the Windows leg now runs `./utils`. Its expected mode is the literal 0755 rather than the constant, so widening `zipDirPerm` fails the test instead of moving it.

Entries declared as symlinks in the archive are written as regular files holding their target text, so extraction never creates a link of its own.

The Windows leg of `build-and-test.yaml` now runs `./utils`. `filepath.VolumeName` always returns `""` on Unix, and a target starting with the separator has already taken the `filepath.IsAbs` branch above, so that check in `resolveZipPath` and `zipPathEqual`'s `strings.EqualFold` branch are unreachable there. They guard a security boundary and no CI leg was executing them. One existing case moved with the leg: `TestUnzip_PathTraversalAttack` expected `/etc/passwd` to be rejected, but on Windows an absolute path needs a volume name, so `filepath.IsAbs` is false for a leading slash and the entry is joined onto the destination instead, where it stays confined. That expectation is now Unix-only.

Three more cases moved with it, after the leg's first run said so. `TestUnzip_ResolvesLinkBeforeParentComponent` and both cases of `TestUnzip_RejectsParentAfterNonDirectory` build an absolute symlink target containing `..` and exist to pin what `resolveZipPath` does when it consumes one. Windows normalizes an absolute target when the link is created, so `Readlink` hands back a path with the `..` already resolved and the precondition is simply not there. `skipUnlessParentInLink` reads the link back and skips on that, rather than on `runtime.GOOS`, so the cases stay live wherever the target survives intact.

## Safety

The destination-prefix check in `Unzip` is not redundant. An earlier version of this description said it was, and that was wrong.

It is redundant for confinement only: `os.Root` holds the boundary whatever the check does. It is load-bearing for rejection. `strings.TrimPrefix` is a no-op when the prefix does not match, so without the check `resolveZipPath` receives an absolute path, splits it on the separator, skips the leading empty component, and silently re-roots the entry under the destination. `../evil.txt` would land inside the destination instead of being refused. Removing only that check:

```
--- FAIL: TestUnzip_PathTraversalAttack/parent_directory_traversal
--- FAIL: TestUnzip_PathTraversalAttack/multiple_parent_directory_traversal
--- FAIL: TestUnzip_PathTraversalAttack/mixed_path_traversal
--- FAIL: TestUnzip_PathTraversalAttack/parent_directory_only
--- FAIL: TestUnzip_PathTraversalAttack/sibling_directory_sharing_the_destination_prefix
--- FAIL: TestUnzip_DirectoryTraversal
```

The check stays exactly as it is, and it is also the shape CodeQL's `go/zipslip` recognizes. Enforcing the invariant locally instead of at a caller check three lines up—`filepath.Rel`, which cannot silently produce an absolute path, or rejecting an absolute `name` on entry to `resolveZipPath`—will be a follow-up, tracked in #444.

Two behaviors are deliberately conservative and fail closed rather than resolve. An absolute symlink target that contains `..` but lands back inside the destination is rejected, because cleaning it before expansion would reintroduce the wrong-file selection described above. `zipPathEqual` folds case only on Windows, so on a case-insensitive macOS volume a target spelled with different case is rejected rather than followed.

Writing through a pre-existing dangling symlink inside the destination creates the missing parents and lands there. This stays inside the destination, and an archive cannot set up that precondition, since its own symlink entries become regular files.

## Testing

```
go test -race -shuffle=on ./...
ok  	github.com/alpacax/alpacon-cli/utils	2.619s
```

```
golangci-lint run ./...
0 issues.
```

The Windows leg cannot be run from this machine. Its first run was on this PR and it failed on the three cases described above; the run after `skipUnlessParentInLink` is green.

`utils/unzip_symlink_test.go` covers the symlink axis. The existing `TestUnzip_ValidFiles`, `TestUnzip_PathTraversalAttack` and `TestUnzip_DirectoryTraversal` cover classic zip slip and still pass; they now build their fixtures through the same `writeUnzipArchive` helper rather than hand-rolling `zip.NewWriter` four times.

`TestUnzip_PathTraversalAttack` now runs its containment check on every case, not only the ones expecting an error. The check was gated on `wantErr`, which left the case this branch turns into a success on Windows writing a file and asserting nothing about where it landed. No entry may leave `extractDir` whether it was rejected or accepted, so the gate came off. Seen red by writing a file into the parent directory inside the subtest: all eight cases fail, `valid_file_with_dots_in_name` and `valid_subdirectory` among them, which is exactly the pair the gate had been skipping.

Every test was seen red against a mutated target, and the table below was re-run against the final diff:

| Mutation | Cases that failed |
|---|---|
| `resolveZipPath` dropped, mkdir and write done with `os.MkdirAll` and `os.OpenFile` on the absolute path | `TestUnzip_ConfinesSymlinks` (9 of 10), `TestUnzip_AllowsAbsoluteInternalSymlinks/dangling_directory` |
| `resolveZipPath` returns its argument unchanged | `TestUnzip_AllowsAbsoluteInternalSymlinks` (5), `TestUnzip_AbsoluteLinksWithDestinationAlias` (2), `TestUnzip_ResolvesLinkBeforeParentComponent` |
| `zipRelativeTarget` allows instead of rejecting | `TestUnzip_ConfinesSymlinks` (4) |
| Parent-escape rejection replaced by `continue` | `TestUnzip_ConfinesSymlinks` (5: the four relative cases and `parent_escape`) |
| Archive symlink entries created as real links | `TestUnzip_MaterializesArchiveSymlinkAsFile` |
| Every symlink rejected | `TestUnzip_AllowsInternalSymlink`, `TestUnzip_ResolvesLinkBeforeParentComponent`, `TestUnzip_AllowsAbsoluteInternalSymlinks` (5), `TestUnzip_AbsoluteLinksWithDestinationAlias` (2) |
| Not-a-directory check dropped | `TestUnzip_RejectsParentAfterNonDirectory/regular_file` |
| Missing-component guard disabled | `TestUnzip_RejectsParentAfterNonDirectory/missing_component` |
| Symlink hop cap dropped | `TestUnzip_ConfinesSymlinks/cycle` hangs until the test timeout |
| `zipDirPerm` set back to 0777 | `TestUnzip_DirectoriesUseFixedPerm`, on all three directories |

Two rows need a note. Under the first mutation `TestUnzip_ConfinesSymlinks/cycle` is the one case that still passes: with `resolveZipPath` gone the kernel walks the loop itself and `os.OpenFile` returns ELOOP, so the test gets its error from a different source. And the last row is the one that does not fail cleanly without its guard: removing the hop cap makes the walk loop forever, so the case ends the run on `panic: test timed out` rather than on an assertion.

Closes #438

